### PR TITLE
feat: add template cloning logic

### DIFF
--- a/apps/web/src/services/template-cloning.service.test.ts
+++ b/apps/web/src/services/template-cloning.service.test.ts
@@ -1,0 +1,271 @@
+/**
+ * Unit tests for TemplateCloningService
+ *
+ * Feature: template-cloning-logic
+ * Issue branch: issue-062-implement-template-cloning-logic
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import * as nodePath from 'path';
+import {
+  TemplateCloningService,
+  templateCloningService,
+  type FileSystemAdapter,
+  type CloningConfig,
+  type CloneRequest,
+} from './template-cloning.service';
+
+// ── In-memory FileSystemAdapter mock ─────────────────────────────────────────
+
+interface MockFsState {
+  dirs: Set<string>;
+  files: Map<string, string>; // path → content
+  mkdirError?: Error;
+  readdirError?: Error;
+  copyFileError?: Error;
+}
+
+function makeMockFs(state: MockFsState): FileSystemAdapter {
+  return {
+    async mkdir(path, _options) {
+      if (state.mkdirError) throw state.mkdirError;
+      state.dirs.add(path);
+    },
+    async readdir(path, _options) {
+      if (state.readdirError) throw state.readdirError;
+      const prefix = path.endsWith(nodePath.sep) ? path : path + nodePath.sep;
+      return Array.from(state.files.keys())
+        .filter((f) => f.startsWith(prefix))
+        .map((f) => nodePath.relative(path, f));
+    },
+    async copyFile(src, dest) {
+      if (state.copyFileError) throw state.copyFileError;
+      const content = state.files.get(src) ?? '';
+      state.files.set(dest, content);
+    },
+    async exists(path) {
+      return state.dirs.has(path) || state.files.has(path);
+    },
+  };
+}
+
+// ── Test config with predictable allowed roots ────────────────────────────────
+
+const ALLOWED_SOURCE = '/allowed/templates';
+const ALLOWED_WORKSPACE = '/allowed/workspaces';
+
+const testConfig: CloningConfig = {
+  allowedSourceRoots: [ALLOWED_SOURCE],
+  allowedWorkspaceRoots: [ALLOWED_WORKSPACE],
+};
+
+function makeRequest(overrides: Partial<CloneRequest> = {}): CloneRequest {
+  return {
+    source: { type: 'local', path: `${ALLOWED_SOURCE}/my-template` },
+    workspaceRoot: ALLOWED_WORKSPACE,
+    runId: 'run-abc123',
+    ...overrides,
+  };
+}
+
+function makeService(state: MockFsState): TemplateCloningService {
+  return new TemplateCloningService(makeMockFs(state), testConfig);
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('TemplateCloningService', () => {
+  describe('singleton export', () => {
+    it('templateCloningService is an instance of TemplateCloningService', () => {
+      expect(templateCloningService).toBeInstanceOf(TemplateCloningService);
+    });
+  });
+
+  describe('happy path', () => {
+    it('copies files to workspace, returns success:true with absolute normalized workspacePath', async () => {
+      const srcBase = `${ALLOWED_SOURCE}/my-template`;
+      const state: MockFsState = {
+        dirs: new Set(),
+        files: new Map([
+          [`${srcBase}/src/index.ts`, 'export {}'],
+          [`${srcBase}/package.json`, '{}'],
+        ]),
+      };
+      const svc = makeService(state);
+      const result = await svc.clone(makeRequest());
+
+      expect(result.success).toBe(true);
+      expect(result.workspacePath).toBeDefined();
+      expect(nodePath.isAbsolute(result.workspacePath!)).toBe(true);
+      expect(result.workspacePath).not.toMatch(/\/$/);
+      expect(result.workspacePath).toBe(`${ALLOWED_WORKSPACE}/run-abc123`);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('creates workspace directory and copies files preserving relative structure', async () => {
+      const srcBase = `${ALLOWED_SOURCE}/my-template`;
+      const state: MockFsState = {
+        dirs: new Set(),
+        files: new Map([
+          [`${srcBase}/src/lib/config.ts`, 'config'],
+          [`${srcBase}/README.md`, '# readme'],
+        ]),
+      };
+      const svc = makeService(state);
+      const result = await svc.clone(makeRequest());
+
+      expect(result.success).toBe(true);
+      const ws = result.workspacePath!;
+      expect(state.files.has(`${ws}/src/lib/config.ts`)).toBe(true);
+      expect(state.files.has(`${ws}/README.md`)).toBe(true);
+    });
+
+    it('empty source directory: workspace created, success:true, no files', async () => {
+      const state: MockFsState = { dirs: new Set(), files: new Map() };
+      const svc = makeService(state);
+      const result = await svc.clone(makeRequest());
+
+      expect(result.success).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+  });
+
+  describe('runId validation', () => {
+    it('rejects runId containing /', async () => {
+      const state: MockFsState = { dirs: new Set(), files: new Map() };
+      const svc = makeService(state);
+      const result = await svc.clone(makeRequest({ runId: 'run/evil' }));
+      expect(result.success).toBe(false);
+      expect(result.errors[0].severity).toBe('error');
+      expect(result.workspacePath).toBeUndefined();
+    });
+
+    it('rejects runId containing ..', async () => {
+      const state: MockFsState = { dirs: new Set(), files: new Map() };
+      const svc = makeService(state);
+      const result = await svc.clone(makeRequest({ runId: '../escape' }));
+      expect(result.success).toBe(false);
+      expect(result.errors[0].severity).toBe('error');
+    });
+
+    it('rejects runId containing \\', async () => {
+      const state: MockFsState = { dirs: new Set(), files: new Map() };
+      const svc = makeService(state);
+      const result = await svc.clone(makeRequest({ runId: 'run\\evil' }));
+      expect(result.success).toBe(false);
+      expect(result.errors[0].severity).toBe('error');
+    });
+  });
+
+  describe('path traversal prevention', () => {
+    it('rejects source path outside allowed source roots', async () => {
+      const state: MockFsState = { dirs: new Set(), files: new Map() };
+      const svc = makeService(state);
+      const result = await svc.clone(
+        makeRequest({ source: { type: 'local', path: '/etc/passwd' } })
+      );
+      expect(result.success).toBe(false);
+      expect(result.errors[0].severity).toBe('error');
+      expect(result.workspacePath).toBeUndefined();
+    });
+
+    it('rejects workspaceRoot outside allowed workspace roots', async () => {
+      const state: MockFsState = { dirs: new Set(), files: new Map() };
+      const svc = makeService(state);
+      const result = await svc.clone(makeRequest({ workspaceRoot: '/tmp/evil' }));
+      expect(result.success).toBe(false);
+      expect(result.errors[0].severity).toBe('error');
+    });
+
+    it('skips files that escape source root with warning, continues cloning safe files', async () => {
+      const srcBase = `${ALLOWED_SOURCE}/my-template`;
+      const state: MockFsState = {
+        dirs: new Set(),
+        files: new Map([
+          [`${srcBase}/safe.ts`, 'safe'],
+        ]),
+      };
+      // Inject a readdir that returns a traversal path alongside a safe one
+      const mockFs: FileSystemAdapter = {
+        async mkdir(_p, _o) { state.dirs.add(_p); },
+        async readdir(_p, _o) {
+          return ['safe.ts', '../../../etc/passwd'];
+        },
+        async copyFile(src, dest) {
+          state.files.set(dest, state.files.get(src) ?? '');
+        },
+        async exists(_p) { return false; },
+      };
+      const svc = new TemplateCloningService(mockFs, testConfig);
+      const result = await svc.clone(makeRequest());
+
+      expect(result.success).toBe(true);
+      expect(result.errors.some((e) => e.severity === 'warning')).toBe(true);
+      // Safe file should be copied
+      const ws = result.workspacePath!;
+      expect(state.files.has(`${ws}/safe.ts`)).toBe(true);
+    });
+  });
+
+  describe('workspace collision detection', () => {
+    it('returns success:false when workspace already exists', async () => {
+      const workspacePath = `${ALLOWED_WORKSPACE}/run-abc123`;
+      const state: MockFsState = {
+        dirs: new Set([workspacePath]),
+        files: new Map(),
+      };
+      const svc = makeService(state);
+      const result = await svc.clone(makeRequest());
+
+      expect(result.success).toBe(false);
+      expect(result.errors[0].message).toContain('collision');
+      expect(result.workspacePath).toBeUndefined();
+    });
+
+    it('propagates mkdir error message on non-collision failure', async () => {
+      const state: MockFsState = {
+        dirs: new Set(),
+        files: new Map(),
+        mkdirError: new Error('disk full'),
+      };
+      const svc = makeService(state);
+      const result = await svc.clone(makeRequest());
+
+      expect(result.success).toBe(false);
+      expect(result.errors[0].message).toContain('disk full');
+    });
+  });
+
+  describe('unknown source type', () => {
+    it('returns success:false for unrecognised source type', async () => {
+      const state: MockFsState = { dirs: new Set(), files: new Map() };
+      const svc = makeService(state);
+      const result = await svc.clone(
+        makeRequest({ source: { type: 'git', url: 'https://github.com/x/y' } as any })
+      );
+      expect(result.success).toBe(false);
+      expect(result.errors[0].message).toContain('not supported');
+    });
+  });
+
+  describe('workspacePath invariants', () => {
+    it('workspacePath is undefined on all failure results', async () => {
+      const state: MockFsState = { dirs: new Set(), files: new Map() };
+      const svc = makeService(state);
+
+      const r1 = await svc.clone(makeRequest({ runId: '../bad' }));
+      expect(r1.workspacePath).toBeUndefined();
+
+      const r2 = await svc.clone(makeRequest({ source: { type: 'local', path: '/outside' } }));
+      expect(r2.workspacePath).toBeUndefined();
+    });
+
+    it('never throws — resolves for null/undefined/invalid input', async () => {
+      const state: MockFsState = { dirs: new Set(), files: new Map() };
+      const svc = makeService(state);
+      await expect(svc.clone(null)).resolves.toBeDefined();
+      await expect(svc.clone(undefined)).resolves.toBeDefined();
+      await expect(svc.clone(42)).resolves.toBeDefined();
+    });
+  });
+});

--- a/apps/web/src/services/template-cloning.service.ts
+++ b/apps/web/src/services/template-cloning.service.ts
@@ -1,0 +1,331 @@
+/**
+ * TemplateCloningService
+ *
+ * Copies template source files into an isolated, per-run workspace directory
+ * before CodeGeneratorService applies customizations. Acts as a security and
+ * isolation boundary between the orchestration layer and the filesystem.
+ *
+ * Security guarantees:
+ *   - All paths are resolved to canonical absolute form before any FS operation
+ *   - Source and workspace paths are validated against configured allowed roots
+ *   - Per-file paths are checked to stay within the source root (symlink/traversal guard)
+ *   - runId is validated to prevent directory escape via path separators or ..
+ *
+ * Feature: template-cloning-logic
+ * Issue branch: issue-062-implement-template-cloning-logic
+ */
+
+import * as nodePath from 'path';
+import * as nodeFs from 'fs/promises';
+
+// ── FileSystemAdapter ─────────────────────────────────────────────────────────
+
+/**
+ * Injectable abstraction over fs/promises.
+ * The default implementation delegates to Node's fs/promises.
+ * Tests inject an in-memory implementation.
+ */
+export interface FileSystemAdapter {
+  mkdir(path: string, options?: { recursive?: boolean }): Promise<void>;
+  readdir(path: string, options: { recursive: true }): Promise<string[]>;
+  copyFile(src: string, dest: string): Promise<void>;
+  exists(path: string): Promise<boolean>;
+}
+
+/** Real filesystem adapter wrapping fs/promises. */
+export const realFsAdapter: FileSystemAdapter = {
+  async mkdir(path, options) {
+    await nodeFs.mkdir(path, options);
+  },
+  async readdir(path, options) {
+    const entries = await nodeFs.readdir(path, options);
+    return entries as string[];
+  },
+  async copyFile(src, dest) {
+    // Ensure parent directory exists before copying
+    await nodeFs.mkdir(nodePath.dirname(dest), { recursive: true });
+    await nodeFs.copyFile(src, dest);
+  },
+  async exists(path) {
+    try {
+      await nodeFs.access(path);
+      return true;
+    } catch {
+      return false;
+    }
+  },
+};
+
+// ── TemplateSource discriminated union ────────────────────────────────────────
+
+export interface LocalTemplateSource {
+  type: 'local';
+  /** Absolute path to the template directory on the local filesystem. */
+  path: string;
+}
+
+/**
+ * Discriminated union for template sources.
+ * Currently supports 'local' only; extensible to 'git', 's3', etc.
+ */
+export type TemplateSource = LocalTemplateSource;
+
+// ── CloneRequest / CloneResult / CloneError ───────────────────────────────────
+
+export interface CloneRequest {
+  source: TemplateSource;
+  /** Absolute path to the root directory where workspaces are created. */
+  workspaceRoot: string;
+  /** Caller-supplied unique identifier (e.g. UUID). Must not contain / \ or .. */
+  runId: string;
+}
+
+export interface CloneError {
+  /** The filesystem path involved, or 'unknown'. */
+  path: string;
+  message: string;
+  severity: 'error' | 'warning';
+}
+
+export interface CloneResult {
+  success: boolean;
+  /** Absolute, normalized workspace path. Present only when success: true. */
+  workspacePath?: string;
+  errors: CloneError[];
+}
+
+// ── CloningConfig ─────────────────────────────────────────────────────────────
+
+export interface CloningConfig {
+  /** Absolute paths under which source templates may reside. */
+  allowedSourceRoots: string[];
+  /** Absolute paths under which workspaces may be created. */
+  allowedWorkspaceRoots: string[];
+}
+
+function parseRootsFromEnv(envVar: string, fallback: string[]): string[] {
+  const val = process.env[envVar];
+  if (!val) return fallback;
+  return val.split(':').map((p) => nodePath.resolve(p)).filter(Boolean);
+}
+
+export const defaultCloningConfig: CloningConfig = {
+  allowedSourceRoots: parseRootsFromEnv('CRAFT_TEMPLATE_ROOTS', [
+    nodePath.resolve(process.cwd(), 'templates'),
+    nodePath.resolve(process.cwd(), 'src/templates'),
+  ]),
+  allowedWorkspaceRoots: parseRootsFromEnv('CRAFT_WORKSPACE_ROOTS', [
+    nodePath.resolve(process.cwd(), '.workspaces'),
+    nodePath.resolve('/tmp', 'craft-workspaces'),
+  ]),
+};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/** Returns true if `child` is at or under `parent`. */
+function isUnder(child: string, parent: string): boolean {
+  const rel = nodePath.relative(parent, child);
+  return !rel.startsWith('..') && !nodePath.isAbsolute(rel);
+}
+
+/** Returns true if `p` is under at least one of the given roots. */
+function isUnderAnyRoot(p: string, roots: string[]): boolean {
+  return roots.some((root) => isUnder(p, root));
+}
+
+// ── TemplateCloningService ────────────────────────────────────────────────────
+
+export class TemplateCloningService {
+  constructor(
+    private readonly fs: FileSystemAdapter = realFsAdapter,
+    private readonly config: CloningConfig = defaultCloningConfig
+  ) {}
+
+  /**
+   * Clone template sources into an isolated workspace directory.
+   *
+   * Steps:
+   *   1. Validate runId (no path separators or .. segments)
+   *   2. Resolve and validate source path and workspaceRoot against allowed roots
+   *   3. Create workspace directory (fail on collision)
+   *   4. Enumerate and copy files with per-file traversal guard
+   *
+   * Never throws — all error paths return a resolved Promise<CloneResult>.
+   */
+  async clone(request: unknown): Promise<CloneResult> {
+    try {
+      const req = request as CloneRequest | null | undefined;
+
+      // ── Step 1: Validate runId ───────────────────────────────────────────────
+      const runId = typeof req?.runId === 'string' ? req.runId : '';
+      const runIdError = this.validateRunId(runId);
+      if (runIdError) return { success: false, errors: [runIdError] };
+
+      const workspaceRoot = typeof req?.workspaceRoot === 'string' ? req.workspaceRoot : '';
+      const source = req?.source;
+
+      // ── Step 2: Validate source type ─────────────────────────────────────────
+      if (!source || typeof (source as any).type !== 'string') {
+        return {
+          success: false,
+          errors: [{ path: 'source.type', message: 'source is required', severity: 'error' }],
+        };
+      }
+
+      switch ((source as TemplateSource).type) {
+        case 'local':
+          return await this.cloneLocal(
+            source as LocalTemplateSource,
+            workspaceRoot,
+            runId
+          );
+        default:
+          return {
+            success: false,
+            errors: [
+              {
+                path: 'source.type',
+                message: `source type not supported: ${(source as any).type}`,
+                severity: 'error',
+              },
+            ],
+          };
+      }
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return {
+        success: false,
+        errors: [{ path: 'unknown', message: msg, severity: 'error' }],
+      };
+    }
+  }
+
+  // ── Private helpers ─────────────────────────────────────────────────────────
+
+  private validateRunId(runId: string): CloneError | null {
+    if (!runId) {
+      return { path: 'runId', message: 'runId is required', severity: 'error' };
+    }
+    if (runId.includes('/') || runId.includes('\\') || runId.includes('..')) {
+      return {
+        path: 'runId',
+        message: `runId must not contain path separators or ".." segments: "${runId}"`,
+        severity: 'error',
+      };
+    }
+    return null;
+  }
+
+  private async cloneLocal(
+    source: LocalTemplateSource,
+    workspaceRoot: string,
+    runId: string
+  ): Promise<CloneResult> {
+    // ── Resolve paths ──────────────────────────────────────────────────────────
+    const resolvedSource = nodePath.resolve(source.path);
+    const resolvedWorkspaceRoot = nodePath.resolve(workspaceRoot);
+    const workspacePath = nodePath.join(resolvedWorkspaceRoot, runId);
+
+    // ── Validate against allowed roots ────────────────────────────────────────
+    if (!isUnderAnyRoot(resolvedSource, this.config.allowedSourceRoots)) {
+      return {
+        success: false,
+        errors: [
+          {
+            path: resolvedSource,
+            message: `source path is outside allowed source roots: ${resolvedSource}`,
+            severity: 'error',
+          },
+        ],
+      };
+    }
+
+    if (!isUnderAnyRoot(resolvedWorkspaceRoot, this.config.allowedWorkspaceRoots)) {
+      return {
+        success: false,
+        errors: [
+          {
+            path: resolvedWorkspaceRoot,
+            message: `workspaceRoot is outside allowed workspace roots: ${resolvedWorkspaceRoot}`,
+            severity: 'error',
+          },
+        ],
+      };
+    }
+
+    // ── Create workspace directory (detect collisions) ────────────────────────
+    const alreadyExists = await this.fs.exists(workspacePath);
+    if (alreadyExists) {
+      return {
+        success: false,
+        errors: [
+          {
+            path: workspacePath,
+            message: `workspace already exists (collision): ${workspacePath}`,
+            severity: 'error',
+          },
+        ],
+      };
+    }
+
+    try {
+      await this.fs.mkdir(workspacePath, { recursive: true });
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return {
+        success: false,
+        errors: [{ path: workspacePath, message: `failed to create workspace: ${msg}`, severity: 'error' }],
+      };
+    }
+
+    // ── Enumerate and copy files ──────────────────────────────────────────────
+    const warnings: CloneError[] = [];
+    let entries: string[] = [];
+
+    try {
+      entries = await this.fs.readdir(resolvedSource, { recursive: true });
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return {
+        success: false,
+        errors: [{ path: resolvedSource, message: `failed to read source directory: ${msg}`, severity: 'error' }],
+      };
+    }
+
+    for (const entry of entries) {
+      const srcFile = nodePath.join(resolvedSource, entry);
+      const resolvedSrcFile = nodePath.resolve(srcFile);
+
+      // Per-file traversal guard
+      if (!isUnder(resolvedSrcFile, resolvedSource)) {
+        warnings.push({
+          path: resolvedSrcFile,
+          message: `skipped: file path escapes source root: ${resolvedSrcFile}`,
+          severity: 'warning',
+        });
+        continue;
+      }
+
+      const destFile = nodePath.join(workspacePath, entry);
+
+      try {
+        await this.fs.copyFile(resolvedSrcFile, destFile);
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        warnings.push({
+          path: resolvedSrcFile,
+          message: `failed to copy file: ${msg}`,
+          severity: 'warning',
+        });
+      }
+    }
+
+    return {
+      success: true,
+      workspacePath,
+      errors: warnings,
+    };
+  }
+}
+
+export const templateCloningService = new TemplateCloningService();

