### PR TITLE
Issue 045 implement file upload validation for branding as

### DIFF
--- a/apps/web/src/app/api/branding/upload/route.test.ts
+++ b/apps/web/src/app/api/branding/upload/route.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const mockGetUser = vi.fn();
+vi.mock('@/lib/supabase/server', () => ({
+    createClient: () => ({ auth: { getUser: mockGetUser }, from: vi.fn() }),
+}));
+
+const fakeUser = { id: 'user-1', email: 'a@b.com' };
+
+const PNG_MAGIC = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+function makeMultipartRequest(file: File | null) {
+    if (!file) {
+        // Send form without a file field
+        const form = new FormData();
+        return new NextRequest('http://localhost/api/branding/upload', { method: 'POST', body: form });
+    }
+    const form = new FormData();
+    form.append('file', file);
+    return new NextRequest('http://localhost/api/branding/upload', { method: 'POST', body: form });
+}
+
+describe('POST /api/branding/upload', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockGetUser.mockResolvedValue({ data: { user: fakeUser }, error: null });
+    });
+
+    it('returns 401 when unauthenticated', async () => {
+        mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+        const { POST } = await import('./route');
+        const res = await POST(makeMultipartRequest(null), { params: {} });
+        expect(res.status).toBe(401);
+    });
+
+    it('returns 400 when no file field is present', async () => {
+        const { POST } = await import('./route');
+        const res = await POST(makeMultipartRequest(null), { params: {} });
+        expect(res.status).toBe(400);
+        expect((await res.json()).error).toMatch(/file/i);
+    });
+
+    it('returns 422 for disallowed MIME type', async () => {
+        const { POST } = await import('./route');
+        const file = new File([new Uint8Array([0x47, 0x49, 0x46])], 'logo.gif', { type: 'image/gif' });
+        const res = await POST(makeMultipartRequest(file), { params: {} });
+        expect(res.status).toBe(422);
+        const body = await res.json();
+        expect(body.code).toBe('INVALID_MIME_TYPE');
+    });
+
+    it('returns 422 for file exceeding size limit', async () => {
+        const { POST } = await import('./route');
+        const big = new Uint8Array(2 * 1024 * 1024 + 1);
+        big.set(PNG_MAGIC);
+        const file = new File([big], 'logo.png', { type: 'image/png' });
+        const res = await POST(makeMultipartRequest(file), { params: {} });
+        expect(res.status).toBe(422);
+        expect((await res.json()).code).toBe('FILE_TOO_LARGE');
+    });
+
+    it('returns 200 for a valid PNG', async () => {
+        const { POST } = await import('./route');
+        const file = new File([PNG_MAGIC], 'logo.png', { type: 'image/png' });
+        const res = await POST(makeMultipartRequest(file), { params: {} });
+        expect(res.status).toBe(200);
+    });
+
+    it('returns 422 for unsafe SVG', async () => {
+        const { POST } = await import('./route');
+        const evil = new TextEncoder().encode('<svg><script>alert(1)</script></svg>');
+        const file = new File([evil], 'logo.svg', { type: 'image/svg+xml' });
+        const res = await POST(makeMultipartRequest(file), { params: {} });
+        expect(res.status).toBe(422);
+        expect((await res.json()).code).toBe('UNSAFE_SVG');
+    });
+});

--- a/apps/web/src/app/api/branding/upload/route.ts
+++ b/apps/web/src/app/api/branding/upload/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { withAuth } from '@/lib/api/with-auth';
+import { validateBrandingFile } from '@/lib/customization/validate-branding-file';
+
+/**
+ * POST /api/branding/upload
+ * Accepts a multipart/form-data upload with a single "file" field.
+ * Validates type, extension, size, and content safety before accepting.
+ *
+ * On success returns { url } — currently a placeholder; wire to your storage
+ * provider (e.g. Supabase Storage) in a follow-up.
+ */
+export const POST = withAuth(async (req: NextRequest) => {
+    let formData: FormData;
+    try {
+        formData = await req.formData();
+    } catch {
+        return NextResponse.json({ error: 'Expected multipart/form-data' }, { status: 400 });
+    }
+
+    const file = formData.get('file');
+    if (!(file instanceof File)) {
+        return NextResponse.json({ error: 'Missing "file" field' }, { status: 400 });
+    }
+
+    const buffer = new Uint8Array(await file.arrayBuffer());
+    const result = validateBrandingFile(file.name, file.type, file.size, buffer);
+
+    if (!result.valid) {
+        return NextResponse.json({ error: result.error, code: result.code }, { status: 422 });
+    }
+
+    // TODO: upload buffer to Supabase Storage / S3 and return the real URL
+    return NextResponse.json({ url: null, message: 'File validated successfully. Storage not yet wired.' }, { status: 200 });
+});

--- a/apps/web/src/app/api/customization/validate/route.test.ts
+++ b/apps/web/src/app/api/customization/validate/route.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const mockGetUser = vi.fn();
+vi.mock('@/lib/supabase/server', () => ({
+    createClient: () => ({ auth: { getUser: mockGetUser }, from: vi.fn() }),
+}));
+
+const fakeUser = { id: 'user-1', email: 'a@b.com' };
+
+const valid = {
+    branding: { appName: 'DEX', primaryColor: '#000', secondaryColor: '#fff', fontFamily: 'Inter' },
+    features: { enableCharts: true, enableTransactionHistory: false, enableAnalytics: false, enableNotifications: false },
+    stellar: { network: 'testnet', horizonUrl: 'https://horizon-testnet.stellar.org' },
+};
+
+const makeRequest = (body: unknown) =>
+    new NextRequest('http://localhost/api/customization/validate', {
+        method: 'POST',
+        body: JSON.stringify(body),
+        headers: { 'Content-Type': 'application/json' },
+    });
+
+describe('POST /api/customization/validate', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockGetUser.mockResolvedValue({ data: { user: fakeUser }, error: null });
+    });
+
+    it('returns 401 when unauthenticated', async () => {
+        mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+        const { POST } = await import('./route');
+        const res = await POST(makeRequest(valid), { params: {} });
+        expect(res.status).toBe(401);
+    });
+
+    it('returns 200 and valid:true for a correct config', async () => {
+        const { POST } = await import('./route');
+        const res = await POST(makeRequest(valid), { params: {} });
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.valid).toBe(true);
+        expect(body.errors).toEqual([]);
+    });
+
+    it('returns 422 and field errors for invalid config', async () => {
+        const { POST } = await import('./route');
+        const res = await POST(makeRequest({ ...valid, branding: { ...valid.branding, appName: '' } }), { params: {} });
+        expect(res.status).toBe(422);
+        const body = await res.json();
+        expect(body.valid).toBe(false);
+        expect(body.errors[0].field).toBe('branding.appName');
+    });
+
+    it('returns 422 for business rule violation', async () => {
+        const { POST } = await import('./route');
+        const res = await POST(makeRequest({
+            ...valid,
+            stellar: { network: 'mainnet', horizonUrl: 'https://horizon-testnet.stellar.org' },
+        }), { params: {} });
+        expect(res.status).toBe(422);
+        const body = await res.json();
+        expect(body.errors[0].code).toBe('HORIZON_NETWORK_MISMATCH');
+    });
+
+    it('returns 400 for invalid JSON', async () => {
+        const { POST } = await import('./route');
+        const req = new NextRequest('http://localhost/api/customization/validate', {
+            method: 'POST',
+            body: 'not-json',
+            headers: { 'Content-Type': 'application/json' },
+        });
+        const res = await POST(req, { params: {} });
+        expect(res.status).toBe(400);
+    });
+});

