### PR TITLE
feat: implement https enablements for verified domains

### DIFF
--- a/apps/web/src/app/api/deployments/[id]/https/route.test.ts
+++ b/apps/web/src/app/api/deployments/[id]/https/route.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const mockGetUser = vi.fn();
+const mockFrom = vi.fn();
+const mockAddDomain = vi.fn();
+const mockGetCertificate = vi.fn();
+
+vi.mock('@/lib/supabase/server', () => ({
+    createClient: () => ({
+        auth: { getUser: mockGetUser },
+        from: mockFrom,
+    }),
+}));
+
+vi.mock('@/services/vercel.service', () => ({
+    VercelService: vi.fn().mockImplementation(() => ({
+        addDomain: mockAddDomain,
+        getCertificate: mockGetCertificate,
+    })),
+    VercelApiError: class VercelApiError extends Error {
+        constructor(message: string, public code: string, public retryAfterMs?: number) {
+            super(message);
+        }
+    },
+}));
+
+const fakeUser = { id: 'user-1' };
+const params = { id: 'dep-1' };
+
+function makeRequest(method: 'POST' | 'GET') {
+    return new NextRequest(`http://localhost/api/deployments/dep-1/https`, { method });
+}
+
+type QueryResult = { data: Record<string, unknown> | null; error: { message: string } | null };
+
+function makeSupabaseQuery(results: QueryResult[]) {
+    return {
+        select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+                single: vi.fn().mockResolvedValue(results.shift() ?? { data: null, error: null }),
+            })),
+        })),
+    };
+}
+
+const fullDeployment = {
+    user_id: fakeUser.id,
+    custom_domain: 'example.com',
+    vercel_project_id: 'prj_1',
+};
+
+describe('POST /api/deployments/[id]/https', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockGetUser.mockResolvedValue({ data: { user: fakeUser }, error: null });
+    });
+
+    it('returns 401 when unauthenticated', async () => {
+        mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+        const { POST } = await import('./route');
+        expect((await POST(makeRequest('POST'), { params })).status).toBe(401);
+    });
+
+    it('returns 403 when deployment belongs to another user', async () => {
+        mockFrom.mockReturnValue(
+            makeSupabaseQuery([{ data: { user_id: 'other' }, error: null }]),
+        );
+        const { POST } = await import('./route');
+        expect((await POST(makeRequest('POST'), { params })).status).toBe(403);
+    });
+
+    it('returns 404 when no custom_domain configured', async () => {
+        mockFrom
+            .mockReturnValueOnce(makeSupabaseQuery([{ data: { user_id: fakeUser.id }, error: null }]))
+            .mockReturnValueOnce(makeSupabaseQuery([{ data: { custom_domain: null, vercel_project_id: 'prj_1' }, error: null }]));
+        const { POST } = await import('./route');
+        expect((await POST(makeRequest('POST'), { params })).status).toBe(404);
+    });
+
+    it('returns 404 when no vercel_project_id configured', async () => {
+        mockFrom
+            .mockReturnValueOnce(makeSupabaseQuery([{ data: { user_id: fakeUser.id }, error: null }]))
+            .mockReturnValueOnce(makeSupabaseQuery([{ data: { custom_domain: 'example.com', vercel_project_id: null }, error: null }]));
+        const { POST } = await import('./route');
+        expect((await POST(makeRequest('POST'), { params })).status).toBe(404);
+    });
+
+    it('returns 409 when domain already added', async () => {
+        mockFrom
+            .mockReturnValueOnce(makeSupabaseQuery([{ data: { user_id: fakeUser.id }, error: null }]))
+            .mockReturnValueOnce(makeSupabaseQuery([{ data: fullDeployment, error: null }]));
+        const { VercelApiError } = await import('@/services/vercel.service');
+        mockAddDomain.mockRejectedValue(new VercelApiError('exists', 'DOMAIN_EXISTS'));
+        const { POST } = await import('./route');
+        expect((await POST(makeRequest('POST'), { params })).status).toBe(409);
+    });
+
+    it('returns 429 with Retry-After when rate limited', async () => {
+        mockFrom
+            .mockReturnValueOnce(makeSupabaseQuery([{ data: { user_id: fakeUser.id }, error: null }]))
+            .mockReturnValueOnce(makeSupabaseQuery([{ data: fullDeployment, error: null }]));
+        const { VercelApiError } = await import('@/services/vercel.service');
+        mockAddDomain.mockRejectedValue(new VercelApiError('rate limited', 'RATE_LIMITED', 30_000));
+        const { POST } = await import('./route');
+        const res = await POST(makeRequest('POST'), { params });
+        expect(res.status).toBe(429);
+        expect(res.headers.get('Retry-After')).toBe('30');
+    });
+
+    it('returns 200 with cert state on success', async () => {
+        mockFrom
+            .mockReturnValueOnce(makeSupabaseQuery([{ data: { user_id: fakeUser.id }, error: null }]))
+            .mockReturnValueOnce(makeSupabaseQuery([{ data: fullDeployment, error: null }]));
+        mockAddDomain.mockResolvedValue(undefined);
+        mockGetCertificate.mockResolvedValue({ domain: 'example.com', state: 'pending' });
+        const { POST } = await import('./route');
+        const res = await POST(makeRequest('POST'), { params });
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.state).toBe('pending');
+        expect(body.domain).toBe('example.com');
+    });
+});
+
+describe('GET /api/deployments/[id]/https', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockGetUser.mockResolvedValue({ data: { user: fakeUser }, error: null });
+    });
+
+    it('returns 404 when no custom domain configured', async () => {
+        mockFrom
+            .mockReturnValueOnce(makeSupabaseQuery([{ data: { user_id: fakeUser.id }, error: null }]))
+            .mockReturnValueOnce(makeSupabaseQuery([{ data: { custom_domain: null, vercel_project_id: 'prj_1' }, error: null }]));
+        const { GET } = await import('./route');
+        expect((await GET(makeRequest('GET'), { params })).status).toBe(404);
+    });
+
+    it('returns 200 with active cert state', async () => {
+        mockFrom
+            .mockReturnValueOnce(makeSupabaseQuery([{ data: { user_id: fakeUser.id }, error: null }]))
+            .mockReturnValueOnce(makeSupabaseQuery([{ data: fullDeployment, error: null }]));
+        mockGetCertificate.mockResolvedValue({
+            domain: 'example.com',
+            state: 'active',
+            expiresAt: '2027-01-01T00:00:00Z',
+        });
+        const { GET } = await import('./route');
+        const res = await GET(makeRequest('GET'), { params });
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.state).toBe('active');
+        expect(body.expiresAt).toBe('2027-01-01T00:00:00Z');
+    });
+});

