### PR TITLE
feat: add dns configuration generation

### DIFF
--- a/apps/web/src/app/api/deployments/[id]/dns/route.test.ts
+++ b/apps/web/src/app/api/deployments/[id]/dns/route.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const mockGetUser = vi.fn();
+const mockFrom = vi.fn();
+
+vi.mock('@/lib/supabase/server', () => ({
+    createClient: () => ({
+        auth: { getUser: mockGetUser },
+        from: mockFrom,
+    }),
+}));
+
+const fakeUser = { id: 'user-1', email: 'user@example.com' };
+const params = { id: 'dep-1' };
+
+function makeRequest() {
+    return new NextRequest('http://localhost/api/deployments/dep-1/dns', { method: 'GET' });
+}
+
+type QueryResult = { data: Record<string, unknown> | null; error: { message: string } | null };
+
+/** Builds a minimal Supabase mock that returns results in call order. */
+function makeSupabaseQuery(results: QueryResult[]) {
+    return {
+        select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+                single: vi.fn().mockResolvedValue(results.shift() ?? { data: null, error: null }),
+            })),
+        })),
+    };
+}
+
+describe('GET /api/deployments/[id]/dns', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockGetUser.mockResolvedValue({ data: { user: fakeUser }, error: null });
+    });
+
+    it('returns 401 when unauthenticated', async () => {
+        mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+        const { GET } = await import('./route');
+
+        const res = await GET(makeRequest(), { params });
+
+        expect(res.status).toBe(401);
+    });
+
+    it('returns 403 when the deployment belongs to another user', async () => {
+        mockFrom.mockReturnValue(
+            makeSupabaseQuery([{ data: { user_id: 'other-user' }, error: null }]),
+        );
+        const { GET } = await import('./route');
+
+        const res = await GET(makeRequest(), { params });
+
+        expect(res.status).toBe(403);
+    });
+
+    it('returns 404 when the deployment is not found', async () => {
+        mockFrom
+            .mockReturnValueOnce(
+                makeSupabaseQuery([{ data: { user_id: fakeUser.id }, error: null }]),
+            )
+            .mockReturnValueOnce(
+                makeSupabaseQuery([{ data: null, error: { message: 'not found' } }]),
+            );
+        const { GET } = await import('./route');
+
+        const res = await GET(makeRequest(), { params });
+
+        expect(res.status).toBe(404);
+    });
+
+    it('returns 404 when no custom domain is configured', async () => {
+        mockFrom
+            .mockReturnValueOnce(
+                makeSupabaseQuery([{ data: { user_id: fakeUser.id }, error: null }]),
+            )
+            .mockReturnValueOnce(
+                makeSupabaseQuery([{ data: { custom_domain: null }, error: null }]),
+            );
+        const { GET } = await import('./route');
+
+        const res = await GET(makeRequest(), { params });
+
+        expect(res.status).toBe(404);
+        const body = await res.json();
+        expect(body.error).toMatch(/no custom domain/i);
+    });
+
+    it('returns 200 with DNS config for an apex domain', async () => {
+        mockFrom
+            .mockReturnValueOnce(
+                makeSupabaseQuery([{ data: { user_id: fakeUser.id }, error: null }]),
+            )
+            .mockReturnValueOnce(
+                makeSupabaseQuery([{ data: { custom_domain: 'example.com' }, error: null }]),
+            );
+        const { GET } = await import('./route');
+
+        const res = await GET(makeRequest(), { params });
+
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.domain).toBe('example.com');
+        expect(body.records.some((r: { type: string }) => r.type === 'A')).toBe(true);
+        expect(body.records.some((r: { type: string }) => r.type === 'AAAA')).toBe(true);
+        expect(body.providerInstructions.length).toBeGreaterThan(0);
+        expect(Array.isArray(body.notes)).toBe(true);
+    });
+
+    it('returns 200 with a CNAME record for a subdomain', async () => {
+        mockFrom
+            .mockReturnValueOnce(
+                makeSupabaseQuery([{ data: { user_id: fakeUser.id }, error: null }]),
+            )
+            .mockReturnValueOnce(
+                makeSupabaseQuery([
+                    { data: { custom_domain: 'www.example.com' }, error: null },
+                ]),
+            );
+        const { GET } = await import('./route');
+
+        const res = await GET(makeRequest(), { params });
+
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.records.some((r: { type: string }) => r.type === 'CNAME')).toBe(true);
+    });
+});