--- a/apps/web/src/services/template-generator.service.test.ts
+++ b/apps/web/src/services/template-generator.service.test.ts
@@ -3,6 +3,7 @@
  *
  * Feature: template-generator-entrypoint
  * Issue branch: issue-061-implement-template-generator-entrypoint
+ * Updated: issue-062-implement-template-cloning-logic (cloning integration)
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -61,7 +62,8 @@ const mockGeneratedFiles: GeneratedFile[] = [
 
 function makeService(
   templateMock?: Partial<{ getTemplate: () => Promise<Template> }>,
-  codeGenMock?: Partial<{ generate: () => any }>
+  codeGenMock?: Partial<{ generate: () => any }>,
+  cloningMock?: Partial<{ clone: () => Promise<any> }>
 ) {
   const ts = {
     getTemplate: vi.fn().mockResolvedValue(mockTemplate),
@@ -75,7 +77,15 @@ function makeService(
     }),
     ...codeGenMock,
   };
-  return new TemplateGeneratorService(ts as any, cgs as any);
+  const cs = {
+    clone: vi.fn().mockResolvedValue({
+      success: true,
+      workspacePath: '/tmp/output',
+      errors: [],
+    }),
+    ...cloningMock,
+  };
+  return new TemplateGeneratorService(ts as any, cgs as any, cs as any);
 }
 
 // ── mapCategoryToFamily ───────────────────────────────────────────────────────
