### PR TITLE
feat: implement profile settings page

### DIFF
--- a/apps/web/src/app/app/settings/profile/ProfileSettingsForm.tsx
+++ b/apps/web/src/app/app/settings/profile/ProfileSettingsForm.tsx
@@ -1,0 +1,192 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { useFormState, useFormStatus } from 'react-dom';
+import { updateProfileAction, type ProfileState } from './actions';
+
+const initialState: ProfileState = { status: 'idle', message: '' };
+
+// ---------------------------------------------------------------------------
+// Save button with optimistic feedback via useFormStatus
+// ---------------------------------------------------------------------------
+
+function SaveButton({ savedRecently }: { savedRecently: boolean }) {
+    const { pending } = useFormStatus();
+
+    let label = 'Save changes';
+    if (pending) label = 'Saving…';
+    else if (savedRecently) label = 'Saved!';
+
+    return (
+        <button
+            type="submit"
+            disabled={pending}
+            aria-busy={pending}
+            className={`inline-flex items-center gap-2 rounded-lg px-5 py-2.5 text-sm font-semibold
+                transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-surface-tint focus:ring-offset-2
+                disabled:opacity-60 disabled:cursor-not-allowed
+                ${savedRecently && !pending
+                    ? 'bg-green-600 text-white'
+                    : 'bg-gradient-primary text-on-primary hover:opacity-90'
+                }`}
+        >
+            {pending && (
+                <svg className="animate-spin h-4 w-4" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                </svg>
+            )}
+            {label}
+        </button>
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Inline field error
+// ---------------------------------------------------------------------------
+
+function FieldError({ id, message }: { id: string; message?: string }) {
+    if (!message) return null;
+    return (
+        <p id={id} role="alert" className="mt-1 text-xs text-error">
+            {message}
+        </p>
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Main form
+// ---------------------------------------------------------------------------
+
+interface ProfileSettingsFormProps {
+    defaultValues?: {
+        displayName?: string;
+        email?: string;
+        bio?: string;
+        avatarUrl?: string;
+    };
+}
+
+export default function ProfileSettingsForm({ defaultValues }: ProfileSettingsFormProps) {
+    const [state, formAction] = useFormState(updateProfileAction, initialState);
+    const [savedRecently, setSavedRecently] = useState(false);
+    const timerRef = useRef<ReturnType<typeof setTimeout>>();
+
+    // Flash "Saved!" for 2 seconds after a successful save
+    useEffect(() => {
+        if (state.status === 'success') {
+            setSavedRecently(true);
+            timerRef.current = setTimeout(() => setSavedRecently(false), 2000);
+        }
+        return () => clearTimeout(timerRef.current);
+    }, [state]);
+
+    const inputClasses =
+        'w-full rounded-lg border border-outline-variant bg-surface-container-lowest ' +
+        'px-3 py-2 text-sm text-on-surface shadow-sm placeholder:text-on-surface-variant/50 ' +
+        'focus:outline-none focus:ring-2 focus:ring-surface-tint focus:border-surface-tint ' +
+        'disabled:opacity-50 transition-colors';
+
+    const labelClasses = 'block text-sm font-medium text-on-surface mb-1';
+
+    return (
+        <form action={formAction} noValidate className="space-y-6">
+            {/* Form-level banner */}
+            {state.status === 'error' && !state.fieldErrors && (
+                <div role="alert" className="rounded-lg bg-error-container/50 border border-error/20 px-4 py-3">
+                    <p className="text-sm text-on-error-container">{state.message}</p>
+                </div>
+            )}
+
+            {state.status === 'success' && (
+                <div role="status" className="rounded-lg bg-green-50 border border-green-200 px-4 py-3">
+                    <p className="text-sm text-green-800">{state.message}</p>
+                </div>
+            )}
+
+            {/* Display Name */}
+            <div>
+                <label htmlFor="displayName" className={labelClasses}>
+                    Display name <span aria-hidden="true" className="text-error">*</span>
+                </label>
+                <input
+                    id="displayName"
+                    name="displayName"
+                    type="text"
+                    required
+                    aria-required="true"
+                    aria-describedby={state.fieldErrors?.displayName ? 'displayName-error' : undefined}
+                    aria-invalid={!!state.fieldErrors?.displayName}
+                    defaultValue={defaultValues?.displayName ?? ''}
+                    placeholder="Your display name"
+                    className={`${inputClasses} ${state.fieldErrors?.displayName ? 'border-error focus:ring-error' : ''}`}
+                />
+                <FieldError id="displayName-error" message={state.fieldErrors?.displayName} />
+            </div>
+
+            {/* Email (read-only) */}
+            <div>
+                <label htmlFor="email" className={labelClasses}>
+                    Email address
+                </label>
+                <input
+                    id="email"
+                    name="email"
+                    type="email"
+                    disabled
+                    readOnly
+                    value={defaultValues?.email ?? ''}
+                    className={`${inputClasses} cursor-not-allowed`}
+                />
+                <p className="mt-1 text-xs text-on-surface-variant">
+                    Email cannot be changed here. Contact support if you need to update it.
+                </p>
+            </div>
+
+            {/* Bio */}
+            <div>
+                <label htmlFor="bio" className={labelClasses}>
+                    Bio
+                </label>
+                <textarea
+                    id="bio"
+                    name="bio"
+                    rows={3}
+                    maxLength={160}
+                    aria-describedby={state.fieldErrors?.bio ? 'bio-error' : 'bio-hint'}
+                    aria-invalid={!!state.fieldErrors?.bio}
+                    defaultValue={defaultValues?.bio ?? ''}
+                    placeholder="A short bio about yourself (max 160 characters)"
+                    className={`${inputClasses} resize-none ${state.fieldErrors?.bio ? 'border-error focus:ring-error' : ''}`}
+                />
+                {state.fieldErrors?.bio
+                    ? <FieldError id="bio-error" message={state.fieldErrors.bio} />
+                    : <p id="bio-hint" className="mt-1 text-xs text-on-surface-variant">160 characters max</p>
+                }
+            </div>
+
+            {/* Avatar URL */}
+            <div>
+                <label htmlFor="avatarUrl" className={labelClasses}>
+                    Avatar URL
+                </label>
+                <input
+                    id="avatarUrl"
+                    name="avatarUrl"
+                    type="url"
+                    aria-describedby={state.fieldErrors?.avatarUrl ? 'avatarUrl-error' : undefined}
+                    aria-invalid={!!state.fieldErrors?.avatarUrl}
+                    defaultValue={defaultValues?.avatarUrl ?? ''}
+                    placeholder="https://example.com/avatar.jpg"
+                    className={`${inputClasses} ${state.fieldErrors?.avatarUrl ? 'border-error focus:ring-error' : ''}`}
+                />
+                <FieldError id="avatarUrl-error" message={state.fieldErrors?.avatarUrl} />
+            </div>
+
+            {/* Actions */}
+            <div className="flex items-center justify-end pt-2">
+                <SaveButton savedRecently={savedRecently} />
+            </div>
+        </form>
+    );
+}

--- a/apps/web/src/app/app/settings/profile/actions.test.ts
+++ b/apps/web/src/app/app/settings/profile/actions.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock fetch globally
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+// Import after stubbing globals
+const { updateProfileAction } = await import('./actions');
+
+const idle = { status: 'idle' as const, message: '' };
+
+function makeFormData(fields: Record<string, string>): FormData {
+    const fd = new FormData();
+    for (const [k, v] of Object.entries(fields)) fd.append(k, v);
+    return fd;
+}
+
+describe('updateProfileAction', () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    // ------------------------------------------------------------------
+    // Validation errors (Zod)
+    // ------------------------------------------------------------------
+
+    it('returns field error when displayName is missing', async () => {
+        const result = await updateProfileAction(
+            idle,
+            makeFormData({ displayName: '', bio: '', avatarUrl: '' }),
+        );
+        expect(result.status).toBe('error');
+        expect(result.fieldErrors?.displayName).toBeDefined();
+        expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('returns field error when displayName is too short', async () => {
+        const result = await updateProfileAction(
+            idle,
+            makeFormData({ displayName: 'A', bio: '', avatarUrl: '' }),
+        );
+        expect(result.status).toBe('error');
+        expect(result.fieldErrors?.displayName).toMatch(/at least 2/i);
+        expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('returns field error when avatarUrl is invalid', async () => {
+        const result = await updateProfileAction(
+            idle,
+            makeFormData({
+                displayName: 'Jane Doe',
+                bio: '',
+                avatarUrl: 'not-a-url',
+            }),
+        );
+        expect(result.status).toBe('error');
+        expect(result.fieldErrors?.avatarUrl).toMatch(/valid URL/i);
+        expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    // ------------------------------------------------------------------
+    // Success
+    // ------------------------------------------------------------------
+
+    it('returns success on valid profile update', async () => {
+        mockFetch.mockResolvedValue({
+            ok: true,
+            status: 200,
+            json: async () => ({ displayName: 'Jane Doe' }),
+        });
+
+        const result = await updateProfileAction(
+            idle,
+            makeFormData({
+                displayName: 'Jane Doe',
+                bio: 'Hello world',
+                avatarUrl: '',
+            }),
+        );
+        expect(result.status).toBe('success');
+        expect(result.message).toMatch(/updated/i);
+    });
+
+    // ------------------------------------------------------------------
+    // Network error
+    // ------------------------------------------------------------------
+
+    it('returns network error when fetch throws', async () => {
+        mockFetch.mockRejectedValue(new Error('ECONNREFUSED'));
+
+        const result = await updateProfileAction(
+            idle,
+            makeFormData({
+                displayName: 'Jane Doe',
+                bio: '',
+                avatarUrl: '',
+            }),
+        );
+        expect(result.status).toBe('error');
+        expect(result.message).toMatch(/network error/i);
+    });
+
+    // ------------------------------------------------------------------
+    // API error (non-200)
+    // ------------------------------------------------------------------
+
+    it('returns API error on non-200 response', async () => {
+        mockFetch.mockResolvedValue({
+            ok: false,
+            status: 500,
+            json: async () => ({ error: 'Internal server error' }),
+        });
+
+        const result = await updateProfileAction(
+            idle,
+            makeFormData({
+                displayName: 'Jane Doe',
+                bio: '',
+                avatarUrl: '',
+            }),
+        );
+        expect(result.status).toBe('error');
+        expect(result.message).toBe('Internal server error');
+    });
+});

--- a/apps/web/src/app/app/settings/profile/actions.ts
+++ b/apps/web/src/app/app/settings/profile/actions.ts
@@ -1,0 +1,133 @@
+'use server';
+
+import { z } from 'zod';
+
+// ---------------------------------------------------------------------------
+// State types
+// ---------------------------------------------------------------------------
+
+export interface ProfileState {
+    status: 'idle' | 'success' | 'error';
+    message: string;
+    fieldErrors?: Record<string, string>;
+}
+
+// ---------------------------------------------------------------------------
+// Zod schema
+// ---------------------------------------------------------------------------
+
+export const profileSchema = z.object({
+    displayName: z
+        .string({ required_error: 'Display name is required.' })
+        .trim()
+        .min(2, 'Display name must be at least 2 characters.'),
+    bio: z
+        .string()
+        .max(160, 'Bio must be 160 characters or fewer.')
+        .optional()
+        .default(''),
+    avatarUrl: z
+        .string()
+        .url('Avatar URL must be a valid URL.')
+        .optional()
+        .or(z.literal('')),
+});
+
+// ---------------------------------------------------------------------------
+// Server Action: Fetch profile
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetches the current user profile from GET /api/profile.
+ * Returns a ProfileState with `data` merged into the message on success,
+ * or an error state on failure.
+ */
+export async function fetchProfileAction(): Promise<
+    ProfileState & { data?: Record<string, string> }
+> {
+    const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? 'http://localhost:3000';
+
+    let res: Response;
+    try {
+        res = await fetch(`${baseUrl}/api/profile`, { method: 'GET' });
+    } catch {
+        return { status: 'error', message: 'Network error. Please try again.' };
+    }
+
+    if (res.ok) {
+        const data = await res.json().catch(() => ({}));
+        return { status: 'success', message: '', data };
+    }
+
+    const body = await res.json().catch(() => ({}));
+    return {
+        status: 'error',
+        message: body.error ?? 'Failed to load profile. Please try again.',
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Server Action: Update profile
+// ---------------------------------------------------------------------------
+
+/**
+ * Server Action: validates form data with Zod then calls PUT /api/profile.
+ * Returns a serialisable state object consumed by the ProfileSettingsForm
+ * client component.
+ *
+ * Error copy mapping:
+ *  - Zod validation → field-level errors in `fieldErrors`
+ *  - Network error  → "Network error. Please try again."
+ *  - Non-200 API    → API message or generic fallback
+ *  - 200            → "Profile updated successfully."
+ */
+export async function updateProfileAction(
+    _prev: ProfileState,
+    formData: FormData,
+): Promise<ProfileState> {
+    const raw = {
+        displayName: formData.get('displayName') as string,
+        bio: (formData.get('bio') as string) ?? '',
+        avatarUrl: (formData.get('avatarUrl') as string) ?? '',
+    };
+
+    // Zod validation
+    const parsed = profileSchema.safeParse(raw);
+    if (!parsed.success) {
+        const fieldErrors: Record<string, string> = {};
+        for (const issue of parsed.error.issues) {
+            const key = issue.path[0] as string;
+            if (!fieldErrors[key]) {
+                fieldErrors[key] = issue.message;
+            }
+        }
+        return {
+            status: 'error',
+            message: 'Please fix the errors below.',
+            fieldErrors,
+        };
+    }
+
+    const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? 'http://localhost:3000';
+
+    let res: Response;
+    try {
+        res = await fetch(`${baseUrl}/api/profile`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(parsed.data),
+        });
+    } catch {
+        return { status: 'error', message: 'Network error. Please try again.' };
+    }
+
+    if (res.ok) {
+        return { status: 'success', message: 'Profile updated successfully.' };
+    }
+
+    const body = await res.json().catch(() => ({}));
+    return {
+        status: 'error',
+        message: body.error ?? 'Something went wrong. Please try again.',
+    };
+}

--- a/apps/web/src/app/app/settings/profile/page.tsx
+++ b/apps/web/src/app/app/settings/profile/page.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import { AppShell } from '@/components/app';
+import { User, NavItem } from '@/types/navigation';
+import ProfileSettingsForm from './ProfileSettingsForm';
+
+// Re-use the same shell data as the main app page
+const mockUser: User = {
+    id: '1',
+    name: 'John Doe',
+    email: 'john@example.com',
+    role: 'user',
+};
+
+const navItems: NavItem[] = [
+    {
+        id: 'home',
+        label: 'Home',
+        icon: (
+            <svg fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
+            </svg>
+        ),
+        path: '/app',
+    },
+    {
+        id: 'templates',
+        label: 'Templates',
+        icon: (
+            <svg fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+            </svg>
+        ),
+        path: '/app/templates',
+        badge: 3,
+    },
+    {
+        id: 'deployments',
+        label: 'Deployments',
+        icon: (
+            <svg fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
+            </svg>
+        ),
+        path: '/app/deployments',
+    },
+    {
+        id: 'settings',
+        label: 'Settings',
+        icon: (
+            <svg fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+            </svg>
+        ),
+        path: '/app/settings/profile',
+    },
+];
+
+export default function ProfileSettingsPage() {
+    return (
+        <AppShell
+            user={mockUser}
+            navItems={navItems}
+            breadcrumbs={[
+                { label: 'Home', path: '/app' },
+                { label: 'Settings', path: '/app/settings/profile' },
+                { label: 'Profile' },
+            ]}
+            status="operational"
+        >
+            <div className="p-6 lg:p-8">
+                <div className="max-w-2xl mx-auto">
+                    {/* Page Header */}
+                    <div className="mb-8">
+                        <h1 className="text-3xl font-bold font-headline text-on-surface mb-1">
+                            Profile Settings
+                        </h1>
+                        <p className="text-on-surface-variant">
+                            Manage your personal information and preferences.
+                        </p>
+                    </div>
+
+                    {/* Settings Card */}
+                    <div className="bg-surface-container-lowest rounded-xl border border-outline-variant/10 p-6 sm:p-8 shadow-sm">
+                        <ProfileSettingsForm
+                            defaultValues={{
+                                displayName: mockUser.name,
+                                email: mockUser.email,
+                                bio: '',
+                                avatarUrl: mockUser.avatar ?? '',
+                            }}
+                        />
+                    </div>
+                </div>
+            </div>
+        </AppShell>
+    );
+}


### PR DESCRIPTION
## Summary
Implements issue-009: Profile Settings Page for the CRAFT web app.

## Changes
- New profile settings page under the authenticated app shell
- Reusable ProfileSettingsForm component with display name, email (read-only), bio, and avatar URL fields
- Zod validation with inline field-level error messages
- Optimistic save feedback (Saving... → Saved!)
- Server actions for profile fetch and update following existing repo patterns
- Responsive and accessible (labels, ARIA attributes, keyboard navigation, focus rings)

## Tests
- 6/6 new profile action tests passing
- No regressions on existing tests

Closes #9 