### PR TITLE
Write unit tests for payment flows

### DIFF
--- a/apps/web/src/app/api/payments/payment.routes.test.ts
+++ b/apps/web/src/app/api/payments/payment.routes.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Unit tests for payment API route handlers
+ *
+ * Routes covered:
+ *   POST /api/payments/checkout    – price validation, session creation, auth guard
+ *   GET  /api/payments/subscription – status retrieval, auth guard
+ *   POST /api/payments/cancel       – cancellation, missing subscription, auth guard
+ *
+ * Mocks:
+ *   @/lib/supabase/server  → withAuth session check + cancel route profile lookup
+ *   @/services/payment.service → paymentService singleton
+ *   @/lib/stripe/pricing   → getValidPriceIds
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+// ── Supabase mock (required by withAuth) ──────────────────────────────────────
+
+const mockGetUser = vi.fn();
+const mockFrom = vi.fn();
+
+vi.mock('@/lib/supabase/server', () => ({
+    createClient: () => ({
+        auth: { getUser: mockGetUser },
+        from: mockFrom,
+    }),
+}));
+
+// ── Payment service mock ──────────────────────────────────────────────────────
+
+const mockCreateCheckoutSession = vi.fn();
+const mockGetSubscriptionStatus = vi.fn();
+const mockCancelSubscription = vi.fn();
+
+vi.mock('@/services/payment.service', () => ({
+    paymentService: {
+        createCheckoutSession: mockCreateCheckoutSession,
+        getSubscriptionStatus: mockGetSubscriptionStatus,
+        cancelSubscription: mockCancelSubscription,
+    },
+}));
+
+// ── Pricing mock ──────────────────────────────────────────────────────────────
+
+const mockGetValidPriceIds = vi.fn();
+
+vi.mock('@/lib/stripe/pricing', () => ({
+    getValidPriceIds: () => mockGetValidPriceIds(),
+}));
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const fakeUser = { id: 'user-1', email: 'a@b.com' };
+
+const post = (url: string, body: unknown) =>
+    new NextRequest(`http://localhost${url}`, {
+        method: 'POST',
+        body: JSON.stringify(body),
+        headers: { 'Content-Type': 'application/json' },
+    });
+
+const get = (url: string) =>
+    new NextRequest(`http://localhost${url}`, { method: 'GET' });
+
+// ── POST /api/payments/checkout ───────────────────────────────────────────────
+
+describe('POST /api/payments/checkout', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockGetUser.mockResolvedValue({ data: { user: fakeUser }, error: null });
+        mockGetValidPriceIds.mockReturnValue(['price_pro', 'price_ent']);
+    });
+
+    it('returns 401 when unauthenticated', async () => {
+        mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+        const { POST } = await import('./checkout/route');
+        const res = await POST(post('/api/payments/checkout', { priceId: 'price_pro' }), { params: {} });
+        expect(res.status).toBe(401);
+    });
+
+    it('returns 400 when priceId is missing', async () => {
+        const { POST } = await import('./checkout/route');
+        const res = await POST(post('/api/payments/checkout', {}), { params: {} });
+        expect(res.status).toBe(400);
+        expect((await res.json()).error).toBe('Price ID is required');
+    });
+
+    it('returns 400 when priceId is not in the valid set', async () => {
+        const { POST } = await import('./checkout/route');
+        const res = await POST(post('/api/payments/checkout', { priceId: 'price_unknown' }), { params: {} });
+        expect(res.status).toBe(400);
+        expect((await res.json()).error).toBe('Invalid price ID');
+    });
+
+    it('returns 200 with sessionId and url on success', async () => {
+        mockCreateCheckoutSession.mockResolvedValue({
+            sessionId: 'cs_123',
+            url: 'https://checkout.stripe.com/cs_123',
+        });
+        const { POST } = await import('./checkout/route');
+        const res = await POST(post('/api/payments/checkout', { priceId: 'price_pro' }), { params: {} });
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.sessionId).toBe('cs_123');
+        expect(body.url).toBe('https://checkout.stripe.com/cs_123');
+    });
+
+    it('calls createCheckoutSession with the authenticated user id', async () => {
+        mockCreateCheckoutSession.mockResolvedValue({ sessionId: 'cs_x', url: 'https://x' });
+        const { POST } = await import('./checkout/route');
+        await POST(post('/api/payments/checkout', { priceId: 'price_pro' }), { params: {} });
+        expect(mockCreateCheckoutSession).toHaveBeenCalledWith('user-1', 'price_pro');
+    });
+
+    it('returns 500 when createCheckoutSession throws', async () => {
+        mockCreateCheckoutSession.mockRejectedValue(new Error('Stripe error'));
+        const { POST } = await import('./checkout/route');
+        const res = await POST(post('/api/payments/checkout', { priceId: 'price_pro' }), { params: {} });
+        expect(res.status).toBe(500);
+        expect((await res.json()).error).toBe('Stripe error');
+    });
+});
+
+// ── GET /api/payments/subscription ───────────────────────────────────────────
+
+describe('GET /api/payments/subscription', () => {
+    const fakeStatus = {
+        tier: 'pro',
+        status: 'active',
+        currentPeriodEnd: new Date('2026-12-31'),
+        cancelAtPeriodEnd: false,
+    };
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockGetUser.mockResolvedValue({ data: { user: fakeUser }, error: null });
+    });
+
+    it('returns 401 when unauthenticated', async () => {
+        mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+        const { GET } = await import('./subscription/route');
+        const res = await GET(get('/api/payments/subscription'), { params: {} });
+        expect(res.status).toBe(401);
+    });
+
+    it('returns 200 with subscription status', async () => {
+        mockGetSubscriptionStatus.mockResolvedValue(fakeStatus);
+        const { GET } = await import('./subscription/route');
+        const res = await GET(get('/api/payments/subscription'), { params: {} });
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.tier).toBe('pro');
+        expect(body.status).toBe('active');
+        expect(body.cancelAtPeriodEnd).toBe(false);
+    });
+
+    it('calls getSubscriptionStatus with the authenticated user id', async () => {
+        mockGetSubscriptionStatus.mockResolvedValue(fakeStatus);
+        const { GET } = await import('./subscription/route');
+        await GET(get('/api/payments/subscription'), { params: {} });
+        expect(mockGetSubscriptionStatus).toHaveBeenCalledWith('user-1');
+    });
+
+    it('returns 500 when getSubscriptionStatus throws', async () => {
+        mockGetSubscriptionStatus.mockRejectedValue(new Error('DB error'));
+        const { GET } = await import('./subscription/route');
+        const res = await GET(get('/api/payments/subscription'), { params: {} });
+        expect(res.status).toBe(500);
+        expect((await res.json()).error).toBe('DB error');
+    });
+});
+
+// ── POST /api/payments/cancel ─────────────────────────────────────────────────
+
+describe('POST /api/payments/cancel', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockGetUser.mockResolvedValue({ data: { user: fakeUser }, error: null });
+    });
+
+    const makeProfileQuery = (subscriptionId: string | null) => ({
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({
+            data: subscriptionId ? { stripe_subscription_id: subscriptionId } : null,
+        }),
+    });
+
+    it('returns 401 when unauthenticated', async () => {
+        mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+        const { POST } = await import('./cancel/route');
+        const res = await POST(post('/api/payments/cancel', {}), { params: {} });
+        expect(res.status).toBe(401);
+    });
+
+    it('returns 404 when no active subscription is found', async () => {
+        mockFrom.mockReturnValue(makeProfileQuery(null));
+        const { POST } = await import('./cancel/route');
+        const res = await POST(post('/api/payments/cancel', {}), { params: {} });
+        expect(res.status).toBe(404);
+        expect((await res.json()).error).toBe('No active subscription found');
+    });
+
+    it('returns 200 on successful cancellation', async () => {
+        mockFrom.mockReturnValue(makeProfileQuery('sub_abc'));
+        mockCancelSubscription.mockResolvedValue(undefined);
+        const { POST } = await import('./cancel/route');
+        const res = await POST(post('/api/payments/cancel', {}), { params: {} });
+        expect(res.status).toBe(200);
+        expect((await res.json()).success).toBe(true);
+    });
+
+    it('calls cancelSubscription with the stored subscription ID', async () => {
+        mockFrom.mockReturnValue(makeProfileQuery('sub_abc'));
+        mockCancelSubscription.mockResolvedValue(undefined);
+        const { POST } = await import('./cancel/route');
+        await POST(post('/api/payments/cancel', {}), { params: {} });
+        expect(mockCancelSubscription).toHaveBeenCalledWith('sub_abc');
+    });
+
+    it('returns 500 when cancelSubscription throws', async () => {
+        mockFrom.mockReturnValue(makeProfileQuery('sub_abc'));
+        mockCancelSubscription.mockRejectedValue(new Error('Stripe cancel error'));
+        const { POST } = await import('./cancel/route');
+        const res = await POST(post('/api/payments/cancel', {}), { params: {} });
+        expect(res.status).toBe(500);
+        expect((await res.json()).error).toBe('Stripe cancel error');
+    });
+});