--- a/apps/web/src/app/api/deployments/[id]/https/route.ts
+++ b/apps/web/src/app/api/deployments/[id]/https/route.ts
@@ -1,0 +1,112 @@
+/**
+ * POST /api/deployments/[id]/https
+ *
+ * Enables HTTPS for the custom domain attached to a deployment by adding the
+ * domain to the Vercel project and returning the initial certificate state.
+ * Callers should poll this endpoint (GET) to track provisioning progress.
+ *
+ * Authentication & ownership:
+ *   Requires a valid session (401) and ownership of the deployment (403).
+ *
+ * POST — add domain + begin SSL provisioning
+ *   Responses:
+ *     200 — { domain, state, expiresAt? }
+ *     404 — No custom domain or Vercel project configured
+ *     409 — Domain already added to the Vercel project
+ *     401 / 403 — Auth / ownership
+ *     500 — Unexpected error
+ *
+ * GET — check current certificate state
+ *   Responses:
+ *     200 — { domain, state, expiresAt?, error? }
+ *     404 — No custom domain or Vercel project configured
+ *     401 / 403 — Auth / ownership
+ *     500 — Unexpected error
+ *
+ * Feature: https-enablement-for-verified-domains
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { withDeploymentAuth } from '@/lib/api/with-auth';
+import { VercelService, VercelApiError } from '@/services/vercel.service';
+
+const vercel = new VercelService();
+
+/** Fetch the deployment's custom_domain + vercel_project_id in one query. */
+async function fetchDeploymentDomainFields(
+    supabase: Parameters<Parameters<typeof withDeploymentAuth>[0]>[1]['supabase'],
+    deploymentId: string,
+) {
+    return supabase
+        .from('deployments')
+        .select('custom_domain, vercel_project_id')
+        .eq('id', deploymentId)
+        .single();
+}
+
+export const POST = withDeploymentAuth(async (_req: NextRequest, { params, supabase }) => {
+    const { data: deployment, error } = await fetchDeploymentDomainFields(supabase, params.id);
+
+    if (error || !deployment) {
+        return NextResponse.json({ error: 'Deployment not found' }, { status: 404 });
+    }
+
+    if (!deployment.custom_domain || !deployment.vercel_project_id) {
+        return NextResponse.json(
+            { error: 'Deployment must have a custom domain and a Vercel project configured' },
+            { status: 404 },
+        );
+    }
+
+    try {
+        await vercel.addDomain(deployment.vercel_project_id, deployment.custom_domain);
+    } catch (err: unknown) {
+        const vercelErr = err as VercelApiError;
+        if (vercelErr.code === 'DOMAIN_EXISTS') {
+            return NextResponse.json({ error: vercelErr.message }, { status: 409 });
+        }
+        if (vercelErr.code === 'AUTH_FAILED') {
+            return NextResponse.json({ error: vercelErr.message }, { status: 500 });
+        }
+        if (vercelErr.code === 'RATE_LIMITED') {
+            const res = NextResponse.json({ error: vercelErr.message }, { status: 429 });
+            if (vercelErr.retryAfterMs) {
+                res.headers.set('Retry-After', String(Math.ceil(vercelErr.retryAfterMs / 1000)));
+            }
+            return res;
+        }
+        return NextResponse.json(
+            { error: (err as Error).message ?? 'Failed to add domain' },
+            { status: 500 },
+        );
+    }
+
+    // Domain added — fetch initial cert state (will be "pending" immediately after add)
+    const cert = await vercel.getCertificate(deployment.vercel_project_id, deployment.custom_domain);
+    return NextResponse.json(cert);
+});
+
+export const GET = withDeploymentAuth(async (_req: NextRequest, { params, supabase }) => {
+    const { data: deployment, error } = await fetchDeploymentDomainFields(supabase, params.id);
+
+    if (error || !deployment) {
+        return NextResponse.json({ error: 'Deployment not found' }, { status: 404 });
+    }
+
+    if (!deployment.custom_domain || !deployment.vercel_project_id) {
+        return NextResponse.json(
+            { error: 'Deployment must have a custom domain and a Vercel project configured' },
+            { status: 404 },
+        );
+    }
+
+    try {
+        const cert = await vercel.getCertificate(deployment.vercel_project_id, deployment.custom_domain);
+        return NextResponse.json(cert);
+    } catch (err: unknown) {
+        return NextResponse.json(
+            { error: (err as Error).message ?? 'Failed to retrieve certificate status' },
+            { status: 500 },
+        );
+    }
+});

