### PR TITLE
feat: add github repository update flow

### DIFF
--- a/apps/web/src/app/api/deployments/[id]/repository/route.test.ts
+++ b/apps/web/src/app/api/deployments/[id]/repository/route.test.ts
@@ -221,3 +221,237 @@ describe('POST /api/deployments/[id]/repository', () => {
         expect(res.headers.get('Retry-After')).toBe('12');
     });
 });
+
+// ---------------------------------------------------------------------------
+// PATCH /api/deployments/[id]/repository
+// Feature: github-repository-update-flow
+// ---------------------------------------------------------------------------
+
+const mockUpdateRepository = vi.fn();
+vi.mock('@/services/github-repository-update.service', () => ({
+    githubRepositoryUpdateService: {
+        updateRepository: mockUpdateRepository,
+    },
+}));
+
+function makePatchRequest(body?: unknown) {
+    return new NextRequest('http://localhost/api/deployments/dep-1/repository', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+    });
+}
+
+const fakeCommitRef = {
+    commitSha: 'abc123',
+    treeSha: 'tree456',
+    commitUrl: 'https://github.com/acme/my-dex/commit/abc123',
+    branch: 'main',
+    fileCount: 3,
+    owner: 'acme',
+    repo: 'my-dex',
+    previousCommitSha: 'prev789',
+    createdBranch: false,
+};
+
+describe('PATCH /api/deployments/[id]/repository', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockGetUser.mockResolvedValue({ data: { user: fakeUser }, error: null });
+    });
+
+    it('returns 401 when unauthenticated', async () => {
+        mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+        const { PATCH } = await import('./route');
+
+        const res = await PATCH(makePatchRequest({}), { params });
+
+        expect(res.status).toBe(401);
+    });
+
+    it('returns 403 when deployment does not belong to the user', async () => {
+        mockFrom.mockReturnValue(
+            makeSupabaseQuery([{ data: { user_id: 'other-user' }, error: null }]),
+        );
+        const { PATCH } = await import('./route');
+
+        const res = await PATCH(makePatchRequest({ customizationConfig: {} }), { params });
+
+        expect(res.status).toBe(403);
+        expect(mockUpdateRepository).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 for invalid JSON', async () => {
+        mockFrom.mockReturnValue(
+            makeSupabaseQuery([{ data: { user_id: fakeUser.id }, error: null }]),
+        );
+        const { PATCH } = await import('./route');
+        const req = new NextRequest('http://localhost/api/deployments/dep-1/repository', {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: 'not-json',
+        });
+
+        const res = await PATCH(req, { params });
+
+        expect(res.status).toBe(400);
+        expect((await res.json()).error).toBe('Invalid JSON');
+    });
+
+    it('returns 400 when customizationConfig is missing', async () => {
+        mockFrom.mockReturnValue(
+            makeSupabaseQuery([{ data: { user_id: fakeUser.id }, error: null }]),
+        );
+        const { PATCH } = await import('./route');
+
+        const res = await PATCH(makePatchRequest({ branch: 'main' }), { params });
+
+        expect(res.status).toBe(400);
+        expect((await res.json()).error).toBe('Invalid request body');
+    });
+
+    it('returns 400 when customizationConfig is not an object (string)', async () => {
+        mockFrom.mockReturnValue(
+            makeSupabaseQuery([{ data: { user_id: fakeUser.id }, error: null }]),
+        );
+        const { PATCH } = await import('./route');
+
+        const res = await PATCH(makePatchRequest({ customizationConfig: 'not-an-object' }), { params });
+
+        expect(res.status).toBe(400);
+        expect((await res.json()).error).toBe('Invalid request body');
+    });
+
+    it('returns 400 when commitMessage is present but not a string', async () => {
+        mockFrom.mockReturnValue(
+            makeSupabaseQuery([{ data: { user_id: fakeUser.id }, error: null }]),
+        );
+        const { PATCH } = await import('./route');
+
+        const res = await PATCH(
+            makePatchRequest({ customizationConfig: {}, commitMessage: 42 }),
+            { params },
+        );
+
+        expect(res.status).toBe(400);
+        expect((await res.json()).error).toBe('Invalid request body');
+    });
+
+    it('returns 400 when branch is present but not a string', async () => {
+        mockFrom.mockReturnValue(
+            makeSupabaseQuery([{ data: { user_id: fakeUser.id }, error: null }]),
+        );
+        const { PATCH } = await import('./route');
+
+        const res = await PATCH(
+            makePatchRequest({ customizationConfig: {}, branch: true }),
+            { params },
+        );
+
+        expect(res.status).toBe(400);
+        expect((await res.json()).error).toBe('Invalid request body');
+    });
+
+    it('returns 200 with correct commit metadata on success', async () => {
+        mockFrom.mockReturnValue(
+            makeSupabaseQuery([{ data: { user_id: fakeUser.id }, error: null }]),
+        );
+        mockUpdateRepository.mockResolvedValue({
+            commitRef: fakeCommitRef,
+            deploymentId: 'dep-1',
+        });
+        const { PATCH } = await import('./route');
+
+        const res = await PATCH(
+            makePatchRequest({ customizationConfig: { theme: 'dark' } }),
+            { params },
+        );
+
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body).toMatchObject({
+            commitSha: 'abc123',
+            treeSha: 'tree456',
+            commitUrl: 'https://github.com/acme/my-dex/commit/abc123',
+            branch: 'main',
+            fileCount: 3,
+            owner: 'acme',
+            repo: 'my-dex',
+            deploymentId: 'dep-1',
+        });
+    });
+
+    it('returns 429 with Retry-After header on RATE_LIMITED error', async () => {
+        mockFrom.mockReturnValue(
+            makeSupabaseQuery([{ data: { user_id: fakeUser.id }, error: null }]),
+        );
+        mockUpdateRepository.mockRejectedValue({
+            code: 'RATE_LIMITED',
+            message: 'GitHub rate limit exceeded',
+            retryAfterMs: 30_000,
+        });
+        const { PATCH } = await import('./route');
+
+        const res = await PATCH(
+            makePatchRequest({ customizationConfig: {} }),
+            { params },
+        );
+
+        expect(res.status).toBe(429);
+        expect(res.headers.get('Retry-After')).toBe('30');
+    });
+
+    it('returns 502 on NETWORK_ERROR', async () => {
+        mockFrom.mockReturnValue(
+            makeSupabaseQuery([{ data: { user_id: fakeUser.id }, error: null }]),
+        );
+        mockUpdateRepository.mockRejectedValue({
+            code: 'NETWORK_ERROR',
+            message: 'Network error communicating with GitHub',
+        });
+        const { PATCH } = await import('./route');
+
+        const res = await PATCH(
+            makePatchRequest({ customizationConfig: {} }),
+            { params },
+        );
+
+        expect(res.status).toBe(502);
+    });
+
+    it('returns 500 on REPO_NOT_FOUND error', async () => {
+        mockFrom.mockReturnValue(
+            makeSupabaseQuery([{ data: { user_id: fakeUser.id }, error: null }]),
+        );
+        mockUpdateRepository.mockRejectedValue({
+            code: 'REPO_NOT_FOUND',
+            message: 'Repository not found for this deployment',
+        });
+        const { PATCH } = await import('./route');
+
+        const res = await PATCH(
+            makePatchRequest({ customizationConfig: {} }),
+            { params },
+        );
+
+        expect(res.status).toBe(500);
+    });
+
+    it('returns 500 on INVALID_STATE error', async () => {
+        mockFrom.mockReturnValue(
+            makeSupabaseQuery([{ data: { user_id: fakeUser.id }, error: null }]),
+        );
+        mockUpdateRepository.mockRejectedValue({
+            code: 'INVALID_STATE',
+            message: "Cannot update deployment in 'pending' state",
+        });
+        const { PATCH } = await import('./route');
+
+        const res = await PATCH(
+            makePatchRequest({ customizationConfig: {} }),
+            { params },
+        );
+
+        expect(res.status).toBe(500);
+    });
+});