--- a/apps/web/src/app/api/customization/validate/route.ts
+++ b/apps/web/src/app/api/customization/validate/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { withAuth } from '@/lib/api/with-auth';
+import { validateCustomizationConfig } from '@/lib/customization/validate';
+
+/**
+ * POST /api/customization/validate
+ * Validates a customization config payload without persisting it.
+ * Returns { valid, errors } — stable contract for preview and deployment consumers.
+ */
+export const POST = withAuth(async (req: NextRequest) => {
+    let body: unknown;
+    try {
+        body = await req.json();
+    } catch {
+        return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+    }
+
+    const result = validateCustomizationConfig(body);
+    return NextResponse.json(result, { status: result.valid ? 200 : 422 });
+});

--- a/apps/web/src/app/api/drafts/[templateId]/route.test.ts
+++ b/apps/web/src/app/api/drafts/[templateId]/route.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+// ── Supabase mock ─────────────────────────────────────────────────────────────
+const mockGetUser = vi.fn();
+const mockFrom = vi.fn();
+
+vi.mock('@/lib/supabase/server', () => ({
+    createClient: () => ({
+        auth: { getUser: mockGetUser },
+        from: mockFrom,
+    }),
+}));
+
+// ── Service mock ──────────────────────────────────────────────────────────────
+const mockSaveDraft = vi.fn();
+const mockGetDraft = vi.fn();
+
+vi.mock('@/services/customization-draft.service', () => ({
+    customizationDraftService: {
+        saveDraft: mockSaveDraft,
+        getDraft: mockGetDraft,
+    },
+}));
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+const fakeUser = { id: 'user-1', email: 'a@b.com' };
+const templateId = 'tmpl-1';
+
+const validConfig = {
+    branding: {
+        appName: 'My DEX',
+        primaryColor: '#000',
+        secondaryColor: '#fff',
+        fontFamily: 'Inter',
+    },
+    features: {
+        enableCharts: true,
+        enableTransactionHistory: false,
+        enableAnalytics: true,
+        enableNotifications: false,
+    },
+    stellar: {
+        network: 'testnet' as const,
+        horizonUrl: 'https://horizon-testnet.stellar.org',
+    },
+};
+
+const fakeDraft = {
+    id: 'draft-1',
+    userId: fakeUser.id,
+    templateId,
+    customizationConfig: validConfig,
+    createdAt: new Date('2026-01-01'),
+    updatedAt: new Date('2026-01-02'),
+};
+
+const makeRequest = (method: string, body?: unknown) =>
+    new NextRequest(`http://localhost/api/drafts/${templateId}`, {
+        method,
+        ...(body !== undefined
+            ? { body: JSON.stringify(body), headers: { 'Content-Type': 'application/json' } }
+            : {}),
+    });
+
+const params = { templateId };
+
+// ── GET /api/drafts/[templateId] ──────────────────────────────────────────────
+describe('GET /api/drafts/[templateId]', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockGetUser.mockResolvedValue({ data: { user: fakeUser }, error: null });
+    });
+
+    it('returns 401 when unauthenticated', async () => {
+        mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+        const { GET } = await import('./route');
+        const res = await GET(makeRequest('GET'), { params });
+        expect(res.status).toBe(401);
+    });
+
+    it('returns 404 when no draft exists', async () => {
+        mockGetDraft.mockResolvedValue(null);
+        const { GET } = await import('./route');
+        const res = await GET(makeRequest('GET'), { params });
+        expect(res.status).toBe(404);
+    });
+
+    it('returns the draft when it exists', async () => {
+        mockGetDraft.mockResolvedValue(fakeDraft);
+        const { GET } = await import('./route');
+        const res = await GET(makeRequest('GET'), { params });
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.id).toBe('draft-1');
+        expect(body.templateId).toBe(templateId);
+    });
+
+    it('returns 500 on service error', async () => {
+        mockGetDraft.mockRejectedValue(new Error('DB error'));
+        const { GET } = await import('./route');
+        const res = await GET(makeRequest('GET'), { params });
+        expect(res.status).toBe(500);
+    });
+});
+
+// ── POST /api/drafts/[templateId] ─────────────────────────────────────────────
+describe('POST /api/drafts/[templateId]', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockGetUser.mockResolvedValue({ data: { user: fakeUser }, error: null });
+    });
+
+    it('returns 401 when unauthenticated', async () => {
+        mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+        const { POST } = await import('./route');
+        const res = await POST(makeRequest('POST', validConfig), { params });
+        expect(res.status).toBe(401);
+    });
+
+    it('returns 400 for invalid JSON', async () => {
+        const { POST } = await import('./route');
+        const req = new NextRequest(`http://localhost/api/drafts/${templateId}`, {
+            method: 'POST',
+            body: 'not-json',
+            headers: { 'Content-Type': 'application/json' },
+        });
+        const res = await POST(req, { params });
+        expect(res.status).toBe(400);
+    });
+
+    it('returns 400 for invalid config shape', async () => {
+        const { POST } = await import('./route');
+        const res = await POST(makeRequest('POST', { branding: {} }), { params });
+        expect(res.status).toBe(400);
+        const body = await res.json();
+        expect(body.details).toBeDefined();
+    });
+
+    it('returns 404 when template does not exist', async () => {
+        mockSaveDraft.mockRejectedValue(new Error('Template not found'));
+        const { POST } = await import('./route');
+        const res = await POST(makeRequest('POST', validConfig), { params });
+        expect(res.status).toBe(404);
+    });
+
+    it('saves and returns the draft on valid input', async () => {
+        mockSaveDraft.mockResolvedValue(fakeDraft);
+        const { POST } = await import('./route');
+        const res = await POST(makeRequest('POST', validConfig), { params });
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.id).toBe('draft-1');
+        expect(body.updatedAt).toBeDefined();
+        expect(mockSaveDraft).toHaveBeenCalledWith(fakeUser.id, templateId, validConfig);
+    });
+
+    it('overwrites an existing draft (upsert)', async () => {
+        const updated = { ...fakeDraft, updatedAt: new Date('2026-03-24') };
+        mockSaveDraft.mockResolvedValue(updated);
+        const { POST } = await import('./route');
+        const res = await POST(makeRequest('POST', validConfig), { params });
+        expect(res.status).toBe(200);
+        // saveDraft called once — upsert is handled inside the service
+        expect(mockSaveDraft).toHaveBeenCalledOnce();
+    });
+});