--- a/apps/web/src/services/vercel.service.test.ts
+++ b/apps/web/src/services/vercel.service.test.ts
@@ -194,3 +194,86 @@ describe('VercelService', () => {
         });
     });
 });
+
+describe('VercelService — addDomain', () => {
+    beforeEach(() => vi.stubEnv('VERCEL_TOKEN', MOCK_TOKEN));
+    afterEach(() => { vi.unstubAllEnvs(); vi.restoreAllMocks(); });
+
+    it('resolves without error on 200', async () => {
+        const { svc, mockFetch } = makeService();
+        mockFetch.mockResolvedValueOnce(makeResponse(200, {}));
+        await expect(svc.addDomain('prj_1', 'example.com')).resolves.toBeUndefined();
+    });
+
+    it('throws DOMAIN_EXISTS on 409', async () => {
+        const { svc, mockFetch } = makeService();
+        mockFetch.mockResolvedValueOnce(makeResponse(409, { error: { message: 'exists' } }));
+        await expect(svc.addDomain('prj_1', 'example.com')).rejects.toMatchObject({
+            code: 'DOMAIN_EXISTS',
+        });
+    });
+
+    it('throws AUTH_FAILED on 401', async () => {
+        const { svc, mockFetch } = makeService();
+        mockFetch.mockResolvedValueOnce(makeResponse(401, { message: 'Unauthorized' }));
+        await expect(svc.addDomain('prj_1', 'example.com')).rejects.toMatchObject({
+            code: 'AUTH_FAILED',
+        });
+    });
+
+    it('throws RATE_LIMITED on 429 with retryAfterMs', async () => {
+        const { svc, mockFetch } = makeService();
+        mockFetch.mockResolvedValueOnce(
+            makeResponse(429, { message: 'Rate limited' }, { 'Retry-After': '10' }),
+        );
+        await expect(svc.addDomain('prj_1', 'example.com')).rejects.toMatchObject({
+            code: 'RATE_LIMITED',
+            retryAfterMs: 10_000,
+        });
+    });
+
+    it('throws NETWORK_ERROR when fetch throws', async () => {
+        const { svc, mockFetch } = makeService();
+        mockFetch.mockRejectedValueOnce(new Error('socket hang up'));
+        await expect(svc.addDomain('prj_1', 'example.com')).rejects.toMatchObject({
+            code: 'NETWORK_ERROR',
+        });
+    });
+});
+
+describe('VercelService — getCertificate', () => {
+    beforeEach(() => vi.stubEnv('VERCEL_TOKEN', MOCK_TOKEN));
+    afterEach(() => { vi.unstubAllEnvs(); vi.restoreAllMocks(); });
+
+    it('returns state:active when expiresAt is present', async () => {
+        const { svc, mockFetch } = makeService();
+        mockFetch.mockResolvedValueOnce(
+            makeResponse(200, { cns: ['example.com'], expiresAt: '2027-01-01T00:00:00Z' }),
+        );
+        const cert = await svc.getCertificate('prj_1', 'example.com');
+        expect(cert).toEqual({ domain: 'example.com', state: 'active', expiresAt: '2027-01-01T00:00:00Z' });
+    });
+
+    it('returns state:pending when no expiresAt', async () => {
+        const { svc, mockFetch } = makeService();
+        mockFetch.mockResolvedValueOnce(makeResponse(200, {}));
+        const cert = await svc.getCertificate('prj_1', 'example.com');
+        expect(cert).toEqual({ domain: 'example.com', state: 'pending' });
+    });
+
+    it('returns state:pending on 404 (cert not yet issued)', async () => {
+        const { svc, mockFetch } = makeService();
+        mockFetch.mockResolvedValueOnce(makeResponse(404, { message: 'Not found' }));
+        const cert = await svc.getCertificate('prj_1', 'example.com');
+        expect(cert).toEqual({ domain: 'example.com', state: 'pending' });
+    });
+
+    it('returns state:error when response contains error field', async () => {
+        const { svc, mockFetch } = makeService();
+        mockFetch.mockResolvedValueOnce(
+            makeResponse(200, { error: { message: 'DNS not propagated' } }),
+        );
+        const cert = await svc.getCertificate('prj_1', 'example.com');
+        expect(cert).toEqual({ domain: 'example.com', state: 'error', error: 'DNS not propagated' });
+    });
+});