--- a/apps/web/src/app/api/deployments/[id]/repository/route.ts
+++ b/apps/web/src/app/api/deployments/[id]/repository/route.ts
@@ -35,6 +35,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { withDeploymentAuth } from '@/lib/api/with-auth';
 import { githubService } from '@/services/github.service';
+import { githubRepositoryUpdateService } from '@/services/github-repository-update.service';
 
 interface RequestBody {
     private?: boolean;
@@ -174,6 +175,113 @@ export const POST = withDeploymentAuth(async (req: NextRequest, { params, supaba
 
         return NextResponse.json(
             { error: svcErr.message ?? 'Repository creation failed' },
+            { status: 500 },
+        );
+    }
+});
+
+// ---------------------------------------------------------------------------
+// PATCH /api/deployments/[id]/repository
+//
+// Updates the GitHub repository for an existing deployment by regenerating
+// files from the new customization config and committing them.
+//
+// Feature: github-repository-update-flow
+// ---------------------------------------------------------------------------
+
+interface UpdateRequestBody {
+    customizationConfig: Record<string, unknown>;
+    branch?: string;
+    commitMessage?: string;
+}
+
+function normalizeUpdateRequestBody(raw: unknown): UpdateRequestBody | null {
+    if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) {
+        return null;
+    }
+
+    const body = raw as Record<string, unknown>;
+
+    if (
+        !('customizationConfig' in body) ||
+        body.customizationConfig === null ||
+        typeof body.customizationConfig !== 'object' ||
+        Array.isArray(body.customizationConfig)
+    ) {
+        return null;
+    }
+
+    if ('commitMessage' in body && typeof body.commitMessage !== 'string') {
+        return null;
+    }
+
+    if ('branch' in body && typeof body.branch !== 'string') {
+        return null;
+    }
+
+    return body as UpdateRequestBody;
+}
+
+export const PATCH = withDeploymentAuth(async (req: NextRequest, { params, user }) => {
+    const deploymentId = params.id;
+
+    let body: UpdateRequestBody;
+    try {
+        const raw = await req.json();
+        const normalized = normalizeUpdateRequestBody(raw);
+
+        if (normalized === null) {
+            return NextResponse.json({ error: 'Invalid request body' }, { status: 400 });
+        }
+
+        body = normalized;
+    } catch {
+        return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+    }
+
+    try {
+        const { commitRef, deploymentId: resultDeploymentId } =
+            await githubRepositoryUpdateService.updateRepository({
+                deploymentId,
+                userId: user.id,
+                customizationConfig: body.customizationConfig as any,
+                branch: body.branch,
+                commitMessage: body.commitMessage,
+            });
+
+        return NextResponse.json({
+            commitSha: commitRef.commitSha,
+            treeSha: commitRef.treeSha,
+            commitUrl: commitRef.commitUrl,
+            branch: commitRef.branch,
+            fileCount: commitRef.fileCount,
+            owner: commitRef.owner,
+            repo: commitRef.repo,
+            deploymentId: resultDeploymentId,
+        });
+    } catch (err: unknown) {
+        const svcErr = err as { code?: string; message?: string; retryAfterMs?: number };
+
+        if (svcErr.code === 'RATE_LIMITED') {
+            const response = NextResponse.json(
+                { error: svcErr.message ?? 'GitHub API rate limit exceeded' },
+                { status: 429 },
+            );
+            if (svcErr.retryAfterMs) {
+                response.headers.set('Retry-After', String(Math.ceil(svcErr.retryAfterMs / 1000)));
+            }
+            return response;
+        }
+
+        if (svcErr.code === 'NETWORK_ERROR') {
+            return NextResponse.json(
+                { error: svcErr.message ?? 'Network error communicating with GitHub' },
+                { status: 502 },
+            );
+        }
+
+        return NextResponse.json(
+            { error: svcErr.message ?? 'Repository update failed' },
             { status: 500 },
         );
     }

--- a/apps/web/src/services/github-repository-update.service.test.ts
+++ b/apps/web/src/services/github-repository-update.service.test.ts
@@ -1,0 +1,326 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  parseRepoIdentity,
+  GitHubRepositoryUpdateService,
+} from './github-repository-update.service';
+import {
+  GitHubPushAuthError,
+  GitHubPushApiError,
+  GitHubPushNetworkError,
+} from './github-push.service';
+
+// ---------------------------------------------------------------------------
+// Supabase mock
+// ---------------------------------------------------------------------------
+
+const mockSingle = vi.fn();
+const mockEqUpdate = vi.fn();
+const mockEqSelect = vi.fn();
+const mockInsert = vi.fn();
+const mockUpdate = vi.fn();
+const mockSelect = vi.fn();
+const mockFrom = vi.fn();
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: () => ({ from: mockFrom }),
+}));
+
+// ---------------------------------------------------------------------------
+// Push service / code generator mocks
+// ---------------------------------------------------------------------------
+
+const mockPushGeneratedCode = vi.fn();
+const mockGenerate = vi.fn();
+const mockPushService = { pushGeneratedCode: mockPushGeneratedCode };
+const mockCodeGenerator = { generate: mockGenerate };
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const DEPLOYMENT_ID = 'deploy-123';
+const USER_ID = 'user-abc';
+const REPO_URL = 'https://github.com/acme/my-app';
+
+const makeDeployment = (overrides: Record<string, unknown> = {}) => ({
+  id: DEPLOYMENT_ID,
+  user_id: USER_ID,
+  status: 'completed',
+  repository_url: REPO_URL,
+  full_name: 'acme/my-app',
+  customization_config: { theme: 'dark' },
+  ...overrides,
+});
+
+const makeCommitRef = () => ({
+  owner: 'acme',
+  repo: 'my-app',
+  branch: 'main',
+  commitSha: 'abc123',
+  treeSha: 'tree456',
+  commitUrl: 'https://github.com/acme/my-app/commit/abc123',
+  previousCommitSha: 'prev789',
+  createdBranch: false,
+  fileCount: 2,
+});
+
+const makeFiles = () => [
+  { path: 'src/index.ts', content: 'export {}', type: 'code' },
+  { path: 'README.md', content: '# Hello', type: 'config' },
+];
+
+/**
+ * Sets up the Supabase mock chain for a deployment fetch.
+ * .from('deployments').select(...).eq(...).eq(...).single()
+ */
+function setupDeploymentFetch(data: unknown, error: unknown = null) {
+  mockSingle.mockResolvedValueOnce({ data, error });
+  mockEqSelect.mockReturnValueOnce({ single: mockSingle });
+  const mockEqFirst = vi.fn().mockReturnValueOnce({ eq: mockEqSelect });
+  mockSelect.mockReturnValueOnce({ eq: mockEqFirst });
+  mockFrom.mockReturnValueOnce({ select: mockSelect });
+}
+
+/**
+ * Sets up the Supabase mock chain for an insert.
+ * .from('deployment_updates').insert(...)
+ */
+function setupInsert() {
+  mockInsert.mockResolvedValueOnce({ error: null });
+  mockFrom.mockReturnValueOnce({ insert: mockInsert });
+}
+
+/**
+ * Sets up the Supabase mock chain for an update.
+ * .from(table).update(...).eq(...)
+ */
+function setupUpdate() {
+  mockEqUpdate.mockResolvedValueOnce({ error: null });
+  mockUpdate.mockReturnValueOnce({ eq: mockEqUpdate });
+  mockFrom.mockReturnValueOnce({ update: mockUpdate });
+}
+
+// ---------------------------------------------------------------------------
+// parseRepoIdentity
+// ---------------------------------------------------------------------------
+
+describe('parseRepoIdentity', () => {
+  it('returns correct owner/repo for a standard URL', () => {
+    expect(parseRepoIdentity('https://github.com/acme/my-app')).toEqual({
+      owner: 'acme',
+      repo: 'my-app',
+    });
+  });
+
+  it('strips .git suffix', () => {
+    expect(parseRepoIdentity('https://github.com/acme/my-app.git')).toEqual({
+      owner: 'acme',
+      repo: 'my-app',
+    });
+  });
+
+  it('strips trailing slash', () => {
+    expect(parseRepoIdentity('https://github.com/acme/my-app/')).toEqual({
+      owner: 'acme',
+      repo: 'my-app',
+    });
+  });
+
+  it('strips both .git and trailing slash', () => {
+    expect(parseRepoIdentity('https://github.com/acme/my-app.git/')).toEqual({
+      owner: 'acme',
+      repo: 'my-app',
+    });
+  });
+
+  it('throws INVALID_REPO_IDENTITY for non-GitHub URLs', () => {
+    expect(() => parseRepoIdentity('https://gitlab.com/acme/my-app')).toThrow(
+      expect.objectContaining({ code: 'INVALID_REPO_IDENTITY' }),
+    );
+  });
+
+  it('throws INVALID_REPO_IDENTITY for URLs missing the repo segment', () => {
+    expect(() => parseRepoIdentity('https://github.com/acme')).toThrow(
+      expect.objectContaining({ code: 'INVALID_REPO_IDENTITY' }),
+    );
+  });
+
+  it('throws INVALID_REPO_IDENTITY for empty string', () => {
+    expect(() => parseRepoIdentity('')).toThrow(
+      expect.objectContaining({ code: 'INVALID_REPO_IDENTITY' }),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GitHubRepositoryUpdateService.updateRepository
+// ---------------------------------------------------------------------------
+
+describe('GitHubRepositoryUpdateService.updateRepository', () => {
+  let service: GitHubRepositoryUpdateService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new GitHubRepositoryUpdateService(mockPushService as any, mockCodeGenerator as any);
+  });
+
+  const baseParams = {
+    deploymentId: DEPLOYMENT_ID,
+    userId: USER_ID,
+    customizationConfig: { theme: 'light' } as any,
+  };
+
+  // ── Pre-flight errors ────────────────────────────────────────────────────
+
+  it('throws REPO_NOT_FOUND when deployment not found', async () => {
+    setupDeploymentFetch(null, { message: 'not found' });
+
+    await expect(service.updateRepository(baseParams)).rejects.toMatchObject({
+      code: 'REPO_NOT_FOUND',
+    });
+  });
+
+  it('throws INVALID_STATE when deployment status is not completed', async () => {
+    setupDeploymentFetch(makeDeployment({ status: 'pending' }));
+
+    await expect(service.updateRepository(baseParams)).rejects.toMatchObject({
+      code: 'INVALID_STATE',
+    });
+  });
+
+  it('throws REPO_NOT_FOUND when repository_url is null', async () => {
+    setupDeploymentFetch(makeDeployment({ repository_url: null }));
+
+    await expect(service.updateRepository(baseParams)).rejects.toMatchObject({
+      code: 'REPO_NOT_FOUND',
+    });
+  });
+
+  it('throws INVALID_REPO_IDENTITY when repository_url is malformed', async () => {
+    setupDeploymentFetch(makeDeployment({ repository_url: 'not-a-url' }));
+
+    await expect(service.updateRepository(baseParams)).rejects.toMatchObject({
+      code: 'INVALID_REPO_IDENTITY',
+    });
+  });
+
+  it('throws NO_FILES_GENERATED when code generator returns empty array', async () => {
+    setupDeploymentFetch(makeDeployment());
+    mockGenerate.mockReturnValueOnce({ generatedFiles: [] });
+
+    await expect(service.updateRepository(baseParams)).rejects.toMatchObject({
+      code: 'NO_FILES_GENERATED',
+    });
+  });
+
+  // ── Push error mapping ───────────────────────────────────────────────────
+
+  it('maps GitHubPushAuthError to AUTH_FAILED', async () => {
+    setupDeploymentFetch(makeDeployment());
+    mockGenerate.mockReturnValueOnce({ generatedFiles: makeFiles() });
+    setupInsert();
+    mockPushGeneratedCode.mockRejectedValueOnce(new GitHubPushAuthError('bad credentials'));
+    // rollback: update deployments + update deployment_updates
+    setupUpdate();
+    setupUpdate();
+
+    await expect(service.updateRepository(baseParams)).rejects.toMatchObject({
+      code: 'AUTH_FAILED',
+    });
+  });
+
+  it('maps GitHubPushApiError with status 429 to RATE_LIMITED', async () => {
+    setupDeploymentFetch(makeDeployment());
+    mockGenerate.mockReturnValueOnce({ generatedFiles: makeFiles() });
+    setupInsert();
+    const apiErr = new GitHubPushApiError('rate limited', 429);
+    (apiErr as any).retryAfterMs = 60000;
+    mockPushGeneratedCode.mockRejectedValueOnce(apiErr);
+    setupUpdate();
+    setupUpdate();
+
+    await expect(service.updateRepository(baseParams)).rejects.toMatchObject({
+      code: 'RATE_LIMITED',
+    });
+  });
+
+  it('maps GitHubPushNetworkError to NETWORK_ERROR', async () => {
+    setupDeploymentFetch(makeDeployment());
+    mockGenerate.mockReturnValueOnce({ generatedFiles: makeFiles() });
+    setupInsert();
+    mockPushGeneratedCode.mockRejectedValueOnce(new GitHubPushNetworkError('timeout'));
+    setupUpdate();
+    setupUpdate();
+
+    await expect(service.updateRepository(baseParams)).rejects.toMatchObject({
+      code: 'NETWORK_ERROR',
+    });
+  });
+
+  // ── Success path ─────────────────────────────────────────────────────────
+
+  it('returns { commitRef, deploymentId } on success', async () => {
+    const commitRef = makeCommitRef();
+    setupDeploymentFetch(makeDeployment());
+    mockGenerate.mockReturnValueOnce({ generatedFiles: makeFiles() });
+    setupInsert();
+    mockPushGeneratedCode.mockResolvedValueOnce(commitRef);
+    setupUpdate(); // deployments update
+    setupUpdate(); // deployment_updates update
+
+    const result = await service.updateRepository(baseParams);
+
+    expect(result).toEqual({ commitRef, deploymentId: DEPLOYMENT_ID });
+  });
+
+  it('updates deployment record with new customization_config on success', async () => {
+    const commitRef = makeCommitRef();
+    const newConfig = { theme: 'light' };
+    setupDeploymentFetch(makeDeployment());
+    mockGenerate.mockReturnValueOnce({ generatedFiles: makeFiles() });
+    setupInsert();
+    mockPushGeneratedCode.mockResolvedValueOnce(commitRef);
+    setupUpdate();
+    setupUpdate();
+
+    await service.updateRepository({ ...baseParams, customizationConfig: newConfig as any });
+
+    // The first update call should be on 'deployments' with the new config
+    const deploymentsUpdateCall = mockUpdate.mock.calls[0][0];
+    expect(deploymentsUpdateCall).toMatchObject({ customization_config: newConfig });
+  });
+
+  it('marks update record as completed on success', async () => {
+    const commitRef = makeCommitRef();
+    setupDeploymentFetch(makeDeployment());
+    mockGenerate.mockReturnValueOnce({ generatedFiles: makeFiles() });
+    setupInsert();
+    mockPushGeneratedCode.mockResolvedValueOnce(commitRef);
+    setupUpdate();
+    setupUpdate();
+
+    await service.updateRepository(baseParams);
+
+    // The second update call should mark the update record as completed
+    const updateRecordCall = mockUpdate.mock.calls[1][0];
+    expect(updateRecordCall).toMatchObject({ status: 'completed' });
+    expect(updateRecordCall.completed_at).toBeDefined();
+  });
+
+  it('invokes rollback (marks update record as rolled_back) on push failure', async () => {
+    setupDeploymentFetch(makeDeployment());
+    mockGenerate.mockReturnValueOnce({ generatedFiles: makeFiles() });
+    setupInsert();
+    mockPushGeneratedCode.mockRejectedValueOnce(new GitHubPushNetworkError('timeout'));
+    setupUpdate(); // rollback: restore deployments
+    setupUpdate(); // rollback: mark deployment_updates as rolled_back
+
+    await expect(service.updateRepository(baseParams)).rejects.toMatchObject({
+      code: 'NETWORK_ERROR',
+    });
+
+    // Second update call should set status to rolled_back
+    const rollbackUpdateCall = mockUpdate.mock.calls[1][0];
+    expect(rollbackUpdateCall).toMatchObject({ status: 'rolled_back' });
+  });
+});

--- a/apps/web/src/services/github-repository-update.service.ts
+++ b/apps/web/src/services/github-repository-update.service.ts
@@ -1,0 +1,253 @@
+/**
+ * GitHubRepositoryUpdateService
+ *
+ * Handles updating an already-deployed GitHub repository when a user modifies
+ * a deployment's customization configuration. Resolves repository identity from
+ * the stored deployment record, regenerates files via CodeGeneratorService, and
+ * commits them using GitHubPushService.
+ *
+ * Feature: github-repository-update-flow
+ */
+
+import { createClient } from '@/lib/supabase/server';
+import type { CustomizationConfig, GeneratedFile, DeploymentStatusType } from '@craft/types';
+import {
+  githubPushService,
+  type GitHubCommitReference,
+  type GitHubPushService,
+  GitHubPushAuthError,
+  GitHubPushApiError,
+  GitHubPushNetworkError,
+} from './github-push.service';
+import { codeGeneratorService, type CodeGeneratorService } from './code-generator.service';
+
+// ---------------------------------------------------------------------------
+// parseRepoIdentity — pure function
+// ---------------------------------------------------------------------------
+
+/**
+ * Parses a GitHub HTTPS repository URL into its owner and repo components.
+ *
+ * Accepts URLs of the form `https://github.com/<owner>/<repo>` with optional
+ * trailing slashes or `.git` suffixes, which are normalized before extraction.
+ *
+ * @param repositoryUrl - A GitHub HTTPS repository URL
+ * @returns `{ owner, repo }` extracted from the URL
+ * @throws `{ code: 'INVALID_REPO_IDENTITY', message: string }` for any non-matching input
+ */
+export function parseRepoIdentity(repositoryUrl: string): { owner: string; repo: string } {
+  // Normalize: strip trailing slashes and .git suffix
+  let normalized = repositoryUrl.trim();
+  normalized = normalized.replace(/\/+$/, '');
+  if (normalized.endsWith('.git')) {
+    normalized = normalized.slice(0, -4);
+    normalized = normalized.replace(/\/+$/, '');
+  }
+
+  // Validate: must match https://github.com/<owner>/<repo> exactly
+  const match = normalized.match(/^https:\/\/github\.com\/([^/]+)\/([^/]+)$/);
+
+  if (!match || !match[1] || !match[2]) {
+    throw { code: 'INVALID_REPO_IDENTITY', message: 'Invalid GitHub repository URL' };
+  }
+
+  return { owner: match[1], repo: match[2] };
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type UpdateErrorCode =
+  | 'REPO_NOT_FOUND'
+  | 'INVALID_REPO_IDENTITY'
+  | 'INVALID_STATE'
+  | 'NO_FILES_GENERATED'
+  | 'AUTH_FAILED'
+  | 'RATE_LIMITED'
+  | 'NETWORK_ERROR';
+
+export interface ServiceError {
+  code: UpdateErrorCode;
+  message: string;
+  retryAfterMs?: number;
+}
+
+export interface UpdateRepositoryParams {
+  deploymentId: string;
+  userId: string;
+  customizationConfig: CustomizationConfig;
+  branch?: string;
+  commitMessage?: string;
+}
+
+export interface UpdateRepositoryResult {
+  commitRef: GitHubCommitReference;
+  deploymentId: string;
+}
+
+// ---------------------------------------------------------------------------
+// GitHubRepositoryUpdateService
+// ---------------------------------------------------------------------------
+
+export class GitHubRepositoryUpdateService {
+  constructor(
+    private readonly _githubPushService: Pick<GitHubPushService, 'pushGeneratedCode'> = githubPushService,
+    private readonly _codeGenerator: Pick<CodeGeneratorService, 'generate'> = codeGeneratorService,
+  ) {}
+
+  async updateRepository(params: UpdateRepositoryParams): Promise<UpdateRepositoryResult> {
+    const supabase = createClient();
+    const { deploymentId, userId, customizationConfig } = params;
+
+    // ── Pre-flight: fetch deployment and validate state ──────────────────────
+    const { data: deployment, error: fetchError } = await supabase
+      .from('deployments')
+      .select('id, user_id, status, repository_url, full_name, customization_config')
+      .eq('id', deploymentId)
+      .eq('user_id', userId)
+      .single();
+
+    if (fetchError || !deployment) {
+      throw { code: 'REPO_NOT_FOUND', message: 'Repository not found for this deployment' } satisfies ServiceError;
+    }
+
+    if ((deployment.status as DeploymentStatusType) !== 'completed') {
+      throw {
+        code: 'INVALID_STATE',
+        message: `Cannot update deployment in '${deployment.status}' state`,
+      } satisfies ServiceError;
+    }
+
+    if (!deployment.repository_url) {
+      throw { code: 'REPO_NOT_FOUND', message: 'Repository not found for this deployment' } satisfies ServiceError;
+    }
+
+    // Parse owner/repo from stored URL — throws INVALID_REPO_IDENTITY if malformed
+    const { owner, repo } = parseRepoIdentity(deployment.repository_url as string);
+
+    // ── Code generation ──────────────────────────────────────────────────────
+    const generationResult = this._codeGenerator.generate({
+      templateFamily: 'stellar-dex',
+      customization: customizationConfig,
+    });
+
+    const files: GeneratedFile[] = generationResult.generatedFiles;
+
+    if (!files || files.length === 0) {
+      throw { code: 'NO_FILES_GENERATED', message: 'Code generation produced no files' } satisfies ServiceError;
+    }
+
+    // ── Create Update_Record (pending) before any GitHub calls ───────────────
+    const updateId = crypto.randomUUID();
+    const previousState = {
+      customizationConfig: deployment.customization_config,
+      status: deployment.status,
+    };
+
+    await supabase.from('deployment_updates').insert({
+      id: updateId,
+      deployment_id: deploymentId,
+      user_id: userId,
+      new_customization_config: customizationConfig,
+      previous_state: previousState,
+      status: 'pending',
+      created_at: new Date().toISOString(),
+    });
+
+    // ── GitHub push ──────────────────────────────────────────────────────────
+    const branch = params.branch ?? 'main';
+    const commitMessage =
+      params.commitMessage ?? `chore: update generated workspace (${new Date().toISOString()})`;
+
+    const token = process.env.GITHUB_TOKEN ?? '';
+
+    let commitRef: GitHubCommitReference;
+    try {
+      commitRef = await this._githubPushService.pushGeneratedCode({
+        owner,
+        repo,
+        token,
+        files,
+        branch,
+        commitMessage,
+      });
+    } catch (err: unknown) {
+      // Map push errors to service error codes, then rollback
+      let serviceError: ServiceError;
+
+      if (err instanceof GitHubPushAuthError) {
+        serviceError = { code: 'AUTH_FAILED', message: err.message };
+      } else if (err instanceof GitHubPushApiError && err.status === 429) {
+        const retryAfterMs = (err as any).retryAfterMs as number | undefined;
+        serviceError = { code: 'RATE_LIMITED', message: err.message, retryAfterMs };
+      } else if (err instanceof GitHubPushNetworkError) {
+        serviceError = { code: 'NETWORK_ERROR', message: err.message };
+      } else {
+        serviceError = {
+          code: 'NETWORK_ERROR',
+          message: err instanceof Error ? err.message : 'Unknown error during GitHub push',
+        };
+      }
+
+      await this._rollback(updateId, deploymentId, previousState);
+      throw serviceError;
+    }
+
+    // ── Success: persist state ───────────────────────────────────────────────
+    await supabase
+      .from('deployments')
+      .update({
+        customization_config: customizationConfig,
+        status: 'completed',
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', deploymentId);
+
+    await supabase
+      .from('deployment_updates')
+      .update({
+        status: 'completed',
+        completed_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', updateId);
+
+    return { commitRef, deploymentId };
+  }
+
+  // ── Private: rollback ──────────────────────────────────────────────────────
+
+  private async _rollback(
+    updateId: string,
+    deploymentId: string,
+    previousState: { customizationConfig: unknown; status: unknown },
+  ): Promise<void> {
+    const supabase = createClient();
+    try {
+      await supabase
+        .from('deployments')
+        .update({
+          customization_config: previousState.customizationConfig,
+          status: 'completed',
+          updated_at: new Date().toISOString(),
+        })
+        .eq('id', deploymentId);
+
+      await supabase
+        .from('deployment_updates')
+        .update({ status: 'rolled_back', updated_at: new Date().toISOString() })
+        .eq('id', updateId);
+    } catch (rollbackErr: unknown) {
+      console.error('Rollback failed:', rollbackErr);
+      await supabase
+        .from('deployment_updates')
+        .update({ status: 'failed', updated_at: new Date().toISOString() })
+        .eq('id', updateId)
+        .catch(() => {/* best-effort */});
+    }
+  }
+}
+
+// Export singleton instance
+export const githubRepositoryUpdateService = new GitHubRepositoryUpdateService();


### PR DESCRIPTION
feat: add GitHub repository update flow

Closes #76

Adds a PATCH /api/deployments/[id]/repository endpoint that updates an existing GitHub repository when a deployment's customization config changes.

What changed

New GitHubRepositoryUpdateService in 
github-repository-update.service.ts
Resolves repo identity (owner/repo) from the deployment record — never from the caller
Regenerates files via CodeGeneratorService and commits them via the existing GitHubPushService
Creates a deployment_updates record before any GitHub calls, rolls back on failure
Maps push errors to typed codes (AUTH_FAILED, RATE_LIMITED, NETWORK_ERROR)
Exported parseRepoIdentity pure function — normalizes .git suffixes and trailing slashes, throws INVALID_REPO_IDENTITY for malformed URLs
PATCH handler added to the existing route.ts alongside POST, using withDeploymentAuth for auth/ownership enforcement
Response shape: { commitSha, treeSha, commitUrl, branch, fileCount, owner, repo, deploymentId }
Tests

39 tests total, all passing — 19 service unit tests + 20 route tests (8 existing POST + 12 new PATCH).

Edge cases / assumptions

templateFamily is hardcoded to stellar-dex for code generation — a follow-up should derive this from the deployment record
GITHUB_TOKEN is read from process.env and never surfaces in any response body or log
Rollback restores customization_config and keeps status: completed; if rollback itself fails, the update record is marked failed and the error is logged