### PR TITLE
feat: add customization draft save flow

### DIFF
--- a/apps/web/src/app/api/drafts/[templateId]/route.test.ts
+++ b/apps/web/src/app/api/drafts/[templateId]/route.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+// ── Supabase mock ─────────────────────────────────────────────────────────────
+const mockGetUser = vi.fn();
+const mockFrom = vi.fn();
+
+vi.mock('@/lib/supabase/server', () => ({
+    createClient: () => ({
+        auth: { getUser: mockGetUser },
+        from: mockFrom,
+    }),
+}));
+
+// ── Service mock ──────────────────────────────────────────────────────────────
+const mockSaveDraft = vi.fn();
+const mockGetDraft = vi.fn();
+
+vi.mock('@/services/customization-draft.service', () => ({
+    customizationDraftService: {
+        saveDraft: mockSaveDraft,
+        getDraft: mockGetDraft,
+    },
+}));
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+const fakeUser = { id: 'user-1', email: 'a@b.com' };
+const templateId = 'tmpl-1';
+
+const validConfig = {
+    branding: {
+        appName: 'My DEX',
+        primaryColor: '#000',
+        secondaryColor: '#fff',
+        fontFamily: 'Inter',
+    },
+    features: {
+        enableCharts: true,
+        enableTransactionHistory: false,
+        enableAnalytics: true,
+        enableNotifications: false,
+    },
+    stellar: {
+        network: 'testnet' as const,
+        horizonUrl: 'https://horizon-testnet.stellar.org',
+    },
+};
+
+const fakeDraft = {
+    id: 'draft-1',
+    userId: fakeUser.id,
+    templateId,
+    customizationConfig: validConfig,
+    createdAt: new Date('2026-01-01'),
+    updatedAt: new Date('2026-01-02'),
+};
+
+const makeRequest = (method: string, body?: unknown) =>
+    new NextRequest(`http://localhost/api/drafts/${templateId}`, {
+        method,
+        ...(body !== undefined
+            ? { body: JSON.stringify(body), headers: { 'Content-Type': 'application/json' } }
+            : {}),
+    });
+
+const params = { templateId };
+
+// ── GET /api/drafts/[templateId] ──────────────────────────────────────────────
+describe('GET /api/drafts/[templateId]', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockGetUser.mockResolvedValue({ data: { user: fakeUser }, error: null });
+    });
+
+    it('returns 401 when unauthenticated', async () => {
+        mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+        const { GET } = await import('./route');
+        const res = await GET(makeRequest('GET'), { params });
+        expect(res.status).toBe(401);
+    });
+
+    it('returns 404 when no draft exists', async () => {
+        mockGetDraft.mockResolvedValue(null);
+        const { GET } = await import('./route');
+        const res = await GET(makeRequest('GET'), { params });
+        expect(res.status).toBe(404);
+    });
+
+    it('returns the draft when it exists', async () => {
+        mockGetDraft.mockResolvedValue(fakeDraft);
+        const { GET } = await import('./route');
+        const res = await GET(makeRequest('GET'), { params });
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.id).toBe('draft-1');
+        expect(body.templateId).toBe(templateId);
+    });
+
+    it('returns 500 on service error', async () => {
+        mockGetDraft.mockRejectedValue(new Error('DB error'));
+        const { GET } = await import('./route');
+        const res = await GET(makeRequest('GET'), { params });
+        expect(res.status).toBe(500);
+    });
+});
+
+// ── POST /api/drafts/[templateId] ─────────────────────────────────────────────
+describe('POST /api/drafts/[templateId]', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockGetUser.mockResolvedValue({ data: { user: fakeUser }, error: null });
+    });
+
+    it('returns 401 when unauthenticated', async () => {
+        mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+        const { POST } = await import('./route');
+        const res = await POST(makeRequest('POST', validConfig), { params });
+        expect(res.status).toBe(401);
+    });
+
+    it('returns 400 for invalid JSON', async () => {
+        const { POST } = await import('./route');
+        const req = new NextRequest(`http://localhost/api/drafts/${templateId}`, {
+            method: 'POST',
+            body: 'not-json',
+            headers: { 'Content-Type': 'application/json' },
+        });
+        const res = await POST(req, { params });
+        expect(res.status).toBe(400);
+    });
+
+    it('returns 400 for invalid config shape', async () => {
+        const { POST } = await import('./route');
+        const res = await POST(makeRequest('POST', { branding: {} }), { params });
+        expect(res.status).toBe(400);
+        const body = await res.json();
+        expect(body.details).toBeDefined();
+    });
+
+    it('returns 404 when template does not exist', async () => {
+        mockSaveDraft.mockRejectedValue(new Error('Template not found'));
+        const { POST } = await import('./route');
+        const res = await POST(makeRequest('POST', validConfig), { params });
+        expect(res.status).toBe(404);
+    });
+
+    it('saves and returns the draft on valid input', async () => {
+        mockSaveDraft.mockResolvedValue(fakeDraft);
+        const { POST } = await import('./route');
+        const res = await POST(makeRequest('POST', validConfig), { params });
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.id).toBe('draft-1');
+        expect(body.updatedAt).toBeDefined();
+        expect(mockSaveDraft).toHaveBeenCalledWith(fakeUser.id, templateId, validConfig);
+    });
+
+    it('overwrites an existing draft (upsert)', async () => {
+        const updated = { ...fakeDraft, updatedAt: new Date('2026-03-24') };
+        mockSaveDraft.mockResolvedValue(updated);
+        const { POST } = await import('./route');
+        const res = await POST(makeRequest('POST', validConfig), { params });
+        expect(res.status).toBe(200);
+        // saveDraft called once — upsert is handled inside the service
+        expect(mockSaveDraft).toHaveBeenCalledOnce();
+    });
+});