--- a/apps/web/src/app/api/drafts/[templateId]/route.ts
+++ b/apps/web/src/app/api/drafts/[templateId]/route.ts
@@ -1,30 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { z } from 'zod';
 import { withAuth } from '@/lib/api/with-auth';
 import { customizationDraftService } from '@/services/customization-draft.service';
-
-const customizationConfigSchema = z.object({
-    branding: z.object({
-        appName: z.string().min(1),
-        logoUrl: z.string().url().optional(),
-        primaryColor: z.string(),
-        secondaryColor: z.string(),
-        fontFamily: z.string(),
-    }),
-    features: z.object({
-        enableCharts: z.boolean(),
-        enableTransactionHistory: z.boolean(),
-        enableAnalytics: z.boolean(),
-        enableNotifications: z.boolean(),
-    }),
-    stellar: z.object({
-        network: z.enum(['mainnet', 'testnet']),
-        horizonUrl: z.string().url(),
-        sorobanRpcUrl: z.string().url().optional(),
-        assetPairs: z.array(z.any()).optional(),
-        contractAddresses: z.record(z.string()).optional(),
-    }),
-});
+import { validateCustomizationConfig, customizationConfigSchema } from '@/lib/customization/validate';
 
 type Params = { templateId: string };
 
@@ -57,13 +34,16 @@ export const POST = withAuth<Params>(async (req: NextRequest, { user, params }) 
         return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
     }
 
