### PR TITLE
feat: complete stripe webhook route

### DIFF
--- a/apps/web/src/app/api/webhooks/stripe/route.test.ts
+++ b/apps/web/src/app/api/webhooks/stripe/route.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+// --- Stripe client mock ---
+const mockConstructEvent = vi.fn();
+vi.mock('@/lib/stripe/client', () => ({
+    stripe: { webhooks: { constructEvent: mockConstructEvent } },
+}));
+
+// --- Payment service mock ---
+const mockHandleWebhook = vi.fn();
+vi.mock('@/services/payment.service', () => ({
+    paymentService: { handleWebhook: mockHandleWebhook },
+}));
+
+const WEBHOOK_SECRET = 'whsec_test';
+const VALID_SIG = 'valid-sig';
+
+const makeRequest = (body: string, signature?: string) =>
+    new NextRequest('http://localhost/api/webhooks/stripe', {
+        method: 'POST',
+        body,
+        headers: signature ? { 'stripe-signature': signature } : {},
+    });
+
+const fakeEvent = (type: string) => ({ id: 'evt_1', type, data: { object: {} } });
+
+describe('POST /api/webhooks/stripe', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.stubEnv('STRIPE_WEBHOOK_SECRET', WEBHOOK_SECRET);
+    });
+
+    it('returns 400 when stripe-signature header is missing', async () => {
+        const { POST } = await import('./route');
+        const res = await POST(makeRequest('{}'));
+        expect(res.status).toBe(400);
+        expect((await res.json()).error).toBe('Missing stripe-signature header');
+    });
+
+    it('returns 500 when STRIPE_WEBHOOK_SECRET is not set', async () => {
+        vi.stubEnv('STRIPE_WEBHOOK_SECRET', '');
+        const { POST } = await import('./route');
+        const res = await POST(makeRequest('{}', VALID_SIG));
+        expect(res.status).toBe(500);
+        expect((await res.json()).error).toBe('Webhook secret not configured');
+    });
+
+    it('returns 400 when signature verification fails', async () => {
+        mockConstructEvent.mockImplementation(() => { throw new Error('No signatures found'); });
+        const { POST } = await import('./route');
+        const res = await POST(makeRequest('{}', 'bad-sig'));
+        expect(res.status).toBe(400);
+        expect((await res.json()).error).toBe('Invalid signature');
+    });
+
+    it('returns 200 without calling handleWebhook for unsupported event types', async () => {
+        mockConstructEvent.mockReturnValue(fakeEvent('payment_intent.created'));
+        const { POST } = await import('./route');
+        const res = await POST(makeRequest('{}', VALID_SIG));
+        expect(res.status).toBe(200);
+        expect(await res.json()).toEqual({ received: true });
+        expect(mockHandleWebhook).not.toHaveBeenCalled();
+    });
+
+    it.each([
+        'checkout.session.completed',
+        'customer.subscription.created',
+        'customer.subscription.updated',
+        'customer.subscription.deleted',
+        'invoice.payment_succeeded',
+        'invoice.payment_failed',
+    ])('delegates %s to paymentService.handleWebhook', async (type) => {
+        const event = fakeEvent(type);
+        mockConstructEvent.mockReturnValue(event);
+        mockHandleWebhook.mockResolvedValue(undefined);
+        const { POST } = await import('./route');
+        const res = await POST(makeRequest('{}', VALID_SIG));
+        expect(res.status).toBe(200);
+        expect(await res.json()).toEqual({ received: true });
+        expect(mockHandleWebhook).toHaveBeenCalledWith(event);
+    });
+
+    it('returns 500 when handleWebhook throws', async () => {
+        mockConstructEvent.mockReturnValue(fakeEvent('checkout.session.completed'));
+        mockHandleWebhook.mockRejectedValue(new Error('DB error'));
+        const { POST } = await import('./route');
+        const res = await POST(makeRequest('{}', VALID_SIG));
+        expect(res.status).toBe(500);
+        expect((await res.json()).error).toBe('Webhook processing failed');
+    });
+});

--- a/apps/web/src/app/api/webhooks/stripe/route.ts
+++ b/apps/web/src/app/api/webhooks/stripe/route.ts
@@ -1,12 +1,26 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { stripe } from '@/lib/stripe/client';
 import { paymentService } from '@/services/payment.service';
-import { headers } from 'next/headers';
 
+const SUPPORTED_EVENTS = new Set([
+    'checkout.session.completed',
+    'customer.subscription.created',
+    'customer.subscription.updated',
+    'customer.subscription.deleted',
+    'invoice.payment_succeeded',
+    'invoice.payment_failed',
+]);
+
+/**
+ * POST /api/webhooks/stripe
+ *
+ * Receives Stripe webhook events, verifies the signature, and delegates
+ * to the payment service. Returns 200 for all successfully verified events
+ * (including unsupported types) so Stripe does not retry unnecessarily.
+ */
 export async function POST(req: NextRequest) {
     const body = await req.text();
-    const headersList = headers();
-    const signature = headersList.get('stripe-signature');
+    const signature = req.headers.get('stripe-signature');
 
     if (!signature) {
         return NextResponse.json(
@@ -31,10 +45,11 @@ export async function POST(req: NextRequest) {
         event = stripe.webhooks.constructEvent(body, signature, webhookSecret);
     } catch (err: any) {
         console.error('Webhook signature verification failed:', err.message);
-        return NextResponse.json(
-            { error: 'Invalid signature' },
-            { status: 400 }
-        );
+        return NextResponse.json({ error: 'Invalid signature' }, { status: 400 });
+    }
+
+    if (!SUPPORTED_EVENTS.has(event.type)) {
+        return NextResponse.json({ received: true });
     }
 
     try {


### PR DESCRIPTION

Finalizes signature verification and event dispatching for subscription flows.

Changes
- Read stripe-signature from req.headers (removes next/headers dependency, improves testability)
- Guard unsupported event types with early 200 return — prevents unnecessary Stripe retries
- Add SUPPORTED_EVENTS allowlist covering all 6 subscription flow event types
- 11 tests covering: missing header, missing secret, bad signature, unsupported events, all supported types, and service errors

Closes #39