### PR TITLE
feat: add retry buttons for retryable errors

### DIFF
--- a/apps/web/src/components/app/ErrorState.test.tsx
+++ b/apps/web/src/components/app/ErrorState.test.tsx
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ErrorState } from './ErrorState';
+
+describe('ErrorState', () => {
+  it('renders title and message', () => {
+    render(<ErrorState message="Something failed" />);
+    expect(screen.getByText('Something went wrong')).toBeDefined();
+    expect(screen.getByText('Something failed')).toBeDefined();
+  });
+
+  it('renders custom title', () => {
+    render(<ErrorState title="Custom Title" message="msg" />);
+    expect(screen.getByText('Custom Title')).toBeDefined();
+  });
+
+  it('renders errorCode when provided', () => {
+    render(<ErrorState message="msg" errorCode="ERR_001" />);
+    expect(screen.getByText('ERR_001')).toBeDefined();
+  });
+
+  it('shows retry button when onRetry provided and no error object', () => {
+    render(<ErrorState message="msg" onRetry={vi.fn()} />);
+    expect(screen.getByRole('button', { name: 'Try Again' })).toBeDefined();
+  });
+
+  it('shows retry button for retryable errors (5xx)', () => {
+    render(
+      <ErrorState
+        message="Server error"
+        error={{ status: 500, message: 'Server error' }}
+        onRetry={vi.fn()}
+      />
+    );
+    expect(screen.getByRole('button', { name: 'Try Again' })).toBeDefined();
+  });
+
+  it('shows retry button for 429 rate limit errors', () => {
+    render(
+      <ErrorState
+        message="Rate limited"
+        error={{ status: 429, message: 'Rate limited' }}
+        onRetry={vi.fn()}
+      />
+    );
+    expect(screen.getByRole('button', { name: 'Try Again' })).toBeDefined();
+  });
+
+  it('shows retry button for network errors (no status)', () => {
+    render(
+      <ErrorState
+        message="Network error"
+        error={{ message: 'Failed to fetch' }}
+        onRetry={vi.fn()}
+      />
+    );
+    expect(screen.getByRole('button', { name: 'Try Again' })).toBeDefined();
+  });
+
+  it('hides retry button for non-retryable errors (400)', () => {
+    render(
+      <ErrorState
+        message="Bad request"
+        error={{ status: 400, message: 'Bad request' }}
+        onRetry={vi.fn()}
+      />
+    );
+    expect(screen.queryByRole('button', { name: 'Try Again' })).toBeNull();
+  });
+
+  it('hides retry button for 401 Unauthorized', () => {
+    render(
+      <ErrorState
+        message="Unauthorized"
+        error={{ status: 401, message: 'Unauthorized' }}
+        onRetry={vi.fn()}
+      />
+    );
+    expect(screen.queryByRole('button', { name: 'Try Again' })).toBeNull();
+  });
+
+  it('hides retry button for 403 Forbidden', () => {
+    render(
+      <ErrorState
+        message="Forbidden"
+        error={{ status: 403, message: 'Forbidden' }}
+        onRetry={vi.fn()}
+      />
+    );
+    expect(screen.queryByRole('button', { name: 'Try Again' })).toBeNull();
+  });
+
+  it('hides retry button for 422 validation errors', () => {
+    render(
+      <ErrorState
+        message="Validation failed"
+        error={{ status: 422, message: 'Validation failed' }}
+        onRetry={vi.fn()}
+      />
+    );
+    expect(screen.queryByRole('button', { name: 'Try Again' })).toBeNull();
+  });
+
+  it('shows retry hint for retryable errors', () => {
+    render(
+      <ErrorState
+        message="Server error"
+        error={{ status: 500, message: 'Server error' }}
+        onRetry={vi.fn()}
+      />
+    );
+    expect(screen.getByText(/temporary/i)).toBeDefined();
+  });
+
+  it('does not show retry hint for non-retryable errors', () => {
+    render(
+      <ErrorState
+        message="Bad request"
+        error={{ status: 400, message: 'Bad request' }}
+        onRetry={vi.fn()}
+      />
+    );
+    expect(screen.queryByText(/temporary/i)).toBeNull();
+  });
+
+  it('shows support button when onSupport provided', () => {
+    render(<ErrorState message="msg" onSupport={vi.fn()} />);
+    expect(screen.getByRole('button', { name: 'Contact Support' })).toBeDefined();
+  });
+
+  it('shows both retry and support buttons together', () => {
+    render(
+      <ErrorState
+        message="Server error"
+        error={{ status: 500, message: 'Server error' }}
+        onRetry={vi.fn()}
+        onSupport={vi.fn()}
+      />
+    );
+    expect(screen.getByRole('button', { name: 'Try Again' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Contact Support' })).toBeDefined();
+  });
+
+  it('shows only support button for non-retryable errors', () => {
+    render(
+      <ErrorState
+        message="Forbidden"
+        error={{ status: 403, message: 'Forbidden' }}
+        onRetry={vi.fn()}
+        onSupport={vi.fn()}
+      />
+    );
+    expect(screen.queryByRole('button', { name: 'Try Again' })).toBeNull();
+    expect(screen.getByRole('button', { name: 'Contact Support' })).toBeDefined();
+  });
+});

--- a/apps/web/src/components/app/ErrorState.tsx
+++ b/apps/web/src/components/app/ErrorState.tsx
@@ -1,10 +1,19 @@
 import React from 'react';
+import { RetryButton } from './RetryButton';
+import { isRetryableError, getRetryHint, type AppError } from '@/lib/api/retryable-error';
 
 interface ErrorStateProps {
   title?: string;
   message: string;
   errorCode?: string;
-  onRetry?: () => void;
+  /**
+   * When provided, the retry button is only shown if the error is retryable
+   * (network failures, 429, 5xx). Pass the raw AppError so the component can
+   * make that determination. If omitted, the retry button is always shown when
+   * onRetry is provided (backwards-compatible).
+   */
+  error?: AppError;
+  onRetry?: () => Promise<void> | void;
   onSupport?: () => void;
 }
 
@@ -12,41 +21,47 @@ export function ErrorState({
   title = 'Something went wrong',
   message,
   errorCode,
+  error,
   onRetry,
   onSupport,
 }: ErrorStateProps) {
+  // If an error object is provided, gate the retry button on retryability.
+  // If no error object is provided, fall back to showing retry whenever onRetry exists.
+  const showRetry = onRetry !== undefined && (error === undefined || isRetryableError(error));
+  const retryHint = error ? getRetryHint(error) : undefined;
+
   return (
     <div className="flex flex-col items-center justify-center py-16 px-6 text-center">
       <div className="text-6xl mb-6">
         ⚠️
       </div>
-      
+
       <h3 className="text-2xl font-bold font-headline text-on-surface mb-3">
         {title}
       </h3>
-      
+
       <p className="text-on-surface-variant max-w-md mb-2 leading-relaxed">
         {message}
       </p>
-      
+
+      {retryHint && (
+        <p className="text-sm text-on-surface-variant/70 max-w-md mb-2 leading-relaxed">
+          {retryHint}
+        </p>
+      )}
+
       {errorCode && (
         <p className="text-xs text-on-surface-variant/60 mb-8 font-mono">
           {errorCode}
         </p>
       )}
-      
+
       <div className="flex flex-col sm:flex-row gap-3">
-        {onRetry && (
-          <button
-            onClick={onRetry}
-            className="primary-gradient text-on-primary px-6 py-3 rounded-lg font-semibold shadow-md hover:shadow-lg transition-all active:scale-95"
-          >
-            Try Again
-          </button>
-        )}
-        
+        {showRetry && <RetryButton onRetry={onRetry} />}
+
         {onSupport && (
           <button
+            type="button"
             onClick={onSupport}
             className="bg-surface-container-lowest text-primary px-6 py-3 rounded-lg font-semibold border border-outline-variant/20 hover:bg-surface-container-low transition-all active:scale-95"
           >

--- a/apps/web/src/components/app/RetryButton.test.tsx
+++ b/apps/web/src/components/app/RetryButton.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { RetryButton } from './RetryButton';
+
+describe('RetryButton', () => {
+  it('renders with default label', () => {
+    render(<RetryButton onRetry={vi.fn()} />);
+    expect(screen.getByRole('button', { name: 'Try Again' })).toBeDefined();
+  });
+
+  it('renders with custom label', () => {
+    render(<RetryButton onRetry={vi.fn()} label="Reload" />);
+    expect(screen.getByRole('button', { name: 'Reload' })).toBeDefined();
+  });
+
+  it('calls onRetry when clicked', async () => {
+    const onRetry = vi.fn().mockResolvedValue(undefined);
+    render(<RetryButton onRetry={onRetry} />);
+
+    fireEvent.click(screen.getByRole('button'));
+    await waitFor(() => expect(onRetry).toHaveBeenCalledOnce());
+  });
+
+  it('shows loading state while retrying', async () => {
+    let resolve: () => void;
+    const onRetry = vi.fn(() => new Promise<void>((r) => { resolve = r; }));
+
+    render(<RetryButton onRetry={onRetry} />);
+    fireEvent.click(screen.getByRole('button'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Retrying…' })).toBeDefined();
+    });
+
+    resolve!();
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Try Again' })).toBeDefined();
+    });
+  });
+
+  it('disables the button while loading', async () => {
+    let resolve: () => void;
+    const onRetry = vi.fn(() => new Promise<void>((r) => { resolve = r; }));
+
+    render(<RetryButton onRetry={onRetry} />);
+    fireEvent.click(screen.getByRole('button'));
+
+    await waitFor(() => {
+      const btn = screen.getByRole('button') as HTMLButtonElement;
+      expect(btn.disabled).toBe(true);
+    });
+
+    resolve!();
+  });
+
+  it('re-enables the button after retry completes', async () => {
+    const onRetry = vi.fn().mockResolvedValue(undefined);
+    render(<RetryButton onRetry={onRetry} />);
+
+    fireEvent.click(screen.getByRole('button'));
+    await waitFor(() => {
+      const btn = screen.getByRole('button') as HTMLButtonElement;
+      expect(btn.disabled).toBe(false);
+    });
+  });
+
+  it('re-enables the button after retry throws', async () => {
+    const onRetry = vi.fn().mockRejectedValue(new Error('fail'));
+    render(<RetryButton onRetry={onRetry} />);
+
+    fireEvent.click(screen.getByRole('button'));
+    await waitFor(() => {
+      const btn = screen.getByRole('button') as HTMLButtonElement;
+      expect(btn.disabled).toBe(false);
+    });
+  });
+
+  it('does not call onRetry again while loading (autoDisable)', async () => {
+    let resolve: () => void;
+    const onRetry = vi.fn(() => new Promise<void>((r) => { resolve = r; }));
+
+    render(<RetryButton onRetry={onRetry} />);
+    const btn = screen.getByRole('button');
+
+    fireEvent.click(btn);
+    fireEvent.click(btn); // second click while loading
+
+    await waitFor(() => expect(onRetry).toHaveBeenCalledTimes(1));
+    resolve!();
+  });
+});

--- a/apps/web/src/components/app/RetryButton.tsx
+++ b/apps/web/src/components/app/RetryButton.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import React, { useState, useCallback } from 'react';
+
+interface RetryButtonProps {
+  onRetry: () => Promise<void> | void;
+  label?: string;
+  /** Disables the button while a retry is in-flight. Defaults to true. */
+  autoDisable?: boolean;
+  className?: string;
+}
+
+/**
+ * A button that triggers a retry action and shows a loading spinner
+ * while the operation is in-flight. Prevents double-clicks via autoDisable.
+ */
+export function RetryButton({
+  onRetry,
+  label = 'Try Again',
+  autoDisable = true,
+  className = '',
+}: RetryButtonProps) {
+  const [loading, setLoading] = useState(false);
+
+  const handleClick = useCallback(async () => {
+    if (loading) return;
+    setLoading(true);
+    try {
+      await onRetry();
+    } catch {
+      // Errors are the caller's responsibility — we just reset loading state.
+    } finally {
+      setLoading(false);
+    }
+  }, [loading, onRetry]);
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      disabled={autoDisable && loading}
+      aria-busy={loading}
+      aria-label={loading ? 'Retrying…' : label}
+      className={`
+        inline-flex items-center gap-2
+        primary-gradient text-on-primary
+        px-6 py-3 rounded-lg font-semibold
+        shadow-md hover:shadow-lg transition-all active:scale-95
+        disabled:opacity-60 disabled:cursor-not-allowed disabled:active:scale-100
+        ${className}
+      `.trim()}
+    >
+      {loading && (
+        <svg
+          className="w-4 h-4 animate-spin"
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <circle
+            className="opacity-25"
+            cx="12"
+            cy="12"
+            r="10"
+            stroke="currentColor"
+            strokeWidth="4"
+          />
+          <path
+            className="opacity-75"
+            fill="currentColor"
+            d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+          />
+        </svg>
+      )}
+      {loading ? 'Retrying…' : label}
+    </button>
+  );
+}

--- a/apps/web/src/components/app/index.ts
+++ b/apps/web/src/components/app/index.ts
@@ -9,3 +9,4 @@ export { UserMenu } from './UserMenu';
 export { EmptyState } from './EmptyState';
 export { LoadingSkeleton } from './LoadingSkeleton';
 export { ErrorState } from './ErrorState';
+export { RetryButton } from './RetryButton';

--- a/apps/web/src/lib/api/retryable-error.test.ts
+++ b/apps/web/src/lib/api/retryable-error.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { isRetryableError, getRetryHint } from './retryable-error';
+
+describe('isRetryableError', () => {
+  it('returns true for network errors (no status)', () => {
+    expect(isRetryableError({ message: 'Failed to fetch' })).toBe(true);
+  });
+
+  it('returns true for 429 Too Many Requests', () => {
+    expect(isRetryableError({ status: 429, message: 'Rate limited' })).toBe(true);
+  });
+
+  it('returns true for 500 Internal Server Error', () => {
+    expect(isRetryableError({ status: 500, message: 'Server error' })).toBe(true);
+  });
+
+  it('returns true for 503 Service Unavailable', () => {
+    expect(isRetryableError({ status: 503, message: 'Service unavailable' })).toBe(true);
+  });
+
+  it('returns false for 400 Bad Request', () => {
+    expect(isRetryableError({ status: 400, message: 'Bad request' })).toBe(false);
+  });
+
+  it('returns false for 401 Unauthorized', () => {
+    expect(isRetryableError({ status: 401, message: 'Unauthorized' })).toBe(false);
+  });
+
+  it('returns false for 403 Forbidden', () => {
+    expect(isRetryableError({ status: 403, message: 'Forbidden' })).toBe(false);
+  });
+
+  it('returns false for 404 Not Found', () => {
+    expect(isRetryableError({ status: 404, message: 'Not found' })).toBe(false);
+  });
+
+  it('returns false for 422 Unprocessable Entity', () => {
+    expect(isRetryableError({ status: 422, message: 'Validation failed' })).toBe(false);
+  });
+});
+
+describe('getRetryHint', () => {
+  it('returns a hint for network errors', () => {
+    const hint = getRetryHint({ message: 'Failed to fetch' });
+    expect(hint).toContain('connection');
+  });
+
+  it('returns a rate-limit hint for 429', () => {
+    const hint = getRetryHint({ status: 429, message: 'Rate limited' });
+    expect(hint).toContain('rate limit');
+  });
+
+  it('returns a generic hint for 5xx', () => {
+    const hint = getRetryHint({ status: 500, message: 'Server error' });
+    expect(hint).toContain('temporary');
+  });
+
+  it('returns undefined for non-retryable errors', () => {
+    expect(getRetryHint({ status: 400, message: 'Bad request' })).toBeUndefined();
+    expect(getRetryHint({ status: 403, message: 'Forbidden' })).toBeUndefined();
+    expect(getRetryHint({ status: 422, message: 'Validation failed' })).toBeUndefined();
+  });
+});

--- a/apps/web/src/lib/api/retryable-error.ts
+++ b/apps/web/src/lib/api/retryable-error.ts
@@ -1,0 +1,52 @@
+/**
+ * Utilities for classifying API errors as retryable or not.
+ *
+ * Retryable: transient failures the user can meaningfully retry.
+ *   - Network errors (no status)
+ *   - 429 Too Many Requests
+ *   - 5xx Server Errors
+ *
+ * Non-retryable: client errors that won't change without user action.
+ *   - 400 Bad Request
+ *   - 401 Unauthorized
+ *   - 403 Forbidden
+ *   - 404 Not Found
+ *   - 422 Unprocessable Entity
+ */
+
+export interface AppError {
+  /** HTTP status code, if available. Absent for network-level failures. */
+  status?: number;
+  message: string;
+  /** Optional machine-readable code (e.g. 'NETWORK_ERROR', 'RATE_LIMITED'). */
+  code?: string;
+}
+
+/**
+ * Returns true if the error is transient and worth retrying.
+ * Non-retryable errors (4xx except 429) require user action to resolve.
+ */
+export function isRetryableError(error: AppError): boolean {
+  // Network-level failure — no HTTP status
+  if (error.status === undefined) return true;
+
+  // Rate limited — retry after a delay
+  if (error.status === 429) return true;
+
+  // Server errors — transient, worth retrying
+  if (error.status >= 500) return true;
+
+  return false;
+}
+
+/**
+ * Returns a user-facing hint for retryable errors.
+ * Returns undefined for non-retryable errors.
+ */
+export function getRetryHint(error: AppError): string | undefined {
+  if (!isRetryableError(error)) return undefined;
+
+  if (error.status === 429) return "You've hit the rate limit. Wait a moment before retrying.";
+  if (error.status === undefined) return 'Check your connection and try again.';
+  return 'This looks like a temporary issue. Try again in a moment.';
+}

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -3,15 +3,9 @@
     "compilerOptions": {
         "types": ["vitest/globals"],
         "paths": {
-            "@/*": [
-                "./src/*"
-            ],
-            "@craft/types": [
-                "../../packages/types/src"
-            ],
-            "@craft/stellar": [
-                "../../packages/stellar/src"
-            ]
+            "@/*": ["./src/*"],
+            "@craft/types": ["../../packages/types/src"],
+            "@craft/stellar": ["../../packages/stellar/src"]
         }
     },
     "include": [
@@ -20,10 +14,5 @@
         "**/*.tsx",
         ".next/types/**/*.ts"
     ],
-    "paths": {
-      "@/*": ["./src/*"]
-    }
-  },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+    "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary
Implements retry buttons that only appear for transient/retryable errors, keeping the UI clean for errors that require user action rather than a retry.

## Changes
- `src/lib/api/retryable-error.ts` — `isRetryableError` and `getRetryHint` utilities. Network errors, 429, and 5xx are retryable; 4xx client errors are not.
- `src/components/app/RetryButton.tsx` — standalone button with async loading state, spinner, double-click guard, and internal error swallowing (callers own their error state).
- `src/components/app/ErrorState.tsx` — updated to accept an optional `error: AppError` prop. Retry button is gated on retryability; a contextual hint is shown per error type. Backwards-compatible with existing usages.
- `apps/web/tsconfig.json` — fixed pre-existing malformed JSON (duplicate keys outside the object).

## Tests
37 tests passing across all new files (`retryable-error.test.ts`, `RetryButton.test.tsx`, `ErrorState.test.tsx`).

## Edge cases & assumptions
- 401/403 are intentionally non-retryable — the user needs to re-authenticate or get permissions, not just click retry.
- `RetryButton` swallows thrown errors so loading state always resets cleanly; callers are responsible for updating their own error state.
- Backwards-compatible: `ErrorState` without the `error` prop still shows the retry button whenever `onRetry` is provided.

closes #216 