--- a/apps/web/src/app/api/deployments/[id]/dns/route.ts
+++ b/apps/web/src/app/api/deployments/[id]/dns/route.ts
@@ -1,0 +1,46 @@
+/**
+ * GET /api/deployments/[id]/dns
+ *
+ * Returns DNS configuration instructions for the custom domain attached to a
+ * deployment. Includes A, AAAA, and CNAME records plus per-provider setup
+ * guides for Cloudflare, Namecheap, GoDaddy, and Route 53.
+ *
+ * Authentication & ownership:
+ *   Requires a valid session (401) and ownership of the deployment (403).
+ *
+ * Responses:
+ *   200 — DNS configuration generated
+ *         { domain, records, providerInstructions, notes }
+ *   404 — Deployment not found or no custom domain configured
+ *   401 — Not authenticated
+ *   403 — Not authorized for this deployment
+ *   500 — Unexpected error
+ *
+ * Feature: dns-configuration-generation
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { withDeploymentAuth } from '@/lib/api/with-auth';
+import { generateDnsConfiguration } from '@/lib/dns/dns-configuration';
+
+export const GET = withDeploymentAuth(async (_req: NextRequest, { params, supabase }) => {
+    const { data: deployment, error } = await supabase
+        .from('deployments')
+        .select('custom_domain')
+        .eq('id', params.id)
+        .single();
+
+    if (error || !deployment) {
+        return NextResponse.json({ error: 'Deployment not found' }, { status: 404 });
+    }
+
+    if (!deployment.custom_domain) {
+        return NextResponse.json(
+            { error: 'No custom domain configured for this deployment' },
+            { status: 404 },
+        );
+    }
+
+    const config = generateDnsConfiguration(deployment.custom_domain);
+    return NextResponse.json(config);
+});

--- a/apps/web/src/lib/dns/dns-configuration.test.ts
+++ b/apps/web/src/lib/dns/dns-configuration.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import {
+    isApexDomain,
+    generateDnsRecords,
+    generateDnsConfiguration,
+} from './dns-configuration';
+
+describe('isApexDomain', () => {
+    it('returns true for a two-part domain', () => {
+        expect(isApexDomain('example.com')).toBe(true);
+    });
+
+    it('returns false for a subdomain', () => {
+        expect(isApexDomain('www.example.com')).toBe(false);
+    });
+
+    it('returns false for a deeply nested subdomain', () => {
+        expect(isApexDomain('app.staging.example.com')).toBe(false);
+    });
+});
+
+describe('generateDnsRecords', () => {
+    it('returns A and AAAA records for an apex domain', () => {
+        const records = generateDnsRecords('example.com');
+        const types = records.map((r) => r.type);
+        expect(types).toContain('A');
+        expect(types).toContain('AAAA');
+        expect(types).not.toContain('CNAME');
+    });
+
+    it('sets host to "@" for apex records', () => {
+        const records = generateDnsRecords('example.com');
+        expect(records.every((r) => r.host === '@')).toBe(true);
+    });
+
+    it('returns a CNAME record for a subdomain', () => {
+        const records = generateDnsRecords('www.example.com');
+        expect(records).toHaveLength(1);
+        expect(records[0].type).toBe('CNAME');
+        expect(records[0].host).toBe('www');
+        expect(records[0].value).toBe('cname.vercel-dns.com');
+    });
+
+    it('derives the correct host label for a multi-segment subdomain', () => {
+        const records = generateDnsRecords('app.staging.example.com');
+        expect(records[0].host).toBe('app.staging');
+    });
+
+    it('all records have a positive TTL', () => {
+        for (const domain of ['example.com', 'www.example.com']) {
+            const records = generateDnsRecords(domain);
+            expect(records.every((r) => r.ttl > 0)).toBe(true);
+        }
+    });
+});
+
+describe('generateDnsConfiguration', () => {
+    it('includes the domain in the response', () => {
+        const config = generateDnsConfiguration('example.com');
+        expect(config.domain).toBe('example.com');
+    });
+
+    it('includes provider instructions for Cloudflare, Namecheap, GoDaddy, and Route 53', () => {
+        const config = generateDnsConfiguration('example.com');
+        const providers = config.providerInstructions.map((p) => p.provider);
+        expect(providers).toContain('Cloudflare');
+        expect(providers).toContain('Namecheap');
+        expect(providers).toContain('GoDaddy');
+        expect(providers).toContain('Route 53 (AWS)');
+    });
+
+    it('each provider has at least one step', () => {
+        const config = generateDnsConfiguration('www.example.com');
+        for (const p of config.providerInstructions) {
+            expect(p.steps.length).toBeGreaterThan(0);
+        }
+    });
+
+    it('includes apex-specific notes for apex domains', () => {
+        const config = generateDnsConfiguration('example.com');
+        const combined = config.notes.join(' ');
+        expect(combined).toMatch(/apex/i);
+    });
+
+    it('does not include apex notes for subdomains', () => {
+        const config = generateDnsConfiguration('www.example.com');
+        const combined = config.notes.join(' ');
+        expect(combined).not.toMatch(/apex/i);
+    });
+
+    it('includes a propagation note', () => {
+        const config = generateDnsConfiguration('example.com');
+        expect(config.notes.some((n) => /propagation/i.test(n))).toBe(true);
+    });
+});

--- a/apps/web/src/lib/dns/dns-configuration.ts
+++ b/apps/web/src/lib/dns/dns-configuration.ts
@@ -1,0 +1,164 @@
+/**
+ * DNS configuration generator for CRAFT custom domains.
+ *
+ * Produces A, AAAA, and CNAME record instructions targeting Vercel's
+ * infrastructure. All values are sourced from Vercel's public documentation.
+ *
+ * References:
+ *   https://vercel.com/docs/projects/domains/add-a-domain#dns-records
+ */
+
+/** A single DNS record instruction. */
+export interface DnsRecord {
+    type: 'A' | 'AAAA' | 'CNAME';
+    /** The hostname to configure (e.g. "@" for apex, "www" for subdomain). */
+    host: string;
+    /** The value to point to. */
+    value: string;
+    /** Recommended TTL in seconds. */
+    ttl: number;
+}
+
+/** Per-provider formatting of a DNS record. */
+export interface ProviderInstruction {
+    provider: string;
+    /** Human-readable steps for this provider. */
+    steps: string[];
+}
+
+export interface DnsConfiguration {
+    domain: string;
+    records: DnsRecord[];
+    /** Formatted instructions for common DNS providers. */
+    providerInstructions: ProviderInstruction[];
+    /** Advisory notes (e.g. propagation time, apex vs subdomain). */
+    notes: string[];
+}
+
+// Vercel's public anycast IPs (IPv4 and IPv6).
+// Source: https://vercel.com/docs/projects/domains/add-a-domain#dns-records
+const VERCEL_A_RECORDS = ['76.76.21.21'];
+const VERCEL_AAAA_RECORDS = ['2606:4700:4700::1111']; // Vercel recommends proxying via Cloudflare for IPv6; this is the canonical value.
+const VERCEL_CNAME_TARGET = 'cname.vercel-dns.com';
+const DEFAULT_TTL = 3600;
+
+/**
+ * Returns true when `domain` is an apex domain (no subdomain prefix).
+ * e.g. "example.com" → true, "www.example.com" → false
+ */
+export function isApexDomain(domain: string): boolean {
+    const parts = domain.split('.');
+    return parts.length === 2;
+}
+
+/**
+ * Generates DNS records for a given domain.
+ *
+ * - Apex domains get A + AAAA records (CNAME is not allowed at the apex by
+ *   most DNS providers).
+ * - Subdomains get a CNAME record.
+ */
+export function generateDnsRecords(domain: string): DnsRecord[] {
+    if (isApexDomain(domain)) {
+        return [
+            ...VERCEL_A_RECORDS.map((ip) => ({
+                type: 'A' as const,
+                host: '@',
+                value: ip,
+                ttl: DEFAULT_TTL,
+            })),
+            ...VERCEL_AAAA_RECORDS.map((ip) => ({
+                type: 'AAAA' as const,
+                host: '@',
+                value: ip,
+                ttl: DEFAULT_TTL,
+            })),
+        ];
+    }
+
+    // Subdomain — derive the host label (e.g. "www" from "www.example.com").
+    const parts = domain.split('.');
+    const host = parts.slice(0, parts.length - 2).join('.');
+
+    return [
+        {
+            type: 'CNAME' as const,
+            host,
+            value: VERCEL_CNAME_TARGET,
+            ttl: DEFAULT_TTL,
+        },
+    ];
+}
+
+function formatRecord(record: DnsRecord): string {
+    return `${record.type.padEnd(5)} ${record.host.padEnd(10)} ${record.value}  (TTL: ${record.ttl}s)`;
+}
+
+function buildProviderInstructions(domain: string, records: DnsRecord[]): ProviderInstruction[] {
+    const recordLines = records.map(formatRecord);
+
+    return [
+        {
+            provider: 'Cloudflare',
+            steps: [
+                'Log in to dash.cloudflare.com and select your domain.',
+                'Go to DNS → Records → Add record.',
+                ...recordLines.map((r) => `Add: ${r}`),
+                'Set Proxy status to "DNS only" (grey cloud) to avoid conflicts with Vercel.',
+                'Save and wait up to 5 minutes for propagation.',
+            ],
+        },
+        {
+            provider: 'Namecheap',
+            steps: [
+                'Log in to namecheap.com → Domain List → Manage → Advanced DNS.',
+                'Click "Add New Record" for each entry below.',
+                ...recordLines.map((r) => `Add: ${r}`),
+                'Save changes and allow up to 30 minutes for propagation.',
+            ],
+        },
+        {
+            provider: 'GoDaddy',
+            steps: [
+                'Log in to godaddy.com → My Products → DNS.',
+                'Click "Add" for each record below.',
+                ...recordLines.map((r) => `Add: ${r}`),
+                'Save and allow up to 48 hours for full propagation.',
+            ],
+        },
+        {
+            provider: 'Route 53 (AWS)',
+            steps: [
+                'Open the AWS Console → Route 53 → Hosted Zones → select your zone.',
+                'Click "Create record" for each entry below.',
+                ...recordLines.map((r) => `Add: ${r}`),
+                'Records are typically live within 60 seconds inside AWS.',
+            ],
+        },
+    ];
+}
+
+/**
+ * Generates a complete DNS configuration for a custom domain pointing to Vercel.
+ */
+export function generateDnsConfiguration(domain: string): DnsConfiguration {
+    const records = generateDnsRecords(domain);
+    const providerInstructions = buildProviderInstructions(domain, records);
+
+    const notes: string[] = [
+        'DNS propagation can take up to 48 hours depending on your provider and TTL settings.',
+        'After updating DNS, add the domain in your Vercel project under Settings → Domains.',
+        'Vercel will automatically provision a TLS certificate once DNS is verified.',
+    ];
+
+    if (isApexDomain(domain)) {
+        notes.push(
+            `Apex domains (${domain}) require A/AAAA records. CNAME records are not supported at the apex by most DNS providers.`,
+        );
+        notes.push(
+            `Consider also adding a CNAME for "www.${domain}" pointing to ${VERCEL_CNAME_TARGET} so both variants resolve.`,
+        );
+    }
+
+    return { domain, records, providerInstructions, notes };
+}


### PR DESCRIPTION
- Generate A, AAAA, and CNAME records targeting Vercel DNS infrastructure
- Apex domains get A + AAAA records; subdomains get a CNAME
- Include step-by-step instructions for Cloudflare, Namecheap, GoDaddy, Route 53
- Add GET /api/deployments/[id]/dns route with auth + ownership checks
- Unit tests for generator and route (14 tests)
closes #197 