@@ -274,5 +284,80 @@ describe('TemplateGeneratorService.generate — happy path', () => {
         expect.objectContaining({ templateFamily: expectedFamily })
       );
     }
+  });
+});
+
+// ── TemplateCloningService integration ───────────────────────────────────────
+
+describe('TemplateGeneratorService — cloning integration', () => {
+  it('calls cloningService.clone before codeGeneratorService.generate', async () => {
+    const callOrder: string[] = [];
+    const cloneMock = vi.fn().mockImplementation(async () => {
+      callOrder.push('clone');
+      return { success: true, workspacePath: '/tmp/ws/run-1', errors: [] };
+    });
+    const generateMock = vi.fn().mockImplementation(() => {
+      callOrder.push('generate');
+      return { success: true, generatedFiles: mockGeneratedFiles, errors: [] };
+    });
+    const svc = makeService(undefined, { generate: generateMock }, { clone: cloneMock });
+    await svc.generate(validRequest);
+
+    expect(cloneMock).toHaveBeenCalled();
+    expect(generateMock).toHaveBeenCalled();
+    expect(callOrder).toEqual(['clone', 'generate']);
+  });
+
+  it('passes workspacePath from clone result as outputPath to codeGeneratorService', async () => {
+    const workspacePath = '/tmp/ws/run-abc';
+    const generateMock = vi.fn().mockReturnValue({
+      success: true,
+      generatedFiles: mockGeneratedFiles,
+      errors: [],
+    });
+    const svc = makeService(
+      undefined,
+      { generate: generateMock },
+      { clone: vi.fn().mockResolvedValue({ success: true, workspacePath, errors: [] }) }
+    );
+    await svc.generate(validRequest);
+
+    expect(generateMock).toHaveBeenCalledWith(
+      expect.objectContaining({ outputPath: workspacePath })
+    );
+  });
+
+  it('returns success:false and propagates CloneError messages when clone fails', async () => {
+    const svc = makeService(
+      undefined,
+      undefined,
+      {
+        clone: vi.fn().mockResolvedValue({
+          success: false,
+          errors: [{ path: 'runId', message: 'runId is invalid', severity: 'error' }],
+        }),
+      }
+    );
+    const result = await svc.generate(validRequest);
+
+    expect(result.success).toBe(false);
+    expect(result.errors.some((e) => e.message.includes('runId is invalid'))).toBe(true);
+    expect(result.artifactMetadata).toBeUndefined();
+  });
+
+  it('does not call codeGeneratorService when clone fails', async () => {
+    const generateMock = vi.fn();
+    const svc = makeService(
+      undefined,
+      { generate: generateMock },
+      {
+        clone: vi.fn().mockResolvedValue({
+          success: false,
+          errors: [{ path: 'source', message: 'path traversal', severity: 'error' }],
+        }),
+      }
+    );
+    await svc.generate(validRequest);
+    expect(generateMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/services/template-generator.service.ts
+++ b/apps/web/src/services/template-generator.service.ts
@@ -9,6 +9,7 @@
  *
  * Feature: template-generator-entrypoint
  * Issue branch: issue-061-implement-template-generator-entrypoint
+ * Updated: issue-062-implement-template-cloning-logic
  */
 
 import { validateCustomizationConfig } from '@/lib/customization/validate';
@@ -18,6 +19,11 @@ import {
   TemplateFamilyId,
   codeGeneratorService,
 } from './code-generator.service';
+import {
+  TemplateCloningService,
+  templateCloningService,
+  type CloneRequest,
+} from './template-cloning.service';
 import type { TemplateCategory } from '@craft/types';
 
 // ── Re-exports from @craft/types ──────────────────────────────────────────────
@@ -77,7 +83,8 @@ export function mapCategoryToFamily(category: TemplateCategory): TemplateFamilyI
 export class TemplateGeneratorService {
   constructor(
     private readonly _templateService: Pick<TemplateService, 'getTemplate'> = templateService,
-    private readonly _codeGeneratorService: Pick<CodeGeneratorService, 'generate'> = codeGeneratorService
+    private readonly _codeGeneratorService: Pick<CodeGeneratorService, 'generate'> = codeGeneratorService,
+    private readonly _cloningService: Pick<TemplateCloningService, 'clone'> = templateCloningService
   ) {}
 
   /**
@@ -176,11 +183,34 @@ export class TemplateGeneratorService {
         };
       }
 
-      // ── Step 5: Generate code ────────────────────────────────────────────────
+      // ── Step 5: Clone template into workspace ────────────────────────────────
+      const runId = crypto.randomUUID();
+      const cloneRequest: CloneRequest = {
+        source: { type: 'local', path: template.baseRepositoryUrl },
+        workspaceRoot: outputPath || '/tmp/craft-workspaces',
+        runId,
+      };
+
+      const cloneResult = await this._cloningService.clone(cloneRequest);
+      if (!cloneResult.success) {
+        return {
+          success: false,
+          generatedFiles: [],
+          errors: cloneResult.errors.map((e) => ({
+            file: e.path,
+            message: e.message,
+            severity: 'error' as const,
+          })),
+        };
+      }
+
+      const workspacePath = cloneResult.workspacePath ?? outputPath;
+
+      // ── Step 6: Generate code ────────────────────────────────────────────────
       const innerResult = this._codeGeneratorService.generate({
         templateId,
         customization,
-        outputPath,
+        outputPath: workspacePath,
         templateFamily,
       });
 
@@ -192,13 +222,13 @@ export class TemplateGeneratorService {
         };
       }
 
-      // ── Step 6: Assemble artifact metadata ───────────────────────────────────
+      // ── Step 7: Assemble artifact metadata ───────────────────────────────────
       const artifactMetadata: ArtifactMetadata = {
         templateId,
         templateFamily,
         generatedAt: new Date().toISOString(),
         fileCount: innerResult.generatedFiles.length,
-        outputPath,
+        outputPath: workspacePath,
       };
 
       return {


### PR DESCRIPTION
Closes #62

---

Implemented TemplateCloningService — a secure filesystem service that copies template sources into isolated per-run workspaces. It validates runId against path injection, checks source and workspace paths against configured allowed roots, detects workspace collisions, and skips unsafe per-file paths with warnings rather than failing the whole clone. Integrated it into TemplateGeneratorService so cloning runs before code generation, with workspacePath forwarded as outputPath. 39 tests passing, pushed to issue-062-implement-template-cloning-logic.

#62 