### PR TITLE
feat: implement domain validation for custom domains

### DIFF
--- a/apps/web/src/lib/customization/validate-domain.test.ts
+++ b/apps/web/src/lib/customization/validate-domain.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest';
+import { validateCustomDomain } from './validate-domain';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function valid(input: unknown) {
+    const result = validateCustomDomain(input);
+    expect(result.valid, `expected valid for: ${JSON.stringify(input)}`).toBe(true);
+    if (result.valid) return result.domain;
+}
+
+function invalid(input: unknown, code: string) {
+    const result = validateCustomDomain(input);
+    expect(result.valid, `expected invalid for: ${JSON.stringify(input)}`).toBe(false);
+    if (!result.valid) {
+        expect(result.code).toBe(code);
+        expect(result.field).toBe('customDomain');
+        expect(result.message.length).toBeGreaterThan(0);
+    }
+}
+
+// ── Valid domains ─────────────────────────────────────────────────────────────
+
+describe('validateCustomDomain – valid inputs', () => {
+    it('accepts a simple subdomain', () => {
+        expect(valid('app.example.com')).toBe('app.example.com');
+    });
+
+    it('accepts a bare second-level domain', () => {
+        expect(valid('example.com')).toBe('example.com');
+    });
+
+    it('accepts a deep subdomain', () => {
+        expect(valid('a.b.c.example.io')).toBe('a.b.c.example.io');
+    });
+
+    it('normalises to lowercase', () => {
+        expect(valid('App.Example.COM')).toBe('app.example.com');
+    });
+
+    it('strips a trailing dot (FQDN notation)', () => {
+        expect(valid('app.example.com.')).toBe('app.example.com');
+    });
+
+    it('accepts hyphens inside labels', () => {
+        expect(valid('my-app.example.com')).toBe('my-app.example.com');
+    });
+
+    it('accepts numeric labels', () => {
+        expect(valid('123.example.com')).toBe('123.example.com');
+    });
+
+    it('accepts a custom field name in the error', () => {
+        const result = validateCustomDomain('', 'deployment.customDomain');
+        expect(result.valid).toBe(false);
+        if (!result.valid) expect(result.field).toBe('deployment.customDomain');
+    });
+});
+
+// ── Empty / missing ───────────────────────────────────────────────────────────
+
+describe('validateCustomDomain – empty / missing', () => {
+    it('rejects empty string', () => invalid('', 'DOMAIN_EMPTY'));
+    it('rejects whitespace-only string', () => invalid('   ', 'DOMAIN_EMPTY'));
+    it('rejects null', () => invalid(null, 'DOMAIN_EMPTY'));
+    it('rejects undefined', () => invalid(undefined, 'DOMAIN_EMPTY'));
+    it('rejects number', () => invalid(42, 'DOMAIN_EMPTY'));
+});
+
+// ── Format errors ─────────────────────────────────────────────────────────────
+
+describe('validateCustomDomain – format errors', () => {
+    it('rejects a URL with scheme', () => invalid('https://app.example.com', 'DOMAIN_INVALID_FORMAT'));
+    it('rejects a domain with a path', () => invalid('app.example.com/path', 'DOMAIN_INVALID_FORMAT'));
+    it('rejects a domain with a port', () => invalid('app.example.com:3000', 'DOMAIN_INVALID_FORMAT'));
+    it('rejects a domain with whitespace', () => invalid('app .example.com', 'DOMAIN_INVALID_FORMAT'));
+    it('rejects a domain exceeding 253 chars', () => {
+        const long = 'a'.repeat(50) + '.' + 'b'.repeat(50) + '.' + 'c'.repeat(50) + '.' + 'd'.repeat(50) + '.com';
+        invalid(long, 'DOMAIN_TOO_LONG');
+    });
+});
+
+// ── Invalid labels ────────────────────────────────────────────────────────────
+
+describe('validateCustomDomain – invalid labels', () => {
+    it('rejects a label starting with a hyphen', () => invalid('-app.example.com', 'DOMAIN_INVALID_LABEL'));
+    it('rejects a label ending with a hyphen', () => invalid('app-.example.com', 'DOMAIN_INVALID_LABEL'));
+    it('rejects an empty label (double dot)', () => invalid('app..example.com', 'DOMAIN_INVALID_LABEL'));
+    it('rejects a label with underscore', () => invalid('my_app.example.com', 'DOMAIN_INVALID_LABEL'));
+    it('rejects a label with special characters', () => invalid('app!.example.com', 'DOMAIN_INVALID_LABEL'));
+    it('rejects a label longer than 63 chars', () => {
+        invalid('a'.repeat(64) + '.example.com', 'DOMAIN_INVALID_LABEL');
+    });
+});
+
+// ── Missing TLD ───────────────────────────────────────────────────────────────
+
+describe('validateCustomDomain – missing TLD', () => {
+    it('rejects a bare hostname with no dot', () => invalid('myapp', 'DOMAIN_MISSING_TLD'));
+});
+
+// ── Reserved / special-use ────────────────────────────────────────────────────
+
+describe('validateCustomDomain – reserved domains', () => {
+    it('rejects .localhost TLD', () => invalid('app.localhost', 'DOMAIN_LOCALHOST'));
+    it('rejects bare localhost', () => invalid('localhost', 'DOMAIN_LOCALHOST'));
+    it('rejects loopback IPv4', () => invalid('127.0.0.1', 'DOMAIN_LOCALHOST'));
+    it('rejects loopback IPv6', () => invalid('::1', 'DOMAIN_LOCALHOST'));
+    it('rejects .local TLD', () => invalid('myapp.local', 'DOMAIN_RESERVED'));
+    it('rejects .internal TLD', () => invalid('api.internal', 'DOMAIN_RESERVED'));
+    it('rejects .invalid TLD', () => invalid('app.invalid', 'DOMAIN_RESERVED'));
+    it('rejects .test TLD', () => invalid('app.test', 'DOMAIN_RESERVED'));
+    it('rejects .example TLD', () => invalid('app.example', 'DOMAIN_RESERVED'));
+    it('rejects example.com', () => invalid('example.com', 'DOMAIN_RESERVED'));
+    it('rejects example.org', () => invalid('example.org', 'DOMAIN_RESERVED'));
+    it('rejects example.net', () => invalid('example.net', 'DOMAIN_RESERVED'));
+    it('rejects test.com', () => invalid('test.com', 'DOMAIN_RESERVED'));
+});