-    const parsed = customizationConfigSchema.safeParse(body);
-    if (!parsed.success) {
-        return NextResponse.json({ error: 'Invalid input', details: parsed.error.flatten() }, { status: 400 });
+    const validation = validateCustomizationConfig(body);
+    if (!validation.valid) {
+        return NextResponse.json({ error: 'Invalid input', details: validation.errors }, { status: 400 });
     }
 
+    // Schema parse is safe here — validateCustomizationConfig already confirmed shape
+    const config = customizationConfigSchema.parse(body);
+
     try {
-        const draft = await customizationDraftService.saveDraft(user.id, params.templateId, parsed.data);
+        const draft = await customizationDraftService.saveDraft(user.id, params.templateId, config);
         return NextResponse.json(draft, { status: 200 });
     } catch (error: any) {
         const status = error.message === 'Template not found' ? 404 : 500;

--- a/apps/web/src/app/api/drafts/[templateId]/route.ts
+++ b/apps/web/src/app/api/drafts/[templateId]/route.ts
@@ -1,0 +1,72 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { withAuth } from '@/lib/api/with-auth';
+import { customizationDraftService } from '@/services/customization-draft.service';
+
+const customizationConfigSchema = z.object({
+    branding: z.object({
+        appName: z.string().min(1),
+        logoUrl: z.string().url().optional(),
+        primaryColor: z.string(),
+        secondaryColor: z.string(),
+        fontFamily: z.string(),
+    }),
+    features: z.object({
+        enableCharts: z.boolean(),
+        enableTransactionHistory: z.boolean(),
+        enableAnalytics: z.boolean(),
+        enableNotifications: z.boolean(),
+    }),
+    stellar: z.object({
+        network: z.enum(['mainnet', 'testnet']),
+        horizonUrl: z.string().url(),
+        sorobanRpcUrl: z.string().url().optional(),
+        assetPairs: z.array(z.any()).optional(),
+        contractAddresses: z.record(z.string()).optional(),
+    }),
+});
+
+type Params = { templateId: string };
+
+/**
+ * GET /api/drafts/[templateId]
+ * Returns the saved draft for the authenticated user and template, or 404.
+ */
+export const GET = withAuth<Params>(async (_req, { user, params }) => {
+    try {
+        const draft = await customizationDraftService.getDraft(user.id, params.templateId);
+        if (!draft) {
+            return NextResponse.json({ error: 'Draft not found' }, { status: 404 });
+        }
+        return NextResponse.json(draft);
+    } catch (error: any) {
+        return NextResponse.json({ error: error.message || 'Failed to get draft' }, { status: 500 });
+    }
+});
+
+/**
+ * POST /api/drafts/[templateId]
+ * Creates or overwrites the draft for the authenticated user and template.
+ * Returns the saved draft with id and updatedAt.
+ */
+export const POST = withAuth<Params>(async (req: NextRequest, { user, params }) => {
+    let body: unknown;
+    try {
+        body = await req.json();
+    } catch {
+        return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+    }
+
+    const parsed = customizationConfigSchema.safeParse(body);
+    if (!parsed.success) {
+        return NextResponse.json({ error: 'Invalid input', details: parsed.error.flatten() }, { status: 400 });
+    }
+
+    try {
+        const draft = await customizationDraftService.saveDraft(user.id, params.templateId, parsed.data);
+        return NextResponse.json(draft, { status: 200 });
+    } catch (error: any) {
+        const status = error.message === 'Template not found' ? 404 : 500;
+        return NextResponse.json({ error: error.message || 'Failed to save draft' }, { status });
+    }
+});

--- a/apps/web/src/app/api/drafts/deployment/[deploymentId]/route.test.ts
+++ b/apps/web/src/app/api/drafts/deployment/[deploymentId]/route.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const mockGetUser = vi.fn();
+vi.mock('@/lib/supabase/server', () => ({
+    createClient: () => ({ auth: { getUser: mockGetUser }, from: vi.fn() }),
+}));
+
+const mockGetDraftByDeployment = vi.fn();
+vi.mock('@/services/customization-draft.service', () => ({
+    customizationDraftService: { getDraftByDeployment: mockGetDraftByDeployment },
+}));
+
+const fakeUser = { id: 'user-1', email: 'a@b.com' };
+const deploymentId = 'dep-1';
+
+const fakeDraft = {
+    id: 'draft-1',
+    userId: fakeUser.id,
+    templateId: 'tmpl-1',
+    customizationConfig: {
+        branding: { appName: 'DEX', primaryColor: '#f00', secondaryColor: '#0f0', fontFamily: 'Inter' },
+        features: { enableCharts: true, enableTransactionHistory: true, enableAnalytics: false, enableNotifications: false },
+        stellar: { network: 'testnet', horizonUrl: 'https://horizon-testnet.stellar.org' },
+    },
+    createdAt: new Date('2026-01-01'),
+    updatedAt: new Date('2026-01-02'),
+};
+
+const makeRequest = () =>
+    new NextRequest(`http://localhost/api/drafts/deployment/${deploymentId}`);
+
+const params = { deploymentId };
+
+describe('GET /api/drafts/deployment/[deploymentId]', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockGetUser.mockResolvedValue({ data: { user: fakeUser }, error: null });
+    });
+
+    it('returns 401 when unauthenticated', async () => {
+        mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+        const { GET } = await import('./route');
+        const res = await GET(makeRequest(), { params });
+        expect(res.status).toBe(401);
+    });
+
+    it('returns 404 when no draft exists', async () => {
+        mockGetDraftByDeployment.mockResolvedValue(null);
+        const { GET } = await import('./route');
+        const res = await GET(makeRequest(), { params });
+        expect(res.status).toBe(404);
+    });
+
+    it('returns 403 when deployment belongs to another user', async () => {
+        mockGetDraftByDeployment.mockRejectedValue(new Error('Forbidden'));
+        const { GET } = await import('./route');
+        const res = await GET(makeRequest(), { params });
+        expect(res.status).toBe(403);
+    });
+
+    it('returns the normalized draft on success', async () => {
+        mockGetDraftByDeployment.mockResolvedValue(fakeDraft);
+        const { GET } = await import('./route');
+        const res = await GET(makeRequest(), { params });
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.id).toBe('draft-1');
+        expect(body.customizationConfig.branding.appName).toBe('DEX');
+        expect(mockGetDraftByDeployment).toHaveBeenCalledWith(fakeUser.id, deploymentId);
+    });
+
+    it('returns 500 on unexpected service error', async () => {
+        mockGetDraftByDeployment.mockRejectedValue(new Error('DB error'));
+        const { GET } = await import('./route');
+        const res = await GET(makeRequest(), { params });
+        expect(res.status).toBe(500);
+    });
+});

--- a/apps/web/src/app/api/drafts/deployment/[deploymentId]/route.ts
+++ b/apps/web/src/app/api/drafts/deployment/[deploymentId]/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from 'next/server';
+import { withAuth } from '@/lib/api/with-auth';
+import { customizationDraftService } from '@/services/customization-draft.service';
+
+type Params = { deploymentId: string };
+
+/**
+ * GET /api/drafts/deployment/[deploymentId]
+ * Loads the customization draft for the deployment's template.
+ * Returns 404 if no draft exists, 403 if the deployment belongs to another user.
+ */
+export const GET = withAuth<Params>(async (_req, { user, params }) => {
+    try {
+        const draft = await customizationDraftService.getDraftByDeployment(
+            user.id,
+            params.deploymentId
+        );
+        if (!draft) {
+            return NextResponse.json({ error: 'Draft not found' }, { status: 404 });
+        }
+        return NextResponse.json(draft);
+    } catch (error: any) {
+        const status = error.message === 'Forbidden' ? 403 : 500;
+        return NextResponse.json({ error: error.message || 'Failed to load draft' }, { status });
+    }
+});