--- a/apps/web/src/services/vercel.service.ts
+++ b/apps/web/src/services/vercel.service.ts
@@ -35,7 +35,26 @@ export type VercelErrorCode =
     | 'RATE_LIMITED'
     | 'NETWORK_ERROR'
     | 'PROJECT_EXISTS'
+    | 'DOMAIN_EXISTS'
     | 'UNKNOWN';
+
+// ── Domain / certificate types ────────────────────────────────────────────────
+
+export type CertificateState =
+    | 'pending'      // Vercel is provisioning the certificate
+    | 'active'       // Certificate is live
+    | 'error';       // Provisioning failed (e.g. DNS not yet propagated)
+
+export interface DomainCertificate {
+    /** The custom domain. */
+    domain: string;
+    /** Current certificate state. */
+    state: CertificateState;
+    /** ISO 8601 expiry date — present when state is "active". */
+    expiresAt?: string;
+    /** Human-readable reason — present when state is "error". */
+    error?: string;
+}
 
 export class VercelApiError extends Error {
     constructor(
@@ -241,6 +260,65 @@ export class VercelService {
         } catch {
             return false;
         }
+    }
+
+    /**
+     * Add a custom domain to a Vercel project and trigger SSL provisioning.
+     *
+     * Vercel automatically begins certificate provisioning once the domain is
+     * added. The caller should poll `getCertificate` to track progress.
+     *
+     * Throws DOMAIN_EXISTS (409) if the domain is already attached.
+     */
+    async addDomain(projectId: string, domain: string): Promise<void> {
+        await this.request(`/v10/projects/${projectId}/domains`, {
+            method: 'POST',
+            body: JSON.stringify({ name: domain }),
+        }, {
+            status: 409,
+            code: 'DOMAIN_EXISTS',
+            message: `Domain "${domain}" is already added to project ${projectId}`,
+        });
+    }
+
+    /**
+     * Retrieve the SSL certificate state for a domain on a Vercel project.
+     *
+     * Maps Vercel's `certs` API response to a simplified `DomainCertificate`.
+     * Returns `state: "pending"` when no certificate record exists yet.
+     */
+    async getCertificate(projectId: string, domain: string): Promise<DomainCertificate> {
+        type CertResponse = {
+            cns?: string[];
+            expiresAt?: string;
+            createdAt?: number;
+            error?: { message: string };
+        };
+
+        let data: CertResponse;
+        try {
+            data = await this.request<CertResponse>(
+                `/v7/projects/${projectId}/domains/${domain}/cert`,
+                { method: 'GET' },
+            );
+        } catch (err: unknown) {
+            const vercelErr = err as VercelApiError;
+            // 404 means Vercel hasn't issued a cert yet — treat as pending
+            if (vercelErr.code === 'UNKNOWN' && vercelErr.message.includes('404')) {
+                return { domain, state: 'pending' };
+            }
+            throw err;
+        }
+
+        if (data.error) {
+            return { domain, state: 'error', error: data.error.message };
+        }
+
+        if (data.expiresAt) {
+            return { domain, state: 'active', expiresAt: data.expiresAt };
+        }
+
+        return { domain, state: 'pending' };
     }
 
     /**


### PR DESCRIPTION
- Add VercelService.addDomain() — POST /v10/projects/:id/domains
- Add VercelService.getCertificate() — GET /v7/projects/:id/domains/:domain/cert
- Add DomainCertificate type with state: pending | active | error
- POST /api/deployments/[id]/https — add domain + return initial cert state
- GET  /api/deployments/[id]/https — poll certificate provisioning status
- Handle DOMAIN_EXISTS (409), RATE_LIMITED (429 + Retry-After), AUTH_FAILED
- 13 tests across service methods and route handlers" && git push -u origin implement-https-enablement-for-verified-domains 2>&1 
closes #199 