--- a/apps/web/src/app/api/drafts/[templateId]/route.ts
+++ b/apps/web/src/app/api/drafts/[templateId]/route.ts
@@ -1,0 +1,72 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { withAuth } from '@/lib/api/with-auth';
+import { customizationDraftService } from '@/services/customization-draft.service';
+
+const customizationConfigSchema = z.object({
+    branding: z.object({
+        appName: z.string().min(1),
+        logoUrl: z.string().url().optional(),
+        primaryColor: z.string(),
+        secondaryColor: z.string(),
+        fontFamily: z.string(),
+    }),
+    features: z.object({
+        enableCharts: z.boolean(),
+        enableTransactionHistory: z.boolean(),
+        enableAnalytics: z.boolean(),
+        enableNotifications: z.boolean(),
+    }),
+    stellar: z.object({
+        network: z.enum(['mainnet', 'testnet']),
+        horizonUrl: z.string().url(),
+        sorobanRpcUrl: z.string().url().optional(),
+        assetPairs: z.array(z.any()).optional(),
+        contractAddresses: z.record(z.string()).optional(),
+    }),
+});
+
+type Params = { templateId: string };
+
+/**
+ * GET /api/drafts/[templateId]
+ * Returns the saved draft for the authenticated user and template, or 404.
+ */
+export const GET = withAuth<Params>(async (_req, { user, params }) => {
+    try {
+        const draft = await customizationDraftService.getDraft(user.id, params.templateId);
+        if (!draft) {
+            return NextResponse.json({ error: 'Draft not found' }, { status: 404 });
+        }
+        return NextResponse.json(draft);
+    } catch (error: any) {
+        return NextResponse.json({ error: error.message || 'Failed to get draft' }, { status: 500 });
+    }
+});
+
+/**
+ * POST /api/drafts/[templateId]
+ * Creates or overwrites the draft for the authenticated user and template.
+ * Returns the saved draft with id and updatedAt.
+ */
+export const POST = withAuth<Params>(async (req: NextRequest, { user, params }) => {
+    let body: unknown;
+    try {
+        body = await req.json();
+    } catch {
+        return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+    }
+
+    const parsed = customizationConfigSchema.safeParse(body);
+    if (!parsed.success) {
+        return NextResponse.json({ error: 'Invalid input', details: parsed.error.flatten() }, { status: 400 });
+    }
+
+    try {
+        const draft = await customizationDraftService.saveDraft(user.id, params.templateId, parsed.data);
+        return NextResponse.json(draft, { status: 200 });
+    } catch (error: any) {
+        const status = error.message === 'Template not found' ? 404 : 500;
+        return NextResponse.json({ error: error.message || 'Failed to save draft' }, { status });
+    }
+});