--- a/apps/web/src/lib/customization/validate-branding-file.test.ts
+++ b/apps/web/src/lib/customization/validate-branding-file.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest';
+import { validateBrandingFile } from './validate-branding-file';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const PNG_MAGIC = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+const JPEG_MAGIC = new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]);
+const WEBP_MAGIC = new Uint8Array([0x52, 0x49, 0x46, 0x46, 0x00, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50]);
+const SVG_CONTENT = new TextEncoder().encode('<svg xmlns="http://www.w3.org/2000/svg"><rect/></svg>');
+const EVIL_SVG = new TextEncoder().encode('<svg><script>alert(1)</script></svg>');
+const EVENT_SVG = new TextEncoder().encode('<svg onload="evil()"><rect/></svg>');
+const GARBAGE = new Uint8Array([0x00, 0x01, 0x02, 0x03]);
+
+const KB = 1024;
+const MB = 1024 * KB;
+
+// ── MIME type ─────────────────────────────────────────────────────────────────
+
+describe('validateBrandingFile — MIME type', () => {
+    it('accepts image/png', () => {
+        expect(validateBrandingFile('logo.png', 'image/png', 1 * KB, PNG_MAGIC).valid).toBe(true);
+    });
+
+    it('accepts image/jpeg', () => {
+        expect(validateBrandingFile('logo.jpg', 'image/jpeg', 1 * KB, JPEG_MAGIC).valid).toBe(true);
+    });
+
+    it('accepts image/webp', () => {
+        expect(validateBrandingFile('logo.webp', 'image/webp', 1 * KB, WEBP_MAGIC).valid).toBe(true);
+    });
+
+    it('accepts image/svg+xml', () => {
+        expect(validateBrandingFile('logo.svg', 'image/svg+xml', SVG_CONTENT.length, SVG_CONTENT).valid).toBe(true);
+    });
+
+    it('rejects image/gif', () => {
+        const r = validateBrandingFile('logo.gif', 'image/gif', 1 * KB, GARBAGE);
+        expect(r.valid).toBe(false);
+        expect(r.code).toBe('INVALID_MIME_TYPE');
+    });
+
+    it('rejects application/pdf', () => {
+        const r = validateBrandingFile('logo.pdf', 'application/pdf', 1 * KB, GARBAGE);
+        expect(r.valid).toBe(false);
+        expect(r.code).toBe('INVALID_MIME_TYPE');
+    });
+});
+
+// ── Extension ─────────────────────────────────────────────────────────────────
+
+describe('validateBrandingFile — extension', () => {
+    it('rejects .exe extension', () => {
+        const r = validateBrandingFile('logo.exe', 'image/png', 1 * KB, PNG_MAGIC);
+        expect(r.valid).toBe(false);
+        expect(r.code).toBe('INVALID_EXTENSION');
+    });
+
+    it('rejects MIME/extension mismatch (png file named .webp)', () => {
+        const r = validateBrandingFile('logo.webp', 'image/png', 1 * KB, PNG_MAGIC);
+        expect(r.valid).toBe(false);
+        expect(r.code).toBe('MIME_EXTENSION_MISMATCH');
+    });
+
+    it('accepts .jpeg extension for image/jpeg', () => {
+        expect(validateBrandingFile('logo.jpeg', 'image/jpeg', 1 * KB, JPEG_MAGIC).valid).toBe(true);
+    });
+});
+
+// ── Size ──────────────────────────────────────────────────────────────────────
+
+describe('validateBrandingFile — size', () => {
+    it('rejects files over 2 MB', () => {
+        const r = validateBrandingFile('logo.png', 'image/png', 2 * MB + 1, PNG_MAGIC);
+        expect(r.valid).toBe(false);
+        expect(r.code).toBe('FILE_TOO_LARGE');
+    });
+
+    it('accepts files exactly at 2 MB', () => {
+        expect(validateBrandingFile('logo.png', 'image/png', 2 * MB, PNG_MAGIC).valid).toBe(true);
+    });
+});
+
+// ── Magic bytes / content safety ──────────────────────────────────────────────
+
+describe('validateBrandingFile — magic bytes', () => {
+    it('rejects PNG with wrong magic bytes', () => {
+        const r = validateBrandingFile('logo.png', 'image/png', 1 * KB, GARBAGE);
+        expect(r.valid).toBe(false);
+        expect(r.code).toBe('MAGIC_BYTES_MISMATCH');
+    });
+
+    it('rejects JPEG with wrong magic bytes', () => {
+        const r = validateBrandingFile('logo.jpg', 'image/jpeg', 1 * KB, GARBAGE);
+        expect(r.valid).toBe(false);
+        expect(r.code).toBe('MAGIC_BYTES_MISMATCH');
+    });
+});
+
+describe('validateBrandingFile — SVG safety', () => {
+    it('rejects SVG with <script> tag', () => {
+        const r = validateBrandingFile('logo.svg', 'image/svg+xml', EVIL_SVG.length, EVIL_SVG);
+        expect(r.valid).toBe(false);
+        expect(r.code).toBe('UNSAFE_SVG');
+    });
+
+    it('rejects SVG with inline event handler', () => {
+        const r = validateBrandingFile('logo.svg', 'image/svg+xml', EVENT_SVG.length, EVENT_SVG);
+        expect(r.valid).toBe(false);
+        expect(r.code).toBe('UNSAFE_SVG');
+    });
+
+    it('rejects non-SVG content declared as SVG', () => {
+        const r = validateBrandingFile('logo.svg', 'image/svg+xml', GARBAGE.length, GARBAGE);
+        expect(r.valid).toBe(false);
+        expect(r.code).toBe('UNSAFE_SVG');
+    });
+});

--- a/apps/web/src/lib/customization/validate-branding-file.ts
+++ b/apps/web/src/lib/customization/validate-branding-file.ts
@@ -1,0 +1,79 @@
+export interface BrandingFileValidationResult {
+    valid: boolean;
+    error?: string;
+    code?: string;
+}
+
+const ALLOWED_MIME_TYPES = new Set(['image/png', 'image/jpeg', 'image/svg+xml', 'image/webp']);
+const ALLOWED_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.svg', '.webp']);
+const MAX_BYTES = 2 * 1024 * 1024; // 2 MB
+
+// Magic bytes for allowed binary formats (SVG is text, checked separately)
+const MAGIC: Array<{ mime: string; bytes: number[] }> = [
+    { mime: 'image/png',  bytes: [0x89, 0x50, 0x4e, 0x47] },
+    { mime: 'image/jpeg', bytes: [0xff, 0xd8, 0xff] },
+    { mime: 'image/webp', bytes: [0x52, 0x49, 0x46, 0x46] }, // RIFF header
+];
+
+function matchesMagic(buf: Uint8Array, magic: number[]): boolean {
+    return magic.every((b, i) => buf[i] === b);
+}
+
+function isSvgContent(buf: Uint8Array): boolean {
+    const text = new TextDecoder().decode(buf.slice(0, 512));
+    // Must contain <svg and must NOT contain script tags or JS event handlers
+    return /<svg[\s>]/i.test(text) && !/<script/i.test(text) && !/\bon\w+\s*=/i.test(text);
+}
+
+/**
+ * Validate a branding file (logo) before storage or preview use.
+ * Checks MIME type, file extension, size, and magic bytes / content safety.
+ */
+export function validateBrandingFile(
+    filename: string,
+    mimeType: string,
+    sizeBytes: number,
+    buffer: Uint8Array
+): BrandingFileValidationResult {
+    // 1. MIME type allowlist
+    if (!ALLOWED_MIME_TYPES.has(mimeType)) {
+        return { valid: false, error: `File type "${mimeType}" is not allowed. Use PNG, JPEG, WebP, or SVG.`, code: 'INVALID_MIME_TYPE' };
+    }
+
+    // 2. Extension allowlist
+    const ext = ('.' + filename.split('.').pop()!.toLowerCase());
+    if (!ALLOWED_EXTENSIONS.has(ext)) {
+        return { valid: false, error: `File extension "${ext}" is not allowed.`, code: 'INVALID_EXTENSION' };
+    }
+
+    // 3. MIME / extension consistency (prevent .jpg with image/png header tricks)
+    const jpegExts = new Set(['.jpg', '.jpeg']);
+    if (mimeType === 'image/jpeg' && !jpegExts.has(ext)) {
+        return { valid: false, error: 'File extension does not match MIME type.', code: 'MIME_EXTENSION_MISMATCH' };
+    }
+    if (mimeType !== 'image/jpeg' && mimeType !== 'image/svg+xml') {
+        const expectedExt = '.' + mimeType.split('/')[1];
+        if (ext !== expectedExt) {
+            return { valid: false, error: 'File extension does not match MIME type.', code: 'MIME_EXTENSION_MISMATCH' };
+        }
+    }
+
+    // 4. Size limit
+    if (sizeBytes > MAX_BYTES) {
+        return { valid: false, error: `File exceeds the 2 MB size limit (${(sizeBytes / 1024 / 1024).toFixed(2)} MB).`, code: 'FILE_TOO_LARGE' };
+    }
+
+    // 5. Magic bytes / content safety
+    if (mimeType === 'image/svg+xml') {
+        if (!isSvgContent(buffer)) {
+            return { valid: false, error: 'SVG file is invalid or contains unsafe content (script/event handlers).', code: 'UNSAFE_SVG' };
+        }
+    } else {
+        const match = MAGIC.find((m) => m.mime === mimeType);
+        if (match && !matchesMagic(buffer, match.bytes)) {
+            return { valid: false, error: 'File content does not match the declared file type.', code: 'MAGIC_BYTES_MISMATCH' };
+        }
+    }
+
+    return { valid: true };
+}

