### PR TITLE
Issue 034: Add rate limiting middleware for authentication endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,3 +23,8 @@ NEXT_PUBLIC_STRIPE_PRICE_ENTERPRISE=price_xxxxxxxxxxxxx
 
 # App
 NEXT_PUBLIC_APP_URL=http://localhost:3000
+
+# Rate Limiting
+# Set to "true" in local development or CI to bypass auth rate limiting.
+# Never set this in production.
+RATE_LIMIT_DISABLED=false

--- a/apps/web/src/app/api/auth/signin/route.ts
+++ b/apps/web/src/app/api/auth/signin/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import { authService } from '@/services/auth.service';
+import { withRateLimit } from '@/lib/api/with-rate-limit';
+import { AUTH_RATE_LIMIT } from '@/lib/api/rate-limit';
 
 const signInSchema = z.object({
     email: z.string().email(),
@@ -11,23 +13,26 @@ const signInSchema = z.object({
  * POST /api/auth/signin
  * Authenticates an existing user and returns the user + session.
  * Returns 401 for invalid credentials.
+ * Rate limited: 10 requests per 15 minutes per IP (see AUTH_RATE_LIMIT).
  */
-export async function POST(req: NextRequest) {
-    const body = await req.json();
-    const parsed = signInSchema.safeParse(body);
+export const POST = withRateLimit('auth:signin', AUTH_RATE_LIMIT)(
+    async (req: NextRequest) => {
+        const body = await req.json();
+        const parsed = signInSchema.safeParse(body);
 
-    if (!parsed.success) {
-        return NextResponse.json(
-            { error: 'Invalid input', details: parsed.error.flatten().fieldErrors },
-            { status: 400 }
-        );
+        if (!parsed.success) {
+            return NextResponse.json(
+                { error: 'Invalid input', details: parsed.error.flatten().fieldErrors },
+                { status: 400 }
+            );
+        }
+
+        const result = await authService.signIn(parsed.data.email, parsed.data.password);
+
+        if (result.error) {
+            return NextResponse.json({ error: result.error.message }, { status: 401 });
+        }
+
+        return NextResponse.json({ user: result.user, session: result.session });
     }
-
-    const result = await authService.signIn(parsed.data.email, parsed.data.password);
-
-    if (result.error) {
-        return NextResponse.json({ error: result.error.message }, { status: 401 });
-    }
-
-    return NextResponse.json({ user: result.user, session: result.session });
-}
+);

--- a/apps/web/src/app/api/auth/signup/route.ts
+++ b/apps/web/src/app/api/auth/signup/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import { authService } from '@/services/auth.service';
+import { withRateLimit } from '@/lib/api/with-rate-limit';
+import { AUTH_RATE_LIMIT } from '@/lib/api/rate-limit';
 
 const signUpSchema = z.object({
     email: z.string().email(),
@@ -11,24 +13,27 @@ const signUpSchema = z.object({
  * POST /api/auth/signup
  * Creates a new user account and returns the user + session.
  * Returns 409 if the email is already registered.
+ * Rate limited: 10 requests per 15 minutes per IP (see AUTH_RATE_LIMIT).
  */
-export async function POST(req: NextRequest) {
-    const body = await req.json();
-    const parsed = signUpSchema.safeParse(body);
+export const POST = withRateLimit('auth:signup', AUTH_RATE_LIMIT)(
+    async (req: NextRequest) => {
+        const body = await req.json();
+        const parsed = signUpSchema.safeParse(body);
 
-    if (!parsed.success) {
-        return NextResponse.json(
-            { error: 'Invalid input', details: parsed.error.flatten().fieldErrors },
-            { status: 400 }
-        );
+        if (!parsed.success) {
+            return NextResponse.json(
+                { error: 'Invalid input', details: parsed.error.flatten().fieldErrors },
+                { status: 400 }
+            );
+        }
+
+        const result = await authService.signUp(parsed.data.email, parsed.data.password);
+
+        if (result.error) {
+            const status = result.error.code === 'PROFILE_CREATION_ERROR' ? 409 : 400;
+            return NextResponse.json({ error: result.error.message }, { status });
+        }
+
+        return NextResponse.json({ user: result.user, session: result.session }, { status: 201 });
     }
-
-    const result = await authService.signUp(parsed.data.email, parsed.data.password);
-
-    if (result.error) {
-        const status = result.error.code === 'PROFILE_CREATION_ERROR' ? 409 : 400;
-        return NextResponse.json({ error: result.error.message }, { status });
-    }
-
-    return NextResponse.json({ user: result.user, session: result.session }, { status: 201 });
-}
+);

--- a/apps/web/src/lib/api/rate-limit.test.ts
+++ b/apps/web/src/lib/api/rate-limit.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { checkRateLimit, getRateLimitKey, _resetStore, type RateLimitConfig } from './rate-limit';
+
+const config: RateLimitConfig = { limit: 3, windowMs: 60_000 };
+
+describe('checkRateLimit', () => {
+    beforeEach(() => _resetStore());
+    afterEach(() => vi.useRealTimers());
+
+    it('allows requests under the limit', () => {
+        const r1 = checkRateLimit('key1', config);
+        expect(r1.allowed).toBe(true);
+        expect(r1.remaining).toBe(2);
+
+        const r2 = checkRateLimit('key1', config);
+        expect(r2.allowed).toBe(true);
+        expect(r2.remaining).toBe(1);
+    });
+
+    it('blocks the request that exceeds the limit', () => {
+        checkRateLimit('key2', config);
+        checkRateLimit('key2', config);
+        checkRateLimit('key2', config);
+
+        const r = checkRateLimit('key2', config);
+        expect(r.allowed).toBe(false);
+        expect(r.remaining).toBe(0);
+    });
+
+    it('returns retryAfterMs > 0 when blocked', () => {
+        checkRateLimit('key3', config);
+        checkRateLimit('key3', config);
+        checkRateLimit('key3', config);
+
+        const r = checkRateLimit('key3', config);
+        expect(r.retryAfterMs).toBeGreaterThan(0);
+        expect(r.resetAt).toBeGreaterThan(Date.now());
+    });
+
+    it('resets after the window expires', () => {
+        vi.useFakeTimers();
+
+        checkRateLimit('key4', config);
+        checkRateLimit('key4', config);
+        checkRateLimit('key4', config);
+
+        // Advance past the window.
+        vi.advanceTimersByTime(config.windowMs + 1);
+
+        const r = checkRateLimit('key4', config);
+        expect(r.allowed).toBe(true);
+        expect(r.remaining).toBe(2);
+    });
+
+    it('tracks keys independently', () => {
+        checkRateLimit('keyA', config);
+        checkRateLimit('keyA', config);
+        checkRateLimit('keyA', config);
+
+        // keyB is unaffected.
+        const r = checkRateLimit('keyB', config);
+        expect(r.allowed).toBe(true);
+    });
+
+    it('remaining is 0 (not negative) when blocked', () => {
+        for (let i = 0; i < 5; i++) checkRateLimit('key5', config);
+        const r = checkRateLimit('key5', config);
+        expect(r.remaining).toBe(0);
+    });
+});
+
+describe('getRateLimitKey', () => {
+    const makeReq = (headers: Record<string, string | null>) => ({
+        headers: { get: (name: string) => headers[name] ?? null },
+    });
+
+    it('uses x-forwarded-for first', () => {
+        const req = makeReq({ 'x-forwarded-for': '1.2.3.4, 5.6.7.8' });
+        expect(getRateLimitKey(req, 'auth:signin')).toBe('auth:signin:1.2.3.4');
+    });
+
+    it('falls back to x-real-ip', () => {
+        const req = makeReq({ 'x-forwarded-for': null, 'x-real-ip': '9.9.9.9' });
+        expect(getRateLimitKey(req, 'auth:signin')).toBe('auth:signin:9.9.9.9');
+    });
+
+    it('falls back to "unknown" when no IP header present', () => {
+        const req = makeReq({ 'x-forwarded-for': null, 'x-real-ip': null });
+        expect(getRateLimitKey(req, 'auth:signin')).toBe('auth:signin:unknown');
+    });
+
+    it('scopes key by route', () => {
+        const req = makeReq({ 'x-forwarded-for': '1.1.1.1' });
+        expect(getRateLimitKey(req, 'auth:signin')).not.toBe(getRateLimitKey(req, 'auth:signup'));
+    });
+});

--- a/apps/web/src/lib/api/rate-limit.ts
+++ b/apps/web/src/lib/api/rate-limit.ts
@@ -1,0 +1,108 @@
+/**
+ * In-memory sliding-window rate limiter.
+ *
+ * Suitable for single-instance / local-dev use.
+ * In production with multiple replicas, swap the store for a shared
+ * Redis/Upstash backend — the RateLimiter interface stays the same.
+ *
+ * Configuration
+ * ─────────────
+ * Each "limit config" defines:
+ *   - limit      : max requests allowed in the window
+ *   - windowMs   : rolling window length in milliseconds
+ *
+ * Request key
+ * ───────────
+ * Keys are derived from the client IP (x-forwarded-for → x-real-ip →
+ * "unknown") combined with a route identifier so limits are scoped
+ * per-endpoint, not globally.
+ *
+ * Local development
+ * ─────────────────
+ * Set RATE_LIMIT_DISABLED=true in .env.local to bypass all checks.
+ * Thresholds are intentionally generous in dev to avoid friction.
+ */
+
+export interface RateLimitConfig {
+  /** Maximum number of requests allowed within the window. */
+  limit: number;
+  /** Rolling window duration in milliseconds. */
+  windowMs: number;
+}
+
+export interface RateLimitResult {
+  /** Whether the request is allowed. */
+  allowed: boolean;
+  /** Remaining requests in the current window. */
+  remaining: number;
+  /** Unix timestamp (ms) when the oldest request in the window expires. */
+  resetAt: number;
+  /** How many ms until the window resets (convenience alias). */
+  retryAfterMs: number;
+}
+
+// ── Pre-defined configs for auth-sensitive routes ────────────────────────────
+
+/** Strict limit for credential submission (sign-in / sign-up). */
+export const AUTH_RATE_LIMIT: RateLimitConfig = {
+  limit: 10,
+  windowMs: 15 * 60 * 1000, // 10 attempts per 15 minutes
+};
+
+/** Lighter limit for read-only auth endpoints (user, profile). */
+export const AUTH_READ_RATE_LIMIT: RateLimitConfig = {
+  limit: 60,
+  windowMs: 60 * 1000, // 60 requests per minute
+};
+
+// ── Store ────────────────────────────────────────────────────────────────────
+
+// Map<key, timestamps[]> — each entry is a sorted list of request timestamps.
+const store = new Map<string, number[]>();
+
+// ── Core logic ───────────────────────────────────────────────────────────────
+
+/**
+ * Check and record a request against the rate limit for the given key.
+ * Pure function over the shared store — no I/O.
+ */
+export function checkRateLimit(key: string, config: RateLimitConfig): RateLimitResult {
+  const now = Date.now();
+  const windowStart = now - config.windowMs;
+
+  // Retrieve and prune timestamps outside the current window.
+  const timestamps = (store.get(key) ?? []).filter((t) => t > windowStart);
+
+  const allowed = timestamps.length < config.limit;
+
+  if (allowed) {
+    timestamps.push(now);
+    store.set(key, timestamps);
+  }
+
+  const oldest = timestamps[0] ?? now;
+  const resetAt = oldest + config.windowMs;
+
+  return {
+    allowed,
+    remaining: Math.max(0, config.limit - timestamps.length),
+    resetAt,
+    retryAfterMs: Math.max(0, resetAt - now),
+  };
+}
+
+/**
+ * Derive a stable rate-limit key from a Next.js request and a route label.
+ *
+ * Priority: x-forwarded-for → x-real-ip → "unknown"
+ */
+export function getRateLimitKey(req: { headers: { get(name: string): string | null } }, route: string): string {
+  const forwarded = req.headers.get('x-forwarded-for');
+  const ip = forwarded ? forwarded.split(',')[0].trim() : (req.headers.get('x-real-ip') ?? 'unknown');
+  return `${route}:${ip}`;
+}
+
+/** Clears the in-memory store — intended for use in tests only. */
+export function _resetStore(): void {
+  store.clear();
+}

--- a/apps/web/src/lib/api/with-rate-limit.test.ts
+++ b/apps/web/src/lib/api/with-rate-limit.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { NextRequest, NextResponse } from 'next/server';
+import { withRateLimit } from './with-rate-limit';
+import { _resetStore, type RateLimitConfig } from './rate-limit';
+
+const tightConfig: RateLimitConfig = { limit: 2, windowMs: 60_000 };
+
+const makeReq = (ip = '1.2.3.4') =>
+    new NextRequest('http://localhost/api/auth/signin', {
+        method: 'POST',
+        headers: { 'x-forwarded-for': ip },
+    });
+
+const okHandler = vi.fn(async () => NextResponse.json({ ok: true }));
+
+describe('withRateLimit', () => {
+    beforeEach(() => {
+        _resetStore();
+        vi.clearAllMocks();
+        delete process.env.RATE_LIMIT_DISABLED;
+    });
+
+    afterEach(() => {
+        delete process.env.RATE_LIMIT_DISABLED;
+    });
+
+    it('calls the handler when under the limit', async () => {
+        const wrapped = withRateLimit('test:route', tightConfig)(okHandler);
+        const res = await wrapped(makeReq(), { params: {} });
+        expect(res.status).toBe(200);
+        expect(okHandler).toHaveBeenCalledOnce();
+    });
+
+    it('returns 429 when the limit is exceeded', async () => {
+        const wrapped = withRateLimit('test:route', tightConfig)(okHandler);
+        await wrapped(makeReq(), { params: {} });
+        await wrapped(makeReq(), { params: {} });
+
+        const res = await wrapped(makeReq(), { params: {} });
+        expect(res.status).toBe(429);
+        expect(okHandler).toHaveBeenCalledTimes(2);
+    });
+
+    it('429 body contains retryAfterMs and resetAt', async () => {
+        const wrapped = withRateLimit('test:route', tightConfig)(okHandler);
+        await wrapped(makeReq(), { params: {} });
+        await wrapped(makeReq(), { params: {} });
+
+        const res = await wrapped(makeReq(), { params: {} });
+        const body = await res.json();
+        expect(body.retryAfterMs).toBeGreaterThan(0);
+        expect(body.resetAt).toBeGreaterThan(Date.now());
+        expect(body.error).toBeDefined();
+    });
+
+    it('429 response includes Retry-After and X-RateLimit-* headers', async () => {
+        const wrapped = withRateLimit('test:route', tightConfig)(okHandler);
+        await wrapped(makeReq(), { params: {} });
+        await wrapped(makeReq(), { params: {} });
+
+        const res = await wrapped(makeReq(), { params: {} });
+        expect(res.headers.get('Retry-After')).toBeDefined();
+        expect(res.headers.get('X-RateLimit-Limit')).toBe('2');
+        expect(res.headers.get('X-RateLimit-Remaining')).toBe('0');
+        expect(res.headers.get('X-RateLimit-Reset')).toBeDefined();
+    });
+
+    it('attaches X-RateLimit-* headers to successful responses', async () => {
+        const wrapped = withRateLimit('test:route', tightConfig)(okHandler);
+        const res = await wrapped(makeReq(), { params: {} });
+        expect(res.headers.get('X-RateLimit-Limit')).toBe('2');
+        expect(res.headers.get('X-RateLimit-Remaining')).toBe('1');
+    });
+
+    it('limits are scoped per IP', async () => {
+        const wrapped = withRateLimit('test:route', tightConfig)(okHandler);
+        await wrapped(makeReq('1.1.1.1'), { params: {} });
+        await wrapped(makeReq('1.1.1.1'), { params: {} });
+
+        // Different IP should still be allowed.
+        const res = await wrapped(makeReq('2.2.2.2'), { params: {} });
+        expect(res.status).toBe(200);
+    });
+
+    it('bypasses rate limiting when RATE_LIMIT_DISABLED=true', async () => {
+        process.env.RATE_LIMIT_DISABLED = 'true';
+        const wrapped = withRateLimit('test:route', tightConfig)(okHandler);
+
+        // Exceed the limit — should still pass through.
+        for (let i = 0; i < 5; i++) {
+            const res = await wrapped(makeReq(), { params: {} });
+            expect(res.status).toBe(200);
+        }
+        expect(okHandler).toHaveBeenCalledTimes(5);
+    });
+});

--- a/apps/web/src/lib/api/with-rate-limit.ts
+++ b/apps/web/src/lib/api/with-rate-limit.ts
@@ -1,0 +1,69 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { checkRateLimit, getRateLimitKey, type RateLimitConfig } from './rate-limit';
+
+type RouteHandler<TParams = {}> = (
+  req: NextRequest,
+  ctx: { params: TParams }
+) => Promise<NextResponse>;
+
+/**
+ * Wraps a route handler with sliding-window rate limiting.
+ *
+ * When the limit is exceeded the handler is NOT called and a 429 response
+ * is returned with:
+ *   - Retry-After header (seconds)
+ *   - X-RateLimit-* headers for client visibility
+ *   - JSON body with retryAfterMs and resetAt for programmatic use
+ *
+ * Usage:
+ *   export const POST = withRateLimit('auth:signin', AUTH_RATE_LIMIT)(handler);
+ *
+ * Bypass (local dev):
+ *   Set RATE_LIMIT_DISABLED=true in .env.local
+ */
+export function withRateLimit<TParams = {}>(
+  routeKey: string,
+  config: RateLimitConfig
+) {
+  return (handler: RouteHandler<TParams>): RouteHandler<TParams> => {
+    return async (req: NextRequest, ctx: { params: TParams }) => {
+      // Allow bypass in local development / CI.
+      if (process.env.RATE_LIMIT_DISABLED === 'true') {
+        return handler(req, ctx);
+      }
+
+      const key = getRateLimitKey(req, routeKey);
+      const result = checkRateLimit(key, config);
+
+      const rateLimitHeaders = {
+        'X-RateLimit-Limit': String(config.limit),
+        'X-RateLimit-Remaining': String(result.remaining),
+        'X-RateLimit-Reset': String(Math.ceil(result.resetAt / 1000)),
+      };
+
+      if (!result.allowed) {
+        return NextResponse.json(
+          {
+            error: 'Too many requests. Please try again later.',
+            retryAfterMs: result.retryAfterMs,
+            resetAt: result.resetAt,
+          },
+          {
+            status: 429,
+            headers: {
+              ...rateLimitHeaders,
+              'Retry-After': String(Math.ceil(result.retryAfterMs / 1000)),
+            },
+          }
+        );
+      }
+
+      const response = await handler(req, ctx);
+
+      // Attach rate-limit headers to successful responses too.
+      Object.entries(rateLimitHeaders).forEach(([k, v]) => response.headers.set(k, v));
+
+      return response;
+    };
+  };
+}


### PR DESCRIPTION
closes #34 
feat: add auth rate limiting middleware
issue-034 - Implements sliding-window in-memory rate limiter for auth endpoints.

- Add rate-limit.ts: checkRateLimit, getRateLimitKey, AUTH_RATE_LIMIT config
- Add with-rate-limit.ts: withRateLimit HOF wrapper, mirrors withAuth pattern
- Wire withRateLimit into POST /api/auth/signin and POST /api/auth/signup
- Return 429 with Retry-After, X-RateLimit-* headers and retryAfterMs/resetAt body
- Add RATE_LIMIT_DISABLED env var for local dev / CI bypass
- Tests: rate-limit.test.ts and with-rate-limit.test.ts (vitest)