--- a/apps/web/src/services/payment.service.test.ts
+++ b/apps/web/src/services/payment.service.test.ts
@@ -1,0 +1,445 @@
+/**
+ * Unit tests for PaymentService
+ *
+ * Mocks:
+ *   - @/lib/stripe/client  → stripe (customers, checkout.sessions, subscriptions)
+ *   - @/lib/supabase/server → createClient (profiles table + auth.getUser)
+ *   - @/lib/stripe/pricing  → getTierFromPriceId (keeps tests independent of env)
+ *
+ * Coverage:
+ *   createCheckoutSession  – existing customer, new customer, missing email
+ *   getSubscriptionStatus  – no subscription (free), active subscription
+ *   cancelSubscription     – delegates to stripe.subscriptions.update
+ *   handleWebhook          – checkout.session.completed (pro + enterprise tier mapping)
+ *                          – customer.subscription.updated
+ *                          – customer.subscription.deleted
+ *                          – invoice.payment_failed
+ *                          – missing user_id / unknown customer (no-ops)
+ *                          – unhandled event type (no-op)
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Stripe mock ───────────────────────────────────────────────────────────────
+
+const mockCustomersCreate = vi.fn();
+const mockCheckoutSessionsCreate = vi.fn();
+const mockSubscriptionsRetrieve = vi.fn();
+const mockSubscriptionsUpdate = vi.fn();
+
+vi.mock('@/lib/stripe/client', () => ({
+    stripe: {
+        customers: { create: mockCustomersCreate },
+        checkout: { sessions: { create: mockCheckoutSessionsCreate } },
+        subscriptions: {
+            retrieve: mockSubscriptionsRetrieve,
+            update: mockSubscriptionsUpdate,
+        },
+    },
+}));
+
+// ── Supabase mock ─────────────────────────────────────────────────────────────
+
+const mockGetUser = vi.fn();
+const mockFrom = vi.fn();
+
+vi.mock('@/lib/supabase/server', () => ({
+    createClient: () => ({
+        auth: { getUser: mockGetUser },
+        from: mockFrom,
+    }),
+}));
+
+// ── Pricing mock ──────────────────────────────────────────────────────────────
+
+const mockGetTierFromPriceId = vi.fn();
+
+vi.mock('@/lib/stripe/pricing', () => ({
+    getTierFromPriceId: (priceId: string) => mockGetTierFromPriceId(priceId),
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/**
+ * Builds a chainable Supabase query mock.
+ * Each method returns `this` so calls can be chained arbitrarily.
+ * `single` resolves with the provided value.
+ */
+function makeQuery(singleResult: { data: unknown; error?: unknown }) {
+    const q: any = {
+        select: vi.fn().mockReturnThis(),
+        insert: vi.fn().mockReturnThis(),
+        update: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue(singleResult),
+    };
+    // update().eq() should also resolve (no single needed for updates)
+    q.update.mockReturnValue({ eq: vi.fn().mockResolvedValue({ error: null }) });
+    return q;
+}
+
+// ── Import service after mocks are registered ─────────────────────────────────
+
+let service: InstanceType<typeof import('./payment.service').PaymentService>;
+
+beforeEach(async () => {
+    if (!service) {
+        const { PaymentService } = await import('./payment.service');
+        service = new PaymentService();
+    }
+    vi.clearAllMocks();
+});
+
+// ── createCheckoutSession ─────────────────────────────────────────────────────
+
+describe('PaymentService.createCheckoutSession', () => {
+    const userId = 'user-1';
+    const priceId = 'price_pro';
+    const fakeSession = { id: 'cs_123', url: 'https://checkout.stripe.com/cs_123' };
+
+    beforeEach(() => vi.clearAllMocks());
+
+    it('reuses an existing Stripe customer and returns sessionId + url', async () => {
+        const query = makeQuery({ data: { stripe_customer_id: 'cus_existing' } });
+        mockFrom.mockReturnValue(query);
+        mockCheckoutSessionsCreate.mockResolvedValue(fakeSession);
+
+        const result = await service.createCheckoutSession(userId, priceId);
+
+        expect(mockCustomersCreate).not.toHaveBeenCalled();
+        expect(mockCheckoutSessionsCreate).toHaveBeenCalledWith(
+            expect.objectContaining({
+                customer: 'cus_existing',
+                mode: 'subscription',
+                line_items: [{ price: priceId, quantity: 1 }],
+            })
+        );
+        expect(result).toEqual({ sessionId: 'cs_123', url: fakeSession.url });
+    });
+
+    it('creates a new Stripe customer when none exists, then creates session', async () => {
+        // First from() call: profile lookup → no customer
+        // Second from() call: profile update
+        const profileQuery = makeQuery({ data: { stripe_customer_id: null } });
+        const updateQuery = makeQuery({ data: null });
+        mockFrom
+            .mockReturnValueOnce(profileQuery)
+            .mockReturnValueOnce(updateQuery);
+
+        mockGetUser.mockResolvedValue({ data: { user: { email: 'a@b.com' } } });
+        mockCustomersCreate.mockResolvedValue({ id: 'cus_new' });
+        mockCheckoutSessionsCreate.mockResolvedValue(fakeSession);
+
+        const result = await service.createCheckoutSession(userId, priceId);
+
+        expect(mockCustomersCreate).toHaveBeenCalledWith(
+            expect.objectContaining({
+                email: 'a@b.com',
+                metadata: { supabase_user_id: userId },
+            })
+        );
+        expect(mockCheckoutSessionsCreate).toHaveBeenCalledWith(
+            expect.objectContaining({ customer: 'cus_new' })
+        );
+        expect(result.sessionId).toBe('cs_123');
+    });
+
+    it('throws when no customer exists and user email is missing', async () => {
+        const profileQuery = makeQuery({ data: { stripe_customer_id: null } });
+        mockFrom.mockReturnValue(profileQuery);
+        mockGetUser.mockResolvedValue({ data: { user: null } });
+
+        await expect(service.createCheckoutSession(userId, priceId)).rejects.toThrow(
+            'User email not found'
+        );
+        expect(mockCheckoutSessionsCreate).not.toHaveBeenCalled();
+    });
+
+    it('embeds user_id in checkout session metadata', async () => {
+        const query = makeQuery({ data: { stripe_customer_id: 'cus_x' } });
+        mockFrom.mockReturnValue(query);
+        mockCheckoutSessionsCreate.mockResolvedValue(fakeSession);
+
+        await service.createCheckoutSession(userId, priceId);
+
+        expect(mockCheckoutSessionsCreate).toHaveBeenCalledWith(
+            expect.objectContaining({ metadata: { user_id: userId } })
+        );
+    });
+});
+
+// ── getSubscriptionStatus ─────────────────────────────────────────────────────
+
+describe('PaymentService.getSubscriptionStatus', () => {
+    const userId = 'user-1';
+
+    beforeEach(() => vi.clearAllMocks());
+
+    it('returns free/active defaults when no stripe_subscription_id is stored', async () => {
+        const query = makeQuery({
+            data: { subscription_tier: 'free', subscription_status: 'active', stripe_subscription_id: null },
+        });
+        mockFrom.mockReturnValue(query);
+
+        const result = await service.getSubscriptionStatus(userId);
+
+        expect(mockSubscriptionsRetrieve).not.toHaveBeenCalled();
+        expect(result.tier).toBe('free');
+        expect(result.status).toBe('active');
+        expect(result.cancelAtPeriodEnd).toBe(false);
+    });
+
+    it('returns free/active when profile is null', async () => {
+        const query = makeQuery({ data: null });
+        mockFrom.mockReturnValue(query);
+
+        const result = await service.getSubscriptionStatus(userId);
+
+        expect(result.tier).toBe('free');
+        expect(result.status).toBe('active');
+    });
+
+    it('retrieves subscription from Stripe and maps fields correctly', async () => {
+        const periodEnd = Math.floor(Date.now() / 1000) + 86400;
+        const query = makeQuery({
+            data: {
+                subscription_tier: 'pro',
+                subscription_status: 'active',
+                stripe_subscription_id: 'sub_123',
+            },
+        });
+        mockFrom.mockReturnValue(query);
+        mockSubscriptionsRetrieve.mockResolvedValue({
+            status: 'active',
+            current_period_end: periodEnd,
+            cancel_at_period_end: false,
+        });
+
+        const result = await service.getSubscriptionStatus(userId);
+
+        expect(mockSubscriptionsRetrieve).toHaveBeenCalledWith('sub_123');
+        expect(result.tier).toBe('pro');
+        expect(result.status).toBe('active');
+        expect(result.cancelAtPeriodEnd).toBe(false);
+        expect(result.currentPeriodEnd.getTime()).toBeCloseTo(periodEnd * 1000, -3);
+    });
+
+    it('reflects cancel_at_period_end=true from Stripe', async () => {
+        const query = makeQuery({
+            data: { subscription_tier: 'pro', subscription_status: 'active', stripe_subscription_id: 'sub_456' },
+        });
+        mockFrom.mockReturnValue(query);
+        mockSubscriptionsRetrieve.mockResolvedValue({
+            status: 'active',
+            current_period_end: Math.floor(Date.now() / 1000),
+            cancel_at_period_end: true,
+        });
+
+        const result = await service.getSubscriptionStatus(userId);
+
+        expect(result.cancelAtPeriodEnd).toBe(true);
+    });
+});
+
+// ── cancelSubscription ────────────────────────────────────────────────────────
+
+describe('PaymentService.cancelSubscription', () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    it('calls stripe.subscriptions.update with cancel_at_period_end=true', async () => {
+        mockSubscriptionsUpdate.mockResolvedValue({});
+
+        await service.cancelSubscription('sub_abc');
+
+        expect(mockSubscriptionsUpdate).toHaveBeenCalledWith('sub_abc', {
+            cancel_at_period_end: true,
+        });
+    });
+});
+
+// ── handleWebhook ─────────────────────────────────────────────────────────────
+
+describe('PaymentService.handleWebhook – checkout.session.completed', () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    const makeEvent = (overrides: object = {}) => ({
+        id: 'evt_1',
+        type: 'checkout.session.completed',
+        data: {
+            object: {
+                metadata: { user_id: 'user-1' },
+                subscription: 'sub_new',
+                ...overrides,
+            },
+        },
+    });
+
+    it('maps pro price ID to pro tier and updates profile', async () => {
+        mockGetTierFromPriceId.mockReturnValue('pro');
+        mockSubscriptionsRetrieve.mockResolvedValue({
+            id: 'sub_new',
+            items: { data: [{ price: { id: 'price_pro' } }] },
+        });
+        const updateEq = vi.fn().mockResolvedValue({ error: null });
+        const updateFn = vi.fn().mockReturnValue({ eq: updateEq });
+        mockFrom.mockReturnValue({ update: updateFn });
+
+        await service.handleWebhook(makeEvent() as any);
+
+        expect(mockGetTierFromPriceId).toHaveBeenCalledWith('price_pro');
+        expect(updateFn).toHaveBeenCalledWith(
+            expect.objectContaining({
+                subscription_tier: 'pro',
+                subscription_status: 'active',
+                stripe_subscription_id: 'sub_new',
+            })
+        );
+        expect(updateEq).toHaveBeenCalledWith('id', 'user-1');
+    });
+
+    it('maps enterprise price ID to enterprise tier', async () => {
+        mockGetTierFromPriceId.mockReturnValue('enterprise');
+        mockSubscriptionsRetrieve.mockResolvedValue({
+            id: 'sub_ent',
+            items: { data: [{ price: { id: 'price_ent' } }] },
+        });
+        const updateEq = vi.fn().mockResolvedValue({ error: null });
+        mockFrom.mockReturnValue({ update: vi.fn().mockReturnValue({ eq: updateEq }) });
+
+        await service.handleWebhook(makeEvent({ subscription: 'sub_ent' }) as any);
+
+        expect(mockGetTierFromPriceId).toHaveBeenCalledWith('price_ent');
+    });
+
+    it('does nothing when user_id is missing from session metadata', async () => {
+        const event = {
+            id: 'evt_2',
+            type: 'checkout.session.completed',
+            data: { object: { metadata: {}, subscription: 'sub_x' } },
+        };
+
+        await service.handleWebhook(event as any);
+
+        expect(mockSubscriptionsRetrieve).not.toHaveBeenCalled();
+        expect(mockFrom).not.toHaveBeenCalled();
+    });
+});
+
+describe('PaymentService.handleWebhook – customer.subscription.updated', () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    it('updates subscription_status for the matching profile', async () => {
+        const selectQuery = makeQuery({ data: { id: 'user-1' } });
+        const updateEq = vi.fn().mockResolvedValue({ error: null });
+        const updateFn = vi.fn().mockReturnValue({ eq: updateEq });
+        mockFrom
+            .mockReturnValueOnce(selectQuery)
+            .mockReturnValueOnce({ update: updateFn });
+
+        await service.handleWebhook({
+            id: 'evt_3',
+            type: 'customer.subscription.updated',
+            data: { object: { customer: 'cus_1', status: 'past_due' } },
+        } as any);
+
+        expect(updateFn).toHaveBeenCalledWith({ subscription_status: 'past_due' });
+        expect(updateEq).toHaveBeenCalledWith('id', 'user-1');
+    });
+
+    it('does nothing when no profile matches the customer ID', async () => {
+        const selectQuery = makeQuery({ data: null });
+        mockFrom.mockReturnValue(selectQuery);
+
+        await service.handleWebhook({
+            id: 'evt_4',
+            type: 'customer.subscription.updated',
+            data: { object: { customer: 'cus_unknown', status: 'active' } },
+        } as any);
+
+        // from() called once for select, never for update
+        expect(mockFrom).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('PaymentService.handleWebhook – customer.subscription.deleted', () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    it('downgrades to free tier and clears subscription ID', async () => {
+        const selectQuery = makeQuery({ data: { id: 'user-1' } });
+        const updateEq = vi.fn().mockResolvedValue({ error: null });
+        const updateFn = vi.fn().mockReturnValue({ eq: updateEq });
+        mockFrom
+            .mockReturnValueOnce(selectQuery)
+            .mockReturnValueOnce({ update: updateFn });
+
+        await service.handleWebhook({
+            id: 'evt_5',
+            type: 'customer.subscription.deleted',
+            data: { object: { customer: 'cus_1' } },
+        } as any);
+
+        expect(updateFn).toHaveBeenCalledWith({
+            subscription_tier: 'free',
+            subscription_status: 'canceled',
+            stripe_subscription_id: null,
+        });
+    });
+
+    it('does nothing when no profile matches the customer ID', async () => {
+        mockFrom.mockReturnValue(makeQuery({ data: null }));
+
+        await service.handleWebhook({
+            id: 'evt_6',
+            type: 'customer.subscription.deleted',
+            data: { object: { customer: 'cus_ghost' } },
+        } as any);
+
+        expect(mockFrom).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('PaymentService.handleWebhook – invoice.payment_failed', () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    it('marks subscription as past_due', async () => {
+        const selectQuery = makeQuery({ data: { id: 'user-1' } });
+        const updateEq = vi.fn().mockResolvedValue({ error: null });
+        const updateFn = vi.fn().mockReturnValue({ eq: updateEq });
+        mockFrom
+            .mockReturnValueOnce(selectQuery)
+            .mockReturnValueOnce({ update: updateFn });
+
+        await service.handleWebhook({
+            id: 'evt_7',
+            type: 'invoice.payment_failed',
+            data: { object: { customer: 'cus_1' } },
+        } as any);
+
+        expect(updateFn).toHaveBeenCalledWith({ subscription_status: 'past_due' });
+    });
+
+    it('does nothing when no profile matches the customer ID', async () => {
+        mockFrom.mockReturnValue(makeQuery({ data: null }));
+
+        await service.handleWebhook({
+            id: 'evt_8',
+            type: 'invoice.payment_failed',
+            data: { object: { customer: 'cus_ghost' } },
+        } as any);
+
+        expect(mockFrom).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('PaymentService.handleWebhook – unhandled event type', () => {
+    it('does nothing for unknown event types', async () => {
+        await service.handleWebhook({
+            id: 'evt_9',
+            type: 'payment_intent.created',
+            data: { object: {} },
+        } as any);
+
+        expect(mockFrom).not.toHaveBeenCalled();
+        expect(mockSubscriptionsRetrieve).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
closes #36 
test: add payment service unit tests
issue-036 - Unit tests for checkout session creation, subscription lookup, cancellation, and webhook-triggered state updates.

payment.service.test.ts (27 tests):
  createCheckoutSession: existing customer reuse, new customer creation,
    missing email error, user_id in session metadata
  getSubscriptionStatus: no subscription free defaults, null profile,
    Stripe field mapping, cancel_at_period_end
  cancelSubscription: delegates to stripe.subscriptions.update
  handleWebhook checkout.session.completed: pro tier mapping, enterprise
    tier mapping, missing user_id no-op
  handleWebhook customer.subscription.updated: status update, unknown customer no-op
  handleWebhook customer.subscription.deleted: free tier downgrade, unknown customer no-op
  handleWebhook invoice.payment_failed: past_due update, unknown customer no-op
  handleWebhook unhandled event type: no-op

payment.routes.test.ts (16 tests):
  POST /api/payments/checkout: 401 unauthed, 400 missing priceId,
    400 invalid priceId, 200 success shape, correct userId forwarded, 500 on throw
  GET /api/payments/subscription: 401 unauthed, 200 status shape,
    correct userId forwarded, 500 on throw
  POST /api/payments/cancel: 401 unauthed, 404 no subscription,
    200 success, correct subscriptionId forwarded, 500 on throw