### PR TITLE
feat: add signup and signin api routes

### DIFF
--- a/apps/web/src/app/api/auth/auth.test.ts
+++ b/apps/web/src/app/api/auth/auth.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const mockSignUp = vi.fn();
+const mockSignIn = vi.fn();
+vi.mock('@/services/auth.service', () => ({
+    authService: { signUp: mockSignUp, signIn: mockSignIn },
+}));
+
+const fakeUser = { id: 'u1', email: 'a@b.com', subscriptionTier: 'free', githubConnected: false, createdAt: new Date() };
+const fakeSession = { accessToken: 'tok', refreshToken: 'ref', expiresAt: new Date() };
+const successResult = { user: fakeUser, session: fakeSession, error: null };
+
+const post = (url: string, body: unknown) =>
+    new NextRequest(`http://localhost${url}`, {
+        method: 'POST',
+        body: JSON.stringify(body),
+        headers: { 'Content-Type': 'application/json' },
+    });
+
+// ── signup ────────────────────────────────────────────────────────────────────
+describe('POST /api/auth/signup', () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    it('returns 400 for invalid input', async () => {
+        const { POST } = await import('./signup/route');
+        const res = await POST(post('/api/auth/signup', { email: 'bad', password: '123' }));
+        expect(res.status).toBe(400);
+        expect((await res.json()).details).toBeDefined();
+    });
+
+    it('returns 400 when service returns an error', async () => {
+        mockSignUp.mockResolvedValue({ user: null, session: null, error: { code: 'SIGNUP_ERROR', message: 'Email taken' } });
+        const { POST } = await import('./signup/route');
+        const res = await POST(post('/api/auth/signup', { email: 'a@b.com', password: 'password123' }));
+        expect(res.status).toBe(400);
+        expect((await res.json()).error).toBe('Email taken');
+    });
+
+    it('returns 409 on profile creation error', async () => {
+        mockSignUp.mockResolvedValue({ user: null, session: null, error: { code: 'PROFILE_CREATION_ERROR', message: 'duplicate key' } });
+        const { POST } = await import('./signup/route');
+        const res = await POST(post('/api/auth/signup', { email: 'a@b.com', password: 'password123' }));
+        expect(res.status).toBe(409);
+    });
+
+    it('returns 201 with user and session on success', async () => {
+        mockSignUp.mockResolvedValue(successResult);
+        const { POST } = await import('./signup/route');
+        const res = await POST(post('/api/auth/signup', { email: 'a@b.com', password: 'password123' }));
+        expect(res.status).toBe(201);
+        const body = await res.json();
+        expect(body.user.id).toBe('u1');
+        expect(body.session.accessToken).toBe('tok');
+    });
+});
+
+// ── signin ────────────────────────────────────────────────────────────────────
+describe('POST /api/auth/signin', () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    it('returns 400 for invalid input', async () => {
+        const { POST } = await import('./signin/route');
+        const res = await POST(post('/api/auth/signin', { email: 'bad' }));
+        expect(res.status).toBe(400);
+    });
+
+    it('returns 401 for invalid credentials', async () => {
+        mockSignIn.mockResolvedValue({ user: null, session: null, error: { code: 'SIGNIN_ERROR', message: 'Invalid email or password.' } });
+        const { POST } = await import('./signin/route');
+        const res = await POST(post('/api/auth/signin', { email: 'a@b.com', password: 'wrong' }));
+        expect(res.status).toBe(401);
+        expect((await res.json()).error).toBe('Invalid email or password.');
+    });
+
+    it('returns 200 with user and session on success', async () => {
+        mockSignIn.mockResolvedValue(successResult);
+        const { POST } = await import('./signin/route');
+        const res = await POST(post('/api/auth/signin', { email: 'a@b.com', password: 'correct' }));
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.user.id).toBe('u1');
+        expect(body.session.accessToken).toBe('tok');
+    });
+});

--- a/apps/web/src/app/api/auth/signin/route.ts
+++ b/apps/web/src/app/api/auth/signin/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { authService } from '@/services/auth.service';
+
+const signInSchema = z.object({
+    email: z.string().email(),
+    password: z.string().min(1),
+});
+
+/**
+ * POST /api/auth/signin
+ * Authenticates an existing user and returns the user + session.
+ * Returns 401 for invalid credentials.
+ */
+export async function POST(req: NextRequest) {
+    const body = await req.json();
+    const parsed = signInSchema.safeParse(body);
+
+    if (!parsed.success) {
+        return NextResponse.json(
+            { error: 'Invalid input', details: parsed.error.flatten().fieldErrors },
+            { status: 400 }
+        );
+    }
+
+    const result = await authService.signIn(parsed.data.email, parsed.data.password);
+
+    if (result.error) {
+        return NextResponse.json({ error: result.error.message }, { status: 401 });
+    }
+
+    return NextResponse.json({ user: result.user, session: result.session });
+}

--- a/apps/web/src/app/api/auth/signup/route.ts
+++ b/apps/web/src/app/api/auth/signup/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { authService } from '@/services/auth.service';
+
+const signUpSchema = z.object({
+    email: z.string().email(),
+    password: z.string().min(8),
+});
+
+/**
+ * POST /api/auth/signup
+ * Creates a new user account and returns the user + session.
+ * Returns 409 if the email is already registered.
+ */
+export async function POST(req: NextRequest) {
+    const body = await req.json();
+    const parsed = signUpSchema.safeParse(body);
+
+    if (!parsed.success) {
+        return NextResponse.json(
+            { error: 'Invalid input', details: parsed.error.flatten().fieldErrors },
+            { status: 400 }
+        );
+    }
+
+    const result = await authService.signUp(parsed.data.email, parsed.data.password);
+
+    if (result.error) {
+        const status = result.error.code === 'PROFILE_CREATION_ERROR' ? 409 : 400;
+        return NextResponse.json({ error: result.error.message }, { status });
+    }
+
+    return NextResponse.json({ user: result.user, session: result.session }, { status: 201 });
+}


### PR DESCRIPTION
- Add POST /api/auth/signup — Zod validation (email, min 8-char password), 201 on success, 409 on duplicate profile
- Add POST /api/auth/signin — Zod validation, 401 on bad credentials
- Both delegate to authService and return stable { user, session } payload
- 7 tests passing

Closes #30 