--- a/apps/web/src/lib/customization/validate.test.ts
+++ b/apps/web/src/lib/customization/validate.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest';
+import { validateCustomizationConfig } from './validate';
+
+const valid = {
+    branding: {
+        appName: 'My DEX',
+        primaryColor: '#6366f1',
+        secondaryColor: '#a5b4fc',
+        fontFamily: 'Inter',
+    },
+    features: {
+        enableCharts: true,
+        enableTransactionHistory: false,
+        enableAnalytics: false,
+        enableNotifications: false,
+    },
+    stellar: {
+        network: 'testnet' as const,
+        horizonUrl: 'https://horizon-testnet.stellar.org',
+    },
+};
+
+describe('validateCustomizationConfig', () => {
+    it('returns valid for a correct config', () => {
+        expect(validateCustomizationConfig(valid)).toEqual({ valid: true, errors: [] });
+    });
+
+    // ── Schema errors ──────────────────────────────────────────────────────────
+
+    it('returns error when appName is empty', () => {
+        const result = validateCustomizationConfig({ ...valid, branding: { ...valid.branding, appName: '' } });
+        expect(result.valid).toBe(false);
+        expect(result.errors[0].field).toBe('branding.appName');
+        expect(result.errors[0].code).toBeDefined();
+    });
+
+    it('returns error when appName exceeds 60 chars', () => {
+        const result = validateCustomizationConfig({ ...valid, branding: { ...valid.branding, appName: 'a'.repeat(61) } });
+        expect(result.valid).toBe(false);
+        expect(result.errors[0].field).toBe('branding.appName');
+    });
+
+    it('returns error for invalid hex color', () => {
+        const result = validateCustomizationConfig({ ...valid, branding: { ...valid.branding, primaryColor: 'red' } });
+        expect(result.valid).toBe(false);
+        expect(result.errors[0].field).toBe('branding.primaryColor');
+        expect(result.errors[0].code).toBe('INVALID_STRING');
+    });
+
+    it('returns error for invalid logoUrl', () => {
+        const result = validateCustomizationConfig({ ...valid, branding: { ...valid.branding, logoUrl: 'not-a-url' } });
+        expect(result.valid).toBe(false);
+        expect(result.errors[0].field).toBe('branding.logoUrl');
+    });
+
+    it('returns error for invalid network value', () => {
+        const result = validateCustomizationConfig({ ...valid, stellar: { ...valid.stellar, network: 'devnet' as any } });
+        expect(result.valid).toBe(false);
+        expect(result.errors[0].field).toBe('stellar.network');
+    });
+
+    it('returns error for invalid horizonUrl', () => {
+        const result = validateCustomizationConfig({ ...valid, stellar: { ...valid.stellar, horizonUrl: 'not-a-url' } });
+        expect(result.valid).toBe(false);
+        expect(result.errors[0].field).toBe('stellar.horizonUrl');
+    });
+
+    it('returns error for invalid sorobanRpcUrl', () => {
+        const result = validateCustomizationConfig({ ...valid, stellar: { ...valid.stellar, sorobanRpcUrl: 'bad' } });
+        expect(result.valid).toBe(false);
+        expect(result.errors[0].field).toBe('stellar.sorobanRpcUrl');
+    });
+
+    it('handles null input', () => {
+        const result = validateCustomizationConfig(null);
+        expect(result.valid).toBe(false);
+        expect(result.errors.length).toBeGreaterThan(0);
+    });
+
+    // ── Business rule errors ───────────────────────────────────────────────────
+
+    it('returns HORIZON_NETWORK_MISMATCH when mainnet + testnet URL', () => {
+        const result = validateCustomizationConfig({
+            ...valid,
+            stellar: { network: 'mainnet', horizonUrl: 'https://horizon-testnet.stellar.org' },
+        });
+        expect(result.valid).toBe(false);
+        expect(result.errors[0].code).toBe('HORIZON_NETWORK_MISMATCH');
+        expect(result.errors[0].field).toBe('stellar.horizonUrl');
+    });
+
+    it('returns HORIZON_NETWORK_MISMATCH when testnet + mainnet URL', () => {
+        const result = validateCustomizationConfig({
+            ...valid,
+            stellar: { network: 'testnet', horizonUrl: 'https://horizon.stellar.org' },
+        });
+        expect(result.valid).toBe(false);
+        expect(result.errors[0].code).toBe('HORIZON_NETWORK_MISMATCH');
+    });
+
+    it('returns DUPLICATE_COLORS when primary === secondary', () => {
+        const result = validateCustomizationConfig({
+            ...valid,
+            branding: { ...valid.branding, primaryColor: '#abc', secondaryColor: '#abc' },
+        });
+        expect(result.valid).toBe(false);
+        expect(result.errors[0].code).toBe('DUPLICATE_COLORS');
+        expect(result.errors[0].field).toBe('branding.secondaryColor');
+    });
+
+    it('accepts valid mainnet config', () => {
+        const result = validateCustomizationConfig({
+            ...valid,
+            stellar: { network: 'mainnet', horizonUrl: 'https://horizon.stellar.org' },
+        });
+        expect(result.valid).toBe(true);
+    });
+});

