### PR TITLE
feat: add api authentication middleware

### DIFF
--- a/apps/web/src/app/api/deployments/[id]/analytics/export/route.ts
+++ b/apps/web/src/app/api/deployments/[id]/analytics/export/route.ts
@@ -1,56 +1,25 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@/lib/supabase/server';
+import { withDeploymentAuth } from '@/lib/api/with-auth';
 import { analyticsService } from '@/services/analytics.service';
 
-export async function GET(
-    req: NextRequest,
-    { params }: { params: { id: string } }
-) {
+export const GET = withDeploymentAuth(async (req: NextRequest, { params, supabase }) => {
     try {
-        const supabase = createClient();
-
-        // Authenticate user
-        const {
-            data: { user },
-            error: authError,
-        } = await supabase.auth.getUser();
-
-        if (authError || !user) {
-            return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-        }
-
-        // Verify user owns the deployment
         const { data: deployment } = await supabase
             .from('deployments')
-            .select('user_id, name')
+            .select('name')
             .eq('id', params.id)
             .single();
 
-        if (!deployment || deployment.user_id !== user.id) {
-            return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
-        }
-
-        // Get query parameters
         const searchParams = req.nextUrl.searchParams;
-        const startDate = searchParams.get('startDate')
-            ? new Date(searchParams.get('startDate')!)
-            : undefined;
-        const endDate = searchParams.get('endDate')
-            ? new Date(searchParams.get('endDate')!)
-            : undefined;
+        const startDate = searchParams.get('startDate') ? new Date(searchParams.get('startDate')!) : undefined;
+        const endDate = searchParams.get('endDate') ? new Date(searchParams.get('endDate')!) : undefined;
 
-        // Export analytics as CSV
-        const csv = await analyticsService.exportAnalytics(
-            params.id,
-            startDate,
-            endDate
-        );
+        const csv = await analyticsService.exportAnalytics(params.id, startDate, endDate);
 
-        // Return CSV file
         return new NextResponse(csv, {
             headers: {
                 'Content-Type': 'text/csv',
-                'Content-Disposition': `attachment; filename="analytics-${deployment.name}-${Date.now()}.csv"`,
+                'Content-Disposition': `attachment; filename="analytics-${deployment?.name ?? params.id}-${Date.now()}.csv"`,
             },
         });
     } catch (error: any) {
@@ -60,4 +29,4 @@ export async function GET(
             { status: 500 }
         );
     }
-}
+});

--- a/apps/web/src/app/api/deployments/[id]/analytics/route.ts
+++ b/apps/web/src/app/api/deployments/[id]/analytics/route.ts
@@ -1,60 +1,20 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@/lib/supabase/server';
+import { withDeploymentAuth } from '@/lib/api/with-auth';
 import { analyticsService } from '@/services/analytics.service';
 
