### PR TITLE
feat: add signout api route

### DIFF
--- a/apps/web/src/app/api/auth/signout/route.test.ts
+++ b/apps/web/src/app/api/auth/signout/route.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const mockSignOut = vi.fn();
+vi.mock('@/services/auth.service', () => ({
+    authService: { signOut: mockSignOut },
+}));
+
+const makeRequest = () =>
+    new NextRequest('http://localhost/api/auth/signout', { method: 'POST' });
+
+describe('POST /api/auth/signout', () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    it('returns 200 with success message', async () => {
+        mockSignOut.mockResolvedValue(undefined);
+        const { POST } = await import('./route');
+        const res = await POST();
+        expect(res.status).toBe(200);
+        expect(await res.json()).toEqual({ message: 'Signed out successfully' });
+    });
+
+    it('is idempotent — succeeds even when no session exists', async () => {
+        // Supabase signOut resolves regardless; simulate that here
+        mockSignOut.mockResolvedValue(undefined);
+        const { POST } = await import('./route');
+        const res1 = await POST();
+        const res2 = await POST();
+        expect(res1.status).toBe(200);
+        expect(res2.status).toBe(200);
+    });
+
+    it('returns 500 if signOut throws', async () => {
+        mockSignOut.mockRejectedValue(new Error('network failure'));
+        const { POST } = await import('./route');
+        const res = await POST();
+        expect(res.status).toBe(500);
+        expect((await res.json()).error).toBe('network failure');
+    });
+});

--- a/apps/web/src/app/api/auth/signout/route.ts
+++ b/apps/web/src/app/api/auth/signout/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server';
+import { authService } from '@/services/auth.service';
+
+/**
+ * POST /api/auth/signout
+ *
+ * Invalidates the current Supabase session by clearing the auth cookie.
+ * Idempotent — returns 200 even if no active session exists.
+ *
+ * After a successful response the client should redirect to the sign-in page.
+ */
+export async function POST() {
+    try {
+        await authService.signOut();
+        return NextResponse.json({ message: 'Signed out successfully' });
+    } catch (error: any) {
+        console.error('Error signing out:', error);
+        return NextResponse.json(
+            { error: error.message || 'Failed to sign out' },
+            { status: 500 }
+        );
+    }
+}


### PR DESCRIPTION
- Add POST /api/auth/signout — delegates to authService.signOut()
- Idempotent: returns 200 regardless of whether a session was active
- No auth guard required; Supabase clears the cookie unconditionally
- 3 tests passing

Closes #31 