### PR TITLE
feat: add domain verification

### DIFF
--- a/apps/web/src/app/api/deployments/[id]/dns/verify/route.test.ts
+++ b/apps/web/src/app/api/deployments/[id]/dns/verify/route.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const mockGetUser = vi.fn();
+const mockFrom = vi.fn();
+const mockVerifyViaTxt = vi.fn();
+const mockVerifyViaCname = vi.fn();
+
+vi.mock('@/lib/supabase/server', () => ({
+    createClient: () => ({
+        auth: { getUser: mockGetUser },
+        from: mockFrom,
+    }),
+}));
+
+vi.mock('@/lib/dns/domain-verification', () => ({
+    verifyViaTxt: mockVerifyViaTxt,
+    verifyViaCname: mockVerifyViaCname,
+}));
+
+const fakeUser = { id: 'user-1', email: 'user@example.com' };
+const params = { id: 'dep-1' };
+
+function makeRequest(body: unknown) {
+    return new NextRequest('http://localhost/api/deployments/dep-1/dns/verify', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+    });
+}
+
+type QueryResult = { data: Record<string, unknown> | null; error: { message: string } | null };
+
+function makeSupabaseQuery(results: QueryResult[]) {
+    return {
+        select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+                single: vi.fn().mockResolvedValue(results.shift() ?? { data: null, error: null }),
+            })),
+        })),
+    };
+}
+
+describe('POST /api/deployments/[id]/dns/verify', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockGetUser.mockResolvedValue({ data: { user: fakeUser }, error: null });
+    });
+
+    it('returns 401 when unauthenticated', async () => {
+        mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+        const { POST } = await import('./route');
+        const res = await POST(makeRequest({ method: 'txt', token: 'tok' }), { params });
+        expect(res.status).toBe(401);
+    });
+
+    it('returns 403 when deployment belongs to another user', async () => {
+        mockFrom.mockReturnValue(
+            makeSupabaseQuery([{ data: { user_id: 'other' }, error: null }]),
+        );
+        const { POST } = await import('./route');
+        const res = await POST(makeRequest({ method: 'txt', token: 'tok' }), { params });
+        expect(res.status).toBe(403);
+    });
+
+    it('returns 400 for invalid method value', async () => {
+        mockFrom.mockReturnValue(
+            makeSupabaseQuery([{ data: { user_id: fakeUser.id }, error: null }]),
+        );
+        const { POST } = await import('./route');
+        const res = await POST(makeRequest({ method: 'invalid' }), { params });
+        expect(res.status).toBe(400);
+    });
+
+    it('returns 400 when method is txt but token is missing', async () => {
+        mockFrom.mockReturnValue(
+            makeSupabaseQuery([{ data: { user_id: fakeUser.id }, error: null }]),
+        );
+        const { POST } = await import('./route');
+        const res = await POST(makeRequest({ method: 'txt' }), { params });
+        expect(res.status).toBe(400);
+    });
+
+    it('returns 404 when deployment has no custom domain', async () => {
+        mockFrom
+            .mockReturnValueOnce(makeSupabaseQuery([{ data: { user_id: fakeUser.id }, error: null }]))
+            .mockReturnValueOnce(makeSupabaseQuery([{ data: { custom_domain: null }, error: null }]));
+        const { POST } = await import('./route');
+        const res = await POST(makeRequest({ method: 'txt', token: 'tok' }), { params });
+        expect(res.status).toBe(404);
+    });
+
+    it('calls verifyViaTxt and returns result for method=txt', async () => {
+        mockFrom
+            .mockReturnValueOnce(makeSupabaseQuery([{ data: { user_id: fakeUser.id }, error: null }]))
+            .mockReturnValueOnce(makeSupabaseQuery([{ data: { custom_domain: 'example.com' }, error: null }]));
+        mockVerifyViaTxt.mockResolvedValue({ verified: true, method: 'txt', domain: 'example.com' });
+
+        const { POST } = await import('./route');
+        const res = await POST(makeRequest({ method: 'txt', token: 'craft-abc' }), { params });
+
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.verified).toBe(true);
+        expect(mockVerifyViaTxt).toHaveBeenCalledWith('example.com', 'craft-abc');
+    });
+
+    it('calls verifyViaCname and returns result for method=cname', async () => {
+        mockFrom
+            .mockReturnValueOnce(makeSupabaseQuery([{ data: { user_id: fakeUser.id }, error: null }]))
+            .mockReturnValueOnce(makeSupabaseQuery([{ data: { custom_domain: 'www.example.com' }, error: null }]));
+        mockVerifyViaCname.mockResolvedValue({ verified: false, method: 'cname', domain: 'www.example.com', errorCode: 'NOT_FOUND' });
+
+        const { POST } = await import('./route');
+        const res = await POST(makeRequest({ method: 'cname' }), { params });
+
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.verified).toBe(false);
+        expect(body.errorCode).toBe('NOT_FOUND');
+        expect(mockVerifyViaCname).toHaveBeenCalledWith('www.example.com');
+    });
+});