-export async function GET(
-    req: NextRequest,
-    { params }: { params: { id: string } }
-) {
+export const GET = withDeploymentAuth(async (req: NextRequest, { params }) => {
     try {
-        const supabase = createClient();
-
-        // Authenticate user
-        const {
-            data: { user },
-            error: authError,
-        } = await supabase.auth.getUser();
-
-        if (authError || !user) {
-            return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-        }
-
-        // Verify user owns the deployment
-        const { data: deployment } = await supabase
-            .from('deployments')
-            .select('user_id')
-            .eq('id', params.id)
-            .single();
-
-        if (!deployment || deployment.user_id !== user.id) {
-            return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
-        }
-
-        // Get query parameters
         const searchParams = req.nextUrl.searchParams;
         const metricType = searchParams.get('metricType') || undefined;
-        const startDate = searchParams.get('startDate')
-            ? new Date(searchParams.get('startDate')!)
-            : undefined;
-        const endDate = searchParams.get('endDate')
-            ? new Date(searchParams.get('endDate')!)
-            : undefined;
+        const startDate = searchParams.get('startDate') ? new Date(searchParams.get('startDate')!) : undefined;
+        const endDate = searchParams.get('endDate') ? new Date(searchParams.get('endDate')!) : undefined;
 
-        // Get analytics
-        const analytics = await analyticsService.getAnalytics(
-            params.id,
-            metricType,
-            startDate,
-            endDate
-        );
+        const [analytics, summary] = await Promise.all([
+            analyticsService.getAnalytics(params.id, metricType, startDate, endDate),
+            analyticsService.getAnalyticsSummary(params.id),
+        ]);
 
-        // Get summary
-        const summary = await analyticsService.getAnalyticsSummary(params.id);
-
-        return NextResponse.json({
-            analytics,
-            summary,
-        });
+        return NextResponse.json({ analytics, summary });
     } catch (error: any) {
         console.error('Error getting analytics:', error);
         return NextResponse.json(
@@ -62,4 +22,4 @@ export async function GET(
             { status: 500 }
         );
     }
-}
+});

--- a/apps/web/src/app/api/deployments/[id]/health/route.ts
+++ b/apps/web/src/app/api/deployments/[id]/health/route.ts
@@ -1,38 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@/lib/supabase/server';
+import { withDeploymentAuth } from '@/lib/api/with-auth';
 import { healthMonitorService } from '@/services/health-monitor.service';
 
-export async function GET(
-    req: NextRequest,
-    { params }: { params: { id: string } }
-) {
+export const GET = withDeploymentAuth(async (_req: NextRequest, { params }) => {
     try {
-        const supabase = createClient();
-
-        // Authenticate user
-        const {
-            data: { user },
-            error: authError,
-        } = await supabase.auth.getUser();
-
-        if (authError || !user) {
-            return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-        }
-
-        // Verify user owns the deployment
-        const { data: deployment } = await supabase
-            .from('deployments')
-            .select('user_id')
-            .eq('id', params.id)
-            .single();
-
-        if (!deployment || deployment.user_id !== user.id) {
-            return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
-        }
-
-        // Check deployment health
         const health = await healthMonitorService.checkDeploymentHealth(params.id);
-
         return NextResponse.json(health);
     } catch (error: any) {
         console.error('Error checking deployment health:', error);
@@ -41,4 +13,4 @@ export async function GET(
             { status: 500 }
         );
     }
-}
+});

--- a/apps/web/src/app/api/payments/cancel/route.ts
+++ b/apps/web/src/app/api/payments/cancel/route.ts
@@ -1,38 +1,20 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@/lib/supabase/server';
+import { withAuth } from '@/lib/api/with-auth';
 import { paymentService } from '@/services/payment.service';
 
-export async function POST(req: NextRequest) {
+export const POST = withAuth(async (_req: NextRequest, { user, supabase }) => {
+    const { data: profile } = await supabase
+        .from('profiles')
+        .select('stripe_subscription_id')
+        .eq('id', user.id)
+        .single();
+
+    if (!profile?.stripe_subscription_id) {
+        return NextResponse.json({ error: 'No active subscription found' }, { status: 404 });
+    }
+
     try {
-        const supabase = createClient();
-
-        // Authenticate user
-        const {
-            data: { user },
-            error: authError,
-        } = await supabase.auth.getUser();
-
-        if (authError || !user) {
-            return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-        }
-
-        // Get user's subscription ID
-        const { data: profile } = await supabase
-            .from('profiles')
-            .select('stripe_subscription_id')
-            .eq('id', user.id)
-            .single();
-
-        if (!profile?.stripe_subscription_id) {
-            return NextResponse.json(
-                { error: 'No active subscription found' },
-                { status: 404 }
-            );
-        }
-
-        // Cancel subscription
         await paymentService.cancelSubscription(profile.stripe_subscription_id);
-
         return NextResponse.json({ success: true });
     } catch (error: any) {
         console.error('Error canceling subscription:', error);
@@ -41,4 +23,4 @@ export async function POST(req: NextRequest) {
             { status: 500 }
         );
     }
-}
+});

--- a/apps/web/src/app/api/payments/checkout/route.ts
+++ b/apps/web/src/app/api/payments/checkout/route.ts
@@ -1,36 +1,16 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@/lib/supabase/server';
+import { withAuth } from '@/lib/api/with-auth';
 import { paymentService } from '@/services/payment.service';
 
-export async function POST(req: NextRequest) {
+export const POST = withAuth(async (req: NextRequest, { user }) => {
+    const { priceId } = await req.json();
+
+    if (!priceId) {
+        return NextResponse.json({ error: 'Price ID is required' }, { status: 400 });
+    }
+
     try {
-        const supabase = createClient();
-
-        // Authenticate user
-        const {
-            data: { user },
-            error: authError,
-        } = await supabase.auth.getUser();
-
-        if (authError || !user) {
-            return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-        }
-
-        const { priceId } = await req.json();
-
-        if (!priceId) {
-            return NextResponse.json(
-                { error: 'Price ID is required' },
-                { status: 400 }
-            );
-        }
-
-        // Create checkout session
-        const session = await paymentService.createCheckoutSession(
-            user.id,
-            priceId
-        );
-
+        const session = await paymentService.createCheckoutSession(user.id, priceId);
         return NextResponse.json(session);
     } catch (error: any) {
         console.error('Error creating checkout session:', error);
@@ -39,4 +19,4 @@ export async function POST(req: NextRequest) {
             { status: 500 }
         );
     }
-}
+});

--- a/apps/web/src/app/api/payments/subscription/route.ts
+++ b/apps/web/src/app/api/payments/subscription/route.ts
@@ -1,24 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@/lib/supabase/server';
+import { withAuth } from '@/lib/api/with-auth';
 import { paymentService } from '@/services/payment.service';
 
-export async function GET(req: NextRequest) {
+export const GET = withAuth(async (_req: NextRequest, { user }) => {
     try {
-        const supabase = createClient();
-
-        // Authenticate user
-        const {
-            data: { user },
-            error: authError,
-        } = await supabase.auth.getUser();
-
-        if (authError || !user) {
-            return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-        }
-
-        // Get subscription status
         const status = await paymentService.getSubscriptionStatus(user.id);
-
         return NextResponse.json(status);
     } catch (error: any) {
         console.error('Error getting subscription status:', error);
@@ -27,4 +13,4 @@ export async function GET(req: NextRequest) {
             { status: 500 }
         );
     }
-}
+});

--- a/apps/web/src/lib/api/with-auth.test.ts
+++ b/apps/web/src/lib/api/with-auth.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest, NextResponse } from 'next/server';
+import { withAuth, withDeploymentAuth } from './with-auth';
+
+// --- Supabase server mock ---
+const mockGetUser = vi.fn();
+const mockFrom = vi.fn();
+
+vi.mock('@/lib/supabase/server', () => ({
+    createClient: () => ({
+        auth: { getUser: mockGetUser },
+        from: mockFrom,
+    }),
+}));
+
+const makeRequest = () => new NextRequest('http://localhost/api/test');
+
+describe('withAuth', () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    it('returns 401 when no session exists', async () => {
+        mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+
+        const handler = withAuth(async () => NextResponse.json({ ok: true }));
+        const res = await handler(makeRequest(), { params: {} });
+
+        expect(res.status).toBe(401);
+        expect(await res.json()).toEqual({ error: 'Unauthorized' });
+    });
+
+    it('returns 401 when getUser returns an error', async () => {
+        mockGetUser.mockResolvedValue({ data: { user: null }, error: new Error('jwt expired') });
+
+        const handler = withAuth(async () => NextResponse.json({ ok: true }));
+        const res = await handler(makeRequest(), { params: {} });
+
+        expect(res.status).toBe(401);
+    });
+
+    it('calls the handler with user and supabase when authenticated', async () => {
+        const fakeUser = { id: 'user-1', email: 'a@b.com' };
+        mockGetUser.mockResolvedValue({ data: { user: fakeUser }, error: null });
+
+        const inner = vi.fn().mockResolvedValue(NextResponse.json({ ok: true }));
+        const handler = withAuth(inner);
+        const res = await handler(makeRequest(), { params: {} });
+
+        expect(res.status).toBe(200);
+        expect(inner).toHaveBeenCalledOnce();
+        expect(inner.mock.calls[0][1].user).toEqual(fakeUser);
+        expect(inner.mock.calls[0][1].supabase).toBeDefined();
+    });
+});
+
+describe('withDeploymentAuth', () => {
+    const fakeUser = { id: 'user-1', email: 'a@b.com' };
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockGetUser.mockResolvedValue({ data: { user: fakeUser }, error: null });
+    });
+
+    it('returns 403 when deployment not found', async () => {
+        mockFrom.mockReturnValue({
+            select: () => ({ eq: () => ({ single: () => Promise.resolve({ data: null }) }) }),
+        });
+
+        const handler = withDeploymentAuth(async () => NextResponse.json({ ok: true }));
+        const res = await handler(makeRequest(), { params: { id: 'dep-1' } });
+
+        expect(res.status).toBe(403);
+        expect(await res.json()).toEqual({ error: 'Forbidden' });
+    });
+
+    it('returns 403 when deployment belongs to a different user', async () => {
+        mockFrom.mockReturnValue({
+            select: () => ({
+                eq: () => ({ single: () => Promise.resolve({ data: { user_id: 'other-user' } }) }),
+            }),
+        });
+
+        const handler = withDeploymentAuth(async () => NextResponse.json({ ok: true }));
+        const res = await handler(makeRequest(), { params: { id: 'dep-1' } });
+
+        expect(res.status).toBe(403);
+    });
+
+    it('calls the handler when user owns the deployment', async () => {
+        mockFrom.mockReturnValue({
+            select: () => ({
+                eq: () => ({ single: () => Promise.resolve({ data: { user_id: fakeUser.id } }) }),
+            }),
+        });
+
+        const inner = vi.fn().mockResolvedValue(NextResponse.json({ ok: true }));
+        const handler = withDeploymentAuth(inner);
+        const res = await handler(makeRequest(), { params: { id: 'dep-1' } });
+
+        expect(res.status).toBe(200);
+        expect(inner).toHaveBeenCalledOnce();
+    });
+
+    it('returns 401 when unauthenticated (inherits withAuth behaviour)', async () => {
+        mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+
+        const handler = withDeploymentAuth(async () => NextResponse.json({ ok: true }));
+        const res = await handler(makeRequest(), { params: { id: 'dep-1' } });
+
+        expect(res.status).toBe(401);
+    });
+});