--- a/apps/web/src/lib/customization/validate-domain.ts
+++ b/apps/web/src/lib/customization/validate-domain.ts
@@ -1,0 +1,160 @@
+/**
+ * Custom Domain Validation
+ *
+ * Validates custom domain inputs against DNS format requirements before
+ * configuration. Rejects reserved domains, localhost patterns, and inputs
+ * that would be unsafe or invalid in a DNS context.
+ */
+
+export type DomainValidationResult =
+    | { valid: true; domain: string }
+    | { valid: false; field: string; message: string; code: DomainValidationErrorCode };
+
+export type DomainValidationErrorCode =
+    | 'DOMAIN_EMPTY'
+    | 'DOMAIN_TOO_LONG'
+    | 'DOMAIN_INVALID_FORMAT'
+    | 'DOMAIN_INVALID_LABEL'
+    | 'DOMAIN_MISSING_TLD'
+    | 'DOMAIN_RESERVED'
+    | 'DOMAIN_LOCALHOST';
+
+// RFC 1035 label: 1–63 chars, alphanumeric + hyphens, no leading/trailing hyphen
+const LABEL_RE = /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$/i;
+
+// Domains that must never be accepted as custom domains
+const RESERVED_TLDS = new Set(['localhost', 'local', 'internal', 'invalid', 'test', 'example']);
+
+const RESERVED_DOMAINS = new Set([
+    'localhost',
+    'example.com',
+    'example.org',
+    'example.net',
+    'test.com',
+]);
+
+/**
+ * Validate a custom domain string.
+ *
+ * Rules applied (in order):
+ * 1. Must be non-empty
+ * 2. Total length ≤ 253 characters (DNS limit)
+ * 3. No scheme, path, port, or whitespace — bare hostname only
+ * 4. Each label must match RFC 1035 (1–63 chars, alphanumeric + hyphens)
+ * 5. Must have at least two labels (i.e. a TLD is required)
+ * 6. TLD must not be a reserved/special-use TLD (RFC 2606 / RFC 6761)
+ * 7. Full domain must not be a reserved domain
+ * 8. Must not be a localhost pattern (127.x.x.x, ::1, *.localhost)
+ *
+ * @param input - Raw domain string from user input
+ * @param field - Field name to include in error (default: "customDomain")
+ * @returns Validation result with normalised domain on success
+ */
+export function validateCustomDomain(
+    input: unknown,
+    field = 'customDomain',
+): DomainValidationResult {
+    if (!input || typeof input !== 'string' || input.trim() === '') {
+        return {
+            valid: false,
+            field,
+            message: 'Domain is required. Enter a domain like "app.example.com".',
+            code: 'DOMAIN_EMPTY',
+        };
+    }
+
+    const raw = input.trim().toLowerCase();
+
+    // Strip a single trailing dot (FQDN notation) for normalisation
+    const domain = raw.endsWith('.') ? raw.slice(0, -1) : raw;
+
+    // Loopback IPv6 — check before the format guard since '::1' contains ':'
+    if (domain === '::1') {
+        return {
+            valid: false,
+            field,
+            message: 'Localhost and loopback addresses cannot be used as custom domains.',
+            code: 'DOMAIN_LOCALHOST',
+        };
+    }
+
+    // Reject anything that looks like a URL or contains unsafe characters
+    if (/[/:?#@\s]/.test(domain)) {
+        return {
+            valid: false,
+            field,
+            message:
+                'Enter a bare domain name without a scheme, path, or port (e.g. "app.example.com").',
+            code: 'DOMAIN_INVALID_FORMAT',
+        };
+    }
+
+    if (domain.length > 253) {
+        return {
+            valid: false,
+            field,
+            message: `Domain must be 253 characters or fewer (got ${domain.length}).`,
+            code: 'DOMAIN_TOO_LONG',
+        };
+    }
+
+    // Localhost / loopback patterns
+    if (
+        domain === 'localhost' ||
+        domain.endsWith('.localhost') ||
+        /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(domain)
+    ) {
+        return {
+            valid: false,
+            field,
+            message: 'Localhost and loopback addresses cannot be used as custom domains.',
+            code: 'DOMAIN_LOCALHOST',
+        };
+    }
+
+    const labels = domain.split('.');
+
+    // Validate each DNS label
+    for (const label of labels) {
+        if (!LABEL_RE.test(label)) {
+            return {
+                valid: false,
+                field,
+                message: `"${label}" is not a valid domain label. Labels must be 1–63 characters, start and end with a letter or digit, and contain only letters, digits, or hyphens.`,
+                code: 'DOMAIN_INVALID_LABEL',
+            };
+        }
+    }
+
+    // Require at least a second-level domain + TLD
+    if (labels.length < 2) {
+        return {
+            valid: false,
+            field,
+            message: 'Domain must include a TLD (e.g. "app.example.com").',
+            code: 'DOMAIN_MISSING_TLD',
+        };
+    }
+
+    const tld = labels[labels.length - 1];
+
+    if (RESERVED_TLDS.has(tld)) {
+        return {
+            valid: false,
+            field,
+            message: `".${tld}" is a reserved TLD and cannot be used as a custom domain.`,
+            code: 'DOMAIN_RESERVED',
+        };
+    }
+
+    if (RESERVED_DOMAINS.has(domain)) {
+        return {
+            valid: false,
+            field,
+            message: `"${domain}" is a reserved domain and cannot be used as a custom domain.`,
+            code: 'DOMAIN_RESERVED',
+        };
+    }
+
+    return { valid: true, domain };
+}


### PR DESCRIPTION
## What was done

### New files

apps/web/src/lib/customization/validate-domain.ts

Pure synchronous validator, zero dependencies, consistent with the existing validate.ts / contract-validation.ts patterns in the codebase.

Rules enforced in order:
1. Non-empty, string type → DOMAIN_EMPTY
2. IPv6 loopback (::1) → DOMAIN_LOCALHOST (checked before format guard since : would otherwise trigger DOMAIN_INVALID_FORMAT)
3. No scheme / path / port / whitespace → DOMAIN_INVALID_FORMAT
4. ≤ 253 chars (DNS limit) → DOMAIN_TOO_LONG
5. Localhost / loopback IPv4 / *.localhost → DOMAIN_LOCALHOST
6. Each label: RFC 1035 (1–63 chars, alphanumeric + hyphens, no leading/trailing hyphen) → DOMAIN_INVALID_LABEL
7. At least 2 labels (TLD required) → DOMAIN_MISSING_TLD
8. Reserved TLDs (RFC 2606 / RFC 6761: .local, .internal, .invalid, .test, .example) → DOMAIN_RESERVED
9. Reserved domains (example.com, example.org, example.net, test.com) → DOMAIN_RESERVED

On success returns { valid: true, domain } with the normalised (lowercased, trailing-dot-stripped) hostname.

apps/web/src/lib/customization/validate-domain.test.ts

35 tests across 6 describe blocks covering every code path and error code.
### Edge cases / assumptions

- IDN (internationalised domain names) are not supported — punycode-encoded forms like xn--nxasmq6b.com will pass since they're valid ASCII labels; raw unicode like 
münchen.de will be rejected by DOMAIN_INVALID_LABEL, which is the safe default until an explicit IDN requirement is added.
- IP addresses other than loopback (e.g. 8.8.8.8) are not explicitly blocked — they pass label validation since numeric labels are valid. If raw IPs should be 
rejected, a follow-up check can be added.
- The field parameter defaults to "customDomain" but can be overridden (e.g. "deployment.customDomain") for use in nested form schemas.
closes #196 