--- a/apps/web/src/app/api/deployments/[id]/dns/verify/route.ts
+++ b/apps/web/src/app/api/deployments/[id]/dns/verify/route.ts
@@ -1,0 +1,92 @@
+/**
+ * POST /api/deployments/[id]/dns/verify
+ *
+ * Verifies domain ownership for the custom domain attached to a deployment.
+ * Supports TXT record and CNAME verification methods.
+ *
+ * Authentication & ownership:
+ *   Requires a valid session (401) and ownership of the deployment (403).
+ *
+ * Request body:
+ *   {
+ *     "method": "txt" | "cname"   — verification method
+ *     "token":  string            — required for method "txt"; the value the
+ *                                   user placed in their TXT record at
+ *                                   _craft-verify.<domain>
+ *   }
+ *
+ * Responses:
+ *   200 — Verification result (verified: true/false + details)
+ *   400 — Invalid request body
+ *   404 — Deployment not found or no custom domain configured
+ *   401 — Not authenticated
+ *   403 — Not authorized for this deployment
+ *   500 — Unexpected error
+ *
+ * Feature: domain-verification
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { withDeploymentAuth } from '@/lib/api/with-auth';
+import { verifyViaTxt, verifyViaCname } from '@/lib/dns/domain-verification';
+
+interface RequestBody {
+    method: 'txt' | 'cname';
+    token?: string;
+}
+
+function normalizeBody(raw: unknown): RequestBody | null {
+    if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) return null;
+    const body = raw as Record<string, unknown>;
+
+    if (body.method !== 'txt' && body.method !== 'cname') return null;
+    if (body.method === 'txt' && typeof body.token !== 'string') return null;
+    if (body.method === 'cname' && 'token' in body && typeof body.token !== 'string') return null;
+
+    return body as RequestBody;
+}
+
+export const POST = withDeploymentAuth(async (req: NextRequest, { params, supabase }) => {
+    let body: RequestBody;
+    try {
+        const raw = await req.json();
+        const normalized = normalizeBody(raw);
+        if (!normalized) {
+            return NextResponse.json({ error: 'Invalid request body' }, { status: 400 });
+        }
+        body = normalized;
+    } catch {
+        return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+    }
+
+    const { data: deployment, error } = await supabase
+        .from('deployments')
+        .select('custom_domain')
+        .eq('id', params.id)
+        .single();
+
+    if (error || !deployment) {
+        return NextResponse.json({ error: 'Deployment not found' }, { status: 404 });
+    }
+
+    if (!deployment.custom_domain) {
+        return NextResponse.json(
+            { error: 'No custom domain configured for this deployment' },
+            { status: 404 },
+        );
+    }
+
+    try {
+        const result =
+            body.method === 'txt'
+                ? await verifyViaTxt(deployment.custom_domain, body.token!)
+                : await verifyViaCname(deployment.custom_domain);
+
+        return NextResponse.json(result);
+    } catch (err: unknown) {
+        return NextResponse.json(
+            { error: (err as Error).message ?? 'Verification failed' },
+            { status: 500 },
+        );
+    }
+});

--- a/apps/web/src/lib/dns/domain-verification.test.ts
+++ b/apps/web/src/lib/dns/domain-verification.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import * as dnsPromises from 'node:dns/promises';
+
+// Mock the entire dns/promises module
+vi.mock('node:dns/promises', () => ({
+    default: {
+        resolveTxt: vi.fn(),
+        resolveCname: vi.fn(),
+    },
+}));
+
+import {
+    isValidDomain,
+    txtHostname,
+    verifyViaTxt,
+    verifyViaCname,
+} from './domain-verification';
+
+const mockDns = dnsPromises.default as {
+    resolveTxt: ReturnType<typeof vi.fn>;
+    resolveCname: ReturnType<typeof vi.fn>;
+};
+
+afterEach(() => vi.clearAllMocks());
+
+// ---------------------------------------------------------------------------
+// isValidDomain
+// ---------------------------------------------------------------------------
+describe('isValidDomain', () => {
+    it('accepts a plain domain', () => expect(isValidDomain('example.com')).toBe(true));
+    it('accepts a subdomain', () => expect(isValidDomain('www.example.com')).toBe(true));
+    it('rejects an empty string', () => expect(isValidDomain('')).toBe(false));
+    it('rejects a bare label', () => expect(isValidDomain('localhost')).toBe(false));
+    it('rejects a domain with spaces', () => expect(isValidDomain('ex ample.com')).toBe(false));
+});
+
+// ---------------------------------------------------------------------------
+// txtHostname
+// ---------------------------------------------------------------------------
+describe('txtHostname', () => {
+    it('prefixes with _craft-verify', () => {
+        expect(txtHostname('example.com')).toBe('_craft-verify.example.com');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// verifyViaTxt
+// ---------------------------------------------------------------------------
+describe('verifyViaTxt', () => {
+    it('returns verified:true when token is present in TXT records', async () => {
+        mockDns.resolveTxt.mockResolvedValue([['craft-token-abc123']]);
+        const result = await verifyViaTxt('example.com', 'craft-token-abc123');
+        expect(result.verified).toBe(true);
+        expect(result.method).toBe('txt');
+    });
+
+    it('returns WRONG_VALUE when TXT record exists but token does not match', async () => {
+        mockDns.resolveTxt.mockResolvedValue([['some-other-value']]);
+        const result = await verifyViaTxt('example.com', 'craft-token-abc123');
+        expect(result.verified).toBe(false);
+        expect(result.errorCode).toBe('WRONG_VALUE');
+        expect(result.recordsFound).toContain('some-other-value');
+    });
+
+    it('returns NOT_FOUND when ENOTFOUND', async () => {
+        const err = Object.assign(new Error('ENOTFOUND'), { code: 'ENOTFOUND' });
+        mockDns.resolveTxt.mockRejectedValue(err);
+        const result = await verifyViaTxt('example.com', 'token', { retries: 0 });
+        expect(result.verified).toBe(false);
+        expect(result.errorCode).toBe('NOT_FOUND');
+    });
+
+    it('returns NOT_FOUND when ENODATA', async () => {
+        const err = Object.assign(new Error('ENODATA'), { code: 'ENODATA' });
+        mockDns.resolveTxt.mockRejectedValue(err);
+        const result = await verifyViaTxt('example.com', 'token', { retries: 0 });
+        expect(result.errorCode).toBe('NOT_FOUND');
+    });
+
+    it('returns TIMEOUT when DNS query times out', async () => {
+        mockDns.resolveTxt.mockImplementation(
+            () => new Promise((_, reject) => setTimeout(() => reject(new Error('DNS_TIMEOUT')), 10)),
+        );
+        const result = await verifyViaTxt('example.com', 'token', { timeout: 1, retries: 0 });
+        expect(result.errorCode).toBe('TIMEOUT');
+    });
+
+    it('returns INVALID_DOMAIN for a bad domain', async () => {
+        const result = await verifyViaTxt('not a domain', 'token');
+        expect(result.errorCode).toBe('INVALID_DOMAIN');
+        expect(mockDns.resolveTxt).not.toHaveBeenCalled();
+    });
+
+    it('handles multi-chunk TXT records by joining chunks', async () => {
+        mockDns.resolveTxt.mockResolvedValue([['craft-', 'token-abc']]);
+        const result = await verifyViaTxt('example.com', 'craft-token-abc');
+        expect(result.verified).toBe(true);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// verifyViaCname
+// ---------------------------------------------------------------------------
+describe('verifyViaCname', () => {
+    it('returns verified:true when CNAME points to Vercel target', async () => {
+        mockDns.resolveCname.mockResolvedValue(['cname.vercel-dns.com']);
+        const result = await verifyViaCname('www.example.com');
+        expect(result.verified).toBe(true);
+        expect(result.method).toBe('cname');
+    });
+
+    it('accepts trailing dot in CNAME value', async () => {
+        mockDns.resolveCname.mockResolvedValue(['cname.vercel-dns.com.']);
+        const result = await verifyViaCname('www.example.com');
+        expect(result.verified).toBe(true);
+    });
+
+    it('returns WRONG_VALUE when CNAME points elsewhere', async () => {
+        mockDns.resolveCname.mockResolvedValue(['other-target.example.net']);
+        const result = await verifyViaCname('www.example.com');
+        expect(result.verified).toBe(false);
+        expect(result.errorCode).toBe('WRONG_VALUE');
+    });
+
+    it('returns NOT_FOUND when ENOTFOUND', async () => {
+        const err = Object.assign(new Error('ENOTFOUND'), { code: 'ENOTFOUND' });
+        mockDns.resolveCname.mockRejectedValue(err);
+        const result = await verifyViaCname('www.example.com', { retries: 0 });
+        expect(result.errorCode).toBe('NOT_FOUND');
+    });
+
+    it('returns INVALID_DOMAIN for apex domains', async () => {
+        const result = await verifyViaCname('example.com');
+        expect(result.errorCode).toBe('INVALID_DOMAIN');
+        expect(mockDns.resolveCname).not.toHaveBeenCalled();
+    });
+
+    it('returns INVALID_DOMAIN for a bad domain string', async () => {
+        const result = await verifyViaCname('not valid');
+        expect(result.errorCode).toBe('INVALID_DOMAIN');
+    });
+
+    it('returns TIMEOUT when DNS query times out', async () => {
+        mockDns.resolveCname.mockImplementation(
+            () => new Promise((_, reject) => setTimeout(() => reject(new Error('DNS_TIMEOUT')), 10)),
+        );
+        const result = await verifyViaCname('www.example.com', { timeout: 1, retries: 0 });
+        expect(result.errorCode).toBe('TIMEOUT');
+    });
+});

--- a/apps/web/src/lib/dns/domain-verification.ts
+++ b/apps/web/src/lib/dns/domain-verification.ts
@@ -1,0 +1,249 @@
+/**
+ * Domain ownership verification via DNS.
+ *
+ * Supports two verification methods:
+ *
+ * 1. TXT record  — user adds a TXT record containing the verification token
+ *    under the domain root (or `_craft-verify.<domain>`).
+ * 2. CNAME record — user adds a CNAME from their subdomain pointing to
+ *    `cname.vercel-dns.com` (reuses the DNS config target).
+ *
+ * Uses Node's built-in `dns.promises` — no extra dependencies.
+ */
+
+import dns from 'node:dns/promises';
+
+export type VerificationMethod = 'txt' | 'cname';
+
+export type VerificationErrorCode =
+    | 'NOT_FOUND'      // record not present
+    | 'WRONG_VALUE'    // record present but value doesn't match
+    | 'TIMEOUT'        // DNS query timed out / SERVFAIL
+    | 'INVALID_DOMAIN' // domain failed basic validation
+    | 'UNKNOWN';
+
+export interface VerificationResult {
+    verified: boolean;
+    method: VerificationMethod;
+    domain: string;
+    /** Populated on failure. */
+    errorCode?: VerificationErrorCode;
+    errorMessage?: string;
+    /** The records found during the check (useful for debugging). */
+    recordsFound?: string[];
+}
+
+export interface VerifyDomainOptions {
+    /** Milliseconds before giving up. Default: 5000 */
+    timeout?: number;
+    /** How many times to retry on transient errors. Default: 2 */
+    retries?: number;
+}
+
+/** Vercel CNAME target — must match dns-configuration.ts */
+const VERCEL_CNAME_TARGET = 'cname.vercel-dns.com';
+
+/** Basic domain sanity check — not a full RFC validator, just guards obvious garbage. */
+export function isValidDomain(domain: string): boolean {
+    return /^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,}$/i.test(domain);
+}
+
+/**
+ * Derives the TXT record hostname for a given domain.
+ * We use `_craft-verify.<domain>` to avoid polluting the apex.
+ */
+export function txtHostname(domain: string): string {
+    return `_craft-verify.${domain}`;
+}
+
+/**
+ * Verify domain ownership via a TXT record.
+ *
+ * The user must have added a TXT record at `_craft-verify.<domain>` containing
+ * exactly the provided `token`.
+ */
+export async function verifyViaTxt(
+    domain: string,
+    token: string,
+    options: VerifyDomainOptions = {},
+): Promise<VerificationResult> {
+    if (!isValidDomain(domain)) {
+        return {
+            verified: false,
+            method: 'txt',
+            domain,
+            errorCode: 'INVALID_DOMAIN',
+            errorMessage: `"${domain}" is not a valid domain name`,
+        };
+    }
+
+    const host = txtHostname(domain);
+    const retries = options.retries ?? 2;
+
+    for (let attempt = 0; attempt <= retries; attempt++) {
+        try {
+            const records: string[][] = await withTimeout(
+                dns.resolveTxt(host),
+                options.timeout ?? 5000,
+            );
+
+            // resolveTxt returns string[][] — flatten each entry
+            const flat = records.map((chunks) => chunks.join(''));
+
+            if (flat.includes(token)) {
+                return { verified: true, method: 'txt', domain, recordsFound: flat };
+            }
+
+            return {
+                verified: false,
+                method: 'txt',
+                domain,
+                errorCode: 'WRONG_VALUE',
+                errorMessage: `TXT record found at ${host} but token not present`,
+                recordsFound: flat,
+            };
+        } catch (err: unknown) {
+            const code = (err as NodeJS.ErrnoException).code;
+
+            if (code === 'ENOTFOUND' || code === 'ENODATA' || code === 'ESERVFAIL') {
+                if (attempt < retries && code === 'ESERVFAIL') continue; // retry transient
+                return {
+                    verified: false,
+                    method: 'txt',
+                    domain,
+                    errorCode: code === 'ESERVFAIL' ? 'TIMEOUT' : 'NOT_FOUND',
+                    errorMessage: `No TXT record found at ${host}`,
+                };
+            }
+
+            if ((err as Error).message === 'DNS_TIMEOUT') {
+                if (attempt < retries) continue;
+                return {
+                    verified: false,
+                    method: 'txt',
+                    domain,
+                    errorCode: 'TIMEOUT',
+                    errorMessage: `DNS query timed out after ${options.timeout ?? 5000}ms`,
+                };
+            }
+
+            return {
+                verified: false,
+                method: 'txt',
+                domain,
+                errorCode: 'UNKNOWN',
+                errorMessage: (err as Error).message,
+            };
+        }
+    }
+
+    // Should not reach here
+    return { verified: false, method: 'txt', domain, errorCode: 'UNKNOWN' };
+}
+
+/**
+ * Verify domain ownership via CNAME.
+ *
+ * The CNAME for the subdomain must resolve to `cname.vercel-dns.com`.
+ * Not applicable to apex domains (CNAME at apex is forbidden by DNS spec).
+ */
+export async function verifyViaCname(
+    domain: string,
+    options: VerifyDomainOptions = {},
+): Promise<VerificationResult> {
+    if (!isValidDomain(domain)) {
+        return {
+            verified: false,
+            method: 'cname',
+            domain,
+            errorCode: 'INVALID_DOMAIN',
+            errorMessage: `"${domain}" is not a valid domain name`,
+        };
+    }
+
+    const parts = domain.split('.');
+    if (parts.length === 2) {
+        return {
+            verified: false,
+            method: 'cname',
+            domain,
+            errorCode: 'INVALID_DOMAIN',
+            errorMessage: 'CNAME verification is not supported for apex domains — use TXT instead',
+        };
+    }
+
+    const retries = options.retries ?? 2;
+
+    for (let attempt = 0; attempt <= retries; attempt++) {
+        try {
+            const cname: string = await withTimeout(
+                dns.resolveCname(domain),
+                options.timeout ?? 5000,
+            ).then((r: string[]) => r[0] ?? '');
+
+            // Strip trailing dot if present (DNS canonical form)
+            const normalized = cname.replace(/\.$/, '').toLowerCase();
+
+            if (normalized === VERCEL_CNAME_TARGET) {
+                return { verified: true, method: 'cname', domain, recordsFound: [cname] };
+            }
+
+            return {
+                verified: false,
+                method: 'cname',
+                domain,
+                errorCode: 'WRONG_VALUE',
+                errorMessage: `CNAME points to "${normalized}", expected "${VERCEL_CNAME_TARGET}"`,
+                recordsFound: [cname],
+            };
+        } catch (err: unknown) {
+            const code = (err as NodeJS.ErrnoException).code;
+
+            if (code === 'ENOTFOUND' || code === 'ENODATA' || code === 'ESERVFAIL') {
+                if (attempt < retries && code === 'ESERVFAIL') continue;
+                return {
+                    verified: false,
+                    method: 'cname',
+                    domain,
+                    errorCode: code === 'ESERVFAIL' ? 'TIMEOUT' : 'NOT_FOUND',
+                    errorMessage: `No CNAME record found for ${domain}`,
+                };
+            }
+
+            if ((err as Error).message === 'DNS_TIMEOUT') {
+                if (attempt < retries) continue;
+                return {
+                    verified: false,
+                    method: 'cname',
+                    domain,
+                    errorCode: 'TIMEOUT',
+                    errorMessage: `DNS query timed out after ${options.timeout ?? 5000}ms`,
+                };
+            }
+
+            return {
+                verified: false,
+                method: 'cname',
+                domain,
+                errorCode: 'UNKNOWN',
+                errorMessage: (err as Error).message,
+            };
+        }
+    }
+
+    return { verified: false, method: 'cname', domain, errorCode: 'UNKNOWN' };
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+        const id = setTimeout(() => reject(new Error('DNS_TIMEOUT')), ms);
+        promise.then(
+            (v) => { clearTimeout(id); resolve(v); },
+            (e) => { clearTimeout(id); reject(e); },
+        );
+    });
+}


### PR DESCRIPTION
- Verify ownership via TXT record (_craft-verify.<domain>) or CNAME
- Node dns.promises with configurable timeout + retry
- POST /api/deployments/[id]/dns/verify with auth + ownership checks
- Returns structured result: verified, method, errorCode, recordsFound
- 15 tests covering TXT, CNAME, error codes, apex rejection, timeout

closes #198 