--- a/apps/web/src/services/customization-draft.service.ts
+++ b/apps/web/src/services/customization-draft.service.ts
@@ -1,0 +1,92 @@
+import { createClient } from '@/lib/supabase/server';
+import type { CustomizationConfig } from '@craft/types';
+
+export interface CustomizationDraft {
+    id: string;
+    userId: string;
+    templateId: string;
+    customizationConfig: CustomizationConfig;
+    createdAt: Date;
+    updatedAt: Date;
+}
+
+export class CustomizationDraftService {
+    /**
+     * Save (create or overwrite) a customization draft for a user+template pair.
+     * Only one draft per user per template is kept.
+     */
+    async saveDraft(
+        userId: string,
+        templateId: string,
+        config: CustomizationConfig
+    ): Promise<CustomizationDraft> {
+        const supabase = createClient();
+
+        // Verify the template exists and is active
+        const { data: template, error: templateError } = await supabase
+            .from('templates')
+            .select('id')
+            .eq('id', templateId)
+            .eq('is_active', true)
+            .single();
+
+        if (templateError || !template) {
+            throw new Error('Template not found');
+        }
+
+        const { data, error } = await supabase
+            .from('customization_drafts')
+            .upsert(
+                {
+                    user_id: userId,
+                    template_id: templateId,
+                    customization_config: config as any,
+                    updated_at: new Date().toISOString(),
+                },
+                { onConflict: 'user_id,template_id' }
+            )
+            .select()
+            .single();
+
+        if (error) {
+            throw new Error(`Failed to save draft: ${error.message}`);
+        }
+
+        return this.mapRow(data);
+    }
+
+    /**
+     * Get the saved draft for a user+template pair, or null if none exists.
+     */
+    async getDraft(
+        userId: string,
+        templateId: string
+    ): Promise<CustomizationDraft | null> {
+        const supabase = createClient();
+
+        const { data, error } = await supabase
+            .from('customization_drafts')
+            .select('*')
+            .eq('user_id', userId)
+            .eq('template_id', templateId)
+            .single();
+
+        if (error?.code === 'PGRST116') return null; // no rows
+        if (error) throw new Error(`Failed to get draft: ${error.message}`);
+
+        return data ? this.mapRow(data) : null;
+    }
+
+    private mapRow(row: any): CustomizationDraft {
+        return {
+            id: row.id,
+            userId: row.user_id,
+            templateId: row.template_id,
+            customizationConfig: row.customization_config as CustomizationConfig,
+            createdAt: new Date(row.created_at),
+            updatedAt: new Date(row.updated_at),
+        };
+    }
+}
+
+export const customizationDraftService = new CustomizationDraftService();


### PR DESCRIPTION
Closes #42

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

**What**
- CustomizationDraftService — saveDraft (upsert) and getDraft
- POST /api/drafts/[templateId] — create or overwrite draft
- GET /api/drafts/[templateId] — retrieve draft

**Notes**
- One draft per user per template enforced via upsert on (user_id, template_id)
- Requires UNIQUE(user_id, template_id) constraint on customization_drafts if not already in migrations
- 10 tests, all passing