--- a/apps/web/src/lib/customization/validate.ts
+++ b/apps/web/src/lib/customization/validate.ts
@@ -1,0 +1,92 @@
+import { z } from 'zod';
+import type { CustomizationConfig, ValidationResult, ValidationError } from '@craft/types';
+
+// ── Zod schema (single source of truth) ──────────────────────────────────────
+
+const HEX_COLOR = /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/;
+
+export const customizationConfigSchema = z.object({
+    branding: z.object({
+        appName: z.string().min(1, 'App name is required').max(60, 'App name must be 60 characters or fewer'),
+        logoUrl: z.string().url('Logo URL must be a valid URL').optional(),
+        primaryColor: z.string().regex(HEX_COLOR, 'Primary color must be a valid hex color'),
+        secondaryColor: z.string().regex(HEX_COLOR, 'Secondary color must be a valid hex color'),
+        fontFamily: z.string().min(1, 'Font family is required'),
+    }),
+    features: z.object({
+        enableCharts: z.boolean(),
+        enableTransactionHistory: z.boolean(),
+        enableAnalytics: z.boolean(),
+        enableNotifications: z.boolean(),
+    }),
+    stellar: z.object({
+        network: z.enum(['mainnet', 'testnet']),
+        horizonUrl: z.string().url('Horizon URL must be a valid URL'),
+        sorobanRpcUrl: z.string().url('Soroban RPC URL must be a valid URL').optional(),
+        assetPairs: z.array(z.any()).optional(),
+        contractAddresses: z.record(z.string()).optional(),
+    }),
+});
+
+// ── Business rules ────────────────────────────────────────────────────────────
+
+const MAINNET_HORIZON = 'https://horizon.stellar.org';
+const TESTNET_HORIZON = 'https://horizon-testnet.stellar.org';
+
+function businessRuleErrors(config: CustomizationConfig): ValidationError[] {
+    const errors: ValidationError[] = [];
+    const { network, horizonUrl } = config.stellar;
+
+    if (network === 'mainnet' && horizonUrl === TESTNET_HORIZON) {
+        errors.push({
+            field: 'stellar.horizonUrl',
+            message: 'Horizon URL points to testnet but network is set to mainnet',
+            code: 'HORIZON_NETWORK_MISMATCH',
+        });
+    }
+
+    if (network === 'testnet' && horizonUrl === MAINNET_HORIZON) {
+        errors.push({
+            field: 'stellar.horizonUrl',
+            message: 'Horizon URL points to mainnet but network is set to testnet',
+            code: 'HORIZON_NETWORK_MISMATCH',
+        });
+    }
+
+    if (config.branding.primaryColor === config.branding.secondaryColor) {
+        errors.push({
+            field: 'branding.secondaryColor',
+            message: 'Secondary color must differ from primary color',
+            code: 'DUPLICATE_COLORS',
+        });
+    }
+
+    return errors;
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/**
+ * Validate a customization config payload.
+ * Returns a stable ValidationResult with field-level errors.
+ * Safe to call from both API routes and internal services.
+ */
+export function validateCustomizationConfig(input: unknown): ValidationResult {
+    const parsed = customizationConfigSchema.safeParse(input);
+
+    if (!parsed.success) {
+        const errors: ValidationError[] = parsed.error.errors.map((e) => ({
+            field: e.path.join('.'),
+            message: e.message,
+            code: e.code.toUpperCase(),
+        }));
+        return { valid: false, errors };
+    }
+
+    const businessErrors = businessRuleErrors(parsed.data);
+    if (businessErrors.length > 0) {
+        return { valid: false, errors: businessErrors };
+    }
+
+    return { valid: true, errors: [] };
+}

--- a/apps/web/src/services/customization-draft.service.test.ts
+++ b/apps/web/src/services/customization-draft.service.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeDraftConfig } from './customization-draft.service';
+
+const full = {
+    branding: { appName: 'DEX', primaryColor: '#f00', secondaryColor: '#0f0', fontFamily: 'Mono' },
+    features: { enableCharts: false, enableTransactionHistory: false, enableAnalytics: true, enableNotifications: true },
+    stellar: { network: 'mainnet', horizonUrl: 'https://horizon.stellar.org' },
+};
+
+describe('normalizeDraftConfig', () => {
+    it('returns full config unchanged', () => {
+        const result = normalizeDraftConfig(full);
+        expect(result.branding.appName).toBe('DEX');
+        expect(result.stellar.network).toBe('mainnet');
+    });
+
+    it('fills missing branding fields with defaults', () => {
+        const result = normalizeDraftConfig({ branding: { appName: 'X' }, features: full.features, stellar: full.stellar });
+        expect(result.branding.primaryColor).toBe('#6366f1');
+        expect(result.branding.appName).toBe('X');
+    });
+
+    it('fills missing features with defaults', () => {
+        const result = normalizeDraftConfig({ branding: full.branding, stellar: full.stellar });
+        expect(result.features.enableCharts).toBe(true);
+    });
+
+    it('fills missing stellar with defaults', () => {
+        const result = normalizeDraftConfig({ branding: full.branding, features: full.features });
+        expect(result.stellar.network).toBe('testnet');
+        expect(result.stellar.horizonUrl).toBe('https://horizon-testnet.stellar.org');
+    });
+
+    it('handles null/undefined input gracefully', () => {
+        const result = normalizeDraftConfig(null);
+        expect(result.branding.fontFamily).toBe('Inter');
+        expect(result.features.enableCharts).toBe(true);
+    });
+
+    it('handles completely empty object', () => {
+        const result = normalizeDraftConfig({});
+        expect(result.stellar.network).toBe('testnet');
+    });
+});