--- a/apps/web/src/lib/api/with-auth.ts
+++ b/apps/web/src/lib/api/with-auth.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import type { User } from '@supabase/supabase-js';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+export type AuthedRouteContext = {
+    user: User;
+    supabase: SupabaseClient;
+};
+
+type RouteHandler<TParams = {}> = (
+    req: NextRequest,
+    ctx: AuthedRouteContext & { params: TParams }
+) => Promise<NextResponse>;
+
+/**
+ * Wraps a route handler with Supabase session authentication.
+ * Returns 401 if the user is not authenticated.
+ */
+export function withAuth<TParams = {}>(handler: RouteHandler<TParams>) {
+    return async (req: NextRequest, { params }: { params: TParams }) => {
+        const supabase = createClient();
+        const { data: { user }, error } = await supabase.auth.getUser();
+
+        if (error || !user) {
+            return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+        }
+
+        return handler(req, { user, supabase, params });
+    };
+}
+
+/**
+ * Wraps a route handler with auth + deployment ownership check.
+ * Returns 401 if unauthenticated, 403 if the deployment doesn't belong to the user.
+ * Requires `params.id` to be the deployment ID.
+ */
+export function withDeploymentAuth<TParams extends { id: string }>(
+    handler: RouteHandler<TParams>
+) {
+    return withAuth<TParams>(async (req, ctx) => {
+        const { data: deployment } = await ctx.supabase
+            .from('deployments')
+            .select('user_id')
+            .eq('id', ctx.params.id)
+            .single();
+
+        if (!deployment || deployment.user_id !== ctx.user.id) {
+            return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+        }
+
+        return handler(req, ctx);
+    });
+}


### PR DESCRIPTION
- Add withAuth and withDeploymentAuth middleware helpers in lib/api/with-auth.ts
- Resolve user/session from Supabase and standardize 401/403 responses
- Apply middleware to all protected routes (payments, deployments)
- Add unit tests (7/7 passing)

Closes #33 