--- a/apps/web/src/services/customization-draft.service.ts
+++ b/apps/web/src/services/customization-draft.service.ts
@@ -1,6 +1,38 @@
 import { createClient } from '@/lib/supabase/server';
 import type { CustomizationConfig } from '@craft/types';
 
+const DEFAULT_CONFIG: CustomizationConfig = {
+    branding: {
+        appName: '',
+        primaryColor: '#6366f1',
+        secondaryColor: '#a5b4fc',
+        fontFamily: 'Inter',
+    },
+    features: {
+        enableCharts: true,
+        enableTransactionHistory: true,
+        enableAnalytics: false,
+        enableNotifications: false,
+    },
+    stellar: {
+        network: 'testnet',
+        horizonUrl: 'https://horizon-testnet.stellar.org',
+    },
+};
+
+/**
+ * Deep-merge persisted JSONB with defaults so partial/stale drafts are always
+ * safe to hand to the UI without crashing on missing fields.
+ */
+export function normalizeDraftConfig(raw: unknown): CustomizationConfig {
+    const src = (raw && typeof raw === 'object' ? raw : {}) as Record<string, any>;
+    return {
+        branding: { ...DEFAULT_CONFIG.branding, ...(src.branding ?? {}) },
+        features: { ...DEFAULT_CONFIG.features, ...(src.features ?? {}) },
+        stellar: { ...DEFAULT_CONFIG.stellar, ...(src.stellar ?? {}) },
+    };
+}
+
 export interface CustomizationDraft {
     id: string;
     userId: string;
@@ -77,12 +109,35 @@ export class CustomizationDraftService {
         return data ? this.mapRow(data) : null;
     }
 
+    /**
+     * Load a draft via deployment context — resolves the template from the
+     * deployment, then delegates to getDraft. Returns null if no draft exists.
+     */
+    async getDraftByDeployment(
+        userId: string,
+        deploymentId: string
+    ): Promise<CustomizationDraft | null> {
+        const supabase = createClient();
+
+        const { data: deployment, error } = await supabase
+            .from('deployments')
+            .select('template_id, user_id')
+            .eq('id', deploymentId)
+            .single();
+
+        if (error?.code === 'PGRST116' || !deployment) return null;
+        if (error) throw new Error(`Failed to load deployment: ${error.message}`);
+        if (deployment.user_id !== userId) throw new Error('Forbidden');
+
+        return this.getDraft(userId, deployment.template_id);
+    }
+
     private mapRow(row: any): CustomizationDraft {
         return {
             id: row.id,
             userId: row.user_id,
             templateId: row.template_id,
-            customizationConfig: row.customization_config as CustomizationConfig,
+            customizationConfig: normalizeDraftConfig(row.customization_config),
             createdAt: new Date(row.created_at),
             updatedAt: new Date(row.updated_at),
         };

--- a/apps/web/src/services/customization-draft.service.ts
+++ b/apps/web/src/services/customization-draft.service.ts
@@ -1,0 +1,92 @@
+import { createClient } from '@/lib/supabase/server';
+import type { CustomizationConfig } from '@craft/types';
+
+export interface CustomizationDraft {
+    id: string;
+    userId: string;
+    templateId: string;
+    customizationConfig: CustomizationConfig;
+    createdAt: Date;
+    updatedAt: Date;
+}
+
+export class CustomizationDraftService {
+    /**
+     * Save (create or overwrite) a customization draft for a user+template pair.
+     * Only one draft per user per template is kept.
+     */
+    async saveDraft(
+        userId: string,
+        templateId: string,
+        config: CustomizationConfig
+    ): Promise<CustomizationDraft> {
+        const supabase = createClient();
+
+        // Verify the template exists and is active
+        const { data: template, error: templateError } = await supabase
+            .from('templates')
+            .select('id')
+            .eq('id', templateId)
+            .eq('is_active', true)
+            .single();
+
+        if (templateError || !template) {
+            throw new Error('Template not found');
+        }
+
+        const { data, error } = await supabase
+            .from('customization_drafts')
+            .upsert(
+                {
+                    user_id: userId,
+                    template_id: templateId,
+                    customization_config: config as any,
+                    updated_at: new Date().toISOString(),
+                },
+                { onConflict: 'user_id,template_id' }
+            )
+            .select()
+            .single();
+
+        if (error) {
+            throw new Error(`Failed to save draft: ${error.message}`);
+        }
+
+        return this.mapRow(data);
+    }
+
+    /**
+     * Get the saved draft for a user+template pair, or null if none exists.
+     */
+    async getDraft(
+        userId: string,
+        templateId: string
+    ): Promise<CustomizationDraft | null> {
+        const supabase = createClient();
+
+        const { data, error } = await supabase
+            .from('customization_drafts')
+            .select('*')
+            .eq('user_id', userId)
+            .eq('template_id', templateId)
+            .single();
+
+        if (error?.code === 'PGRST116') return null; // no rows
+        if (error) throw new Error(`Failed to get draft: ${error.message}`);
+
+        return data ? this.mapRow(data) : null;
+    }
+
+    private mapRow(row: any): CustomizationDraft {
+        return {
+            id: row.id,
+            userId: row.user_id,
+            templateId: row.template_id,
+            customizationConfig: row.customization_config as CustomizationConfig,
+            createdAt: new Date(row.created_at),
+            updatedAt: new Date(row.updated_at),
+        };
+    }
+}
+
+export const customizationDraftService = new CustomizationDraftService();


### PR DESCRIPTION
Closes #45

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

What
- validateBrandingFile — MIME allowlist, extension allowlist, 2 MB size cap, magic bytes check, SVG script/event-handler rejection
- POST /api/branding/upload — validates file before storage (storage wiring is a follow-up TODO)

Notes
- SVG <script> and on*= event handlers → UNSAFE_SVG
- MIME/extension mismatch caught explicitly → MIME_EXTENSION_MISMATCH
- 22 new tests, 86 total passing