### PR TITLE
feat: add domain configuration api route

### DIFF
--- a/apps/web/src/app/api/deployments/[id]/domains/route.test.ts
+++ b/apps/web/src/app/api/deployments/[id]/domains/route.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const mockGetUser = vi.fn();
+const mockFrom = vi.fn();
+
+vi.mock('@/lib/supabase/server', () => ({
+    createClient: () => ({
+        auth: { getUser: mockGetUser },
+        from: mockFrom,
+    }),
+}));
+
+const fakeUser = { id: 'user-1', email: 'user@example.com' };
+const params = { id: 'dep-1' };
+
+function makeRequest(body: unknown = { customDomain: 'app.example.com' }) {
+    return new NextRequest('http://localhost/api/deployments/dep-1/domains', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+    });
+}
+
+type QueryResult = { data: Record<string, unknown> | null; error: { message: string } | null };
+
+function makeSupabaseQuery(results: QueryResult[]) {
+    return {
+        select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+                single: vi.fn().mockResolvedValue(results.shift() ?? { data: null, error: null }),
+            })),
+        })),
+        update: vi.fn(() => ({
+            eq: vi.fn().mockResolvedValue(results.shift() ?? { data: null, error: null }),
+        })),
+    };
+}
+
+describe('POST /api/deployments/[id]/domains', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockGetUser.mockResolvedValue({ data: { user: fakeUser }, error: null });
+    });
+
+    it('returns 401 when unauthenticated', async () => {
+        mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+        const { POST } = await import('./route');
+
+        const res = await POST(makeRequest(), { params });
+
+        expect(res.status).toBe(401);
+    });
+
+    it('returns 403 when the deployment belongs to another user', async () => {
+        mockFrom.mockReturnValue(
+            makeSupabaseQuery([{ data: { user_id: 'other-user' }, error: null }]),
+        );
+        const { POST } = await import('./route');
+
+        const res = await POST(makeRequest(), { params });
+
+        expect(res.status).toBe(403);
+    });
+
+    it('returns 400 for an empty domain', async () => {
+        mockFrom.mockReturnValue(
+            makeSupabaseQuery([{ data: { user_id: fakeUser.id }, error: null }]),
+        );
+        const { POST } = await import('./route');
+
+        const res = await POST(makeRequest({ customDomain: '' }), { params });
+
+        expect(res.status).toBe(400);
+        const body = await res.json();
+        expect(body.code).toBe('DOMAIN_EMPTY');
+    });
+
+    it('returns 400 for an invalid domain format', async () => {
+        mockFrom.mockReturnValue(
+            makeSupabaseQuery([{ data: { user_id: fakeUser.id }, error: null }]),
+        );
+        const { POST } = await import('./route');
+
+        const res = await POST(makeRequest({ customDomain: 'https://bad-domain.com/path' }), { params });
+
+        expect(res.status).toBe(400);
+        const body = await res.json();
+        expect(body.code).toBe('DOMAIN_INVALID_FORMAT');
+    });
+
+    it('returns 400 for a reserved domain', async () => {
+        mockFrom.mockReturnValue(
+            makeSupabaseQuery([{ data: { user_id: fakeUser.id }, error: null }]),
+        );
+        const { POST } = await import('./route');
+
+        const res = await POST(makeRequest({ customDomain: 'example.com' }), { params });
+
+        expect(res.status).toBe(400);
+        const body = await res.json();
+        expect(body.code).toBe('DOMAIN_RESERVED');
+    });
+
+    it('returns 400 for invalid JSON body', async () => {
+        mockFrom.mockReturnValue(
+            makeSupabaseQuery([{ data: { user_id: fakeUser.id }, error: null }]),
+        );
+        const { POST } = await import('./route');
+
+        const req = new NextRequest('http://localhost/api/deployments/dep-1/domains', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: 'not-json',
+        });
+        const res = await POST(req, { params });
+
+        expect(res.status).toBe(400);
+    });
+
+    it('returns 500 when the database update fails', async () => {
+        mockFrom
+            .mockReturnValueOnce(
+                makeSupabaseQuery([{ data: { user_id: fakeUser.id }, error: null }]),
+            )
+            .mockReturnValueOnce(
+                makeSupabaseQuery([{ data: null, error: { message: 'db error' } }]),
+            );
+        const { POST } = await import('./route');
+
+        const res = await POST(makeRequest(), { params });
+
+        expect(res.status).toBe(500);
+    });
+
+    it('returns 200 with DNS config for a valid apex domain', async () => {
+        mockFrom
+            .mockReturnValueOnce(
+                makeSupabaseQuery([{ data: { user_id: fakeUser.id }, error: null }]),
+            )
+            .mockReturnValueOnce(
+                makeSupabaseQuery([{ data: null, error: null }]),
+            );
+        const { POST } = await import('./route');
+
+        const res = await POST(makeRequest({ customDomain: 'myapp.io' }), { params });
+
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.domain).toBe('myapp.io');
+        expect(body.records.some((r: { type: string }) => r.type === 'A')).toBe(true);
+        expect(body.records.some((r: { type: string }) => r.type === 'AAAA')).toBe(true);
+        expect(body.providerInstructions.length).toBeGreaterThan(0);
+        expect(Array.isArray(body.notes)).toBe(true);
+    });
+
+    it('returns 200 with a CNAME record for a valid subdomain', async () => {
+        mockFrom
+            .mockReturnValueOnce(
+                makeSupabaseQuery([{ data: { user_id: fakeUser.id }, error: null }]),
+            )
+            .mockReturnValueOnce(
+                makeSupabaseQuery([{ data: null, error: null }]),
+            );
+        const { POST } = await import('./route');
+
+        const res = await POST(makeRequest({ customDomain: 'app.example.com' }), { params });
+
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.domain).toBe('app.example.com');
+        expect(body.records.some((r: { type: string }) => r.type === 'CNAME')).toBe(true);
+    });
+});

--- a/apps/web/src/app/api/deployments/[id]/domains/route.ts
+++ b/apps/web/src/app/api/deployments/[id]/domains/route.ts
@@ -1,0 +1,63 @@
+/**
+ * POST /api/deployments/[id]/domains
+ *
+ * Adds a custom domain to a deployment and returns DNS configuration
+ * instructions so the user can point their domain to the deployment.
+ *
+ * Authentication & ownership:
+ *   Requires a valid session (401) and ownership of the deployment (403).
+ *
+ * Request body:
+ *   { "customDomain": "app.example.com" }
+ *
+ * Responses:
+ *   200 — Domain saved; DNS configuration returned
+ *         { domain, records, providerInstructions, notes }
+ *   400 — Missing or invalid domain
+ *   401 — Not authenticated
+ *   403 — Not authorized for this deployment
+ *   404 — Deployment not found
+ *   500 — Unexpected error
+ *
+ * Issue: #204
+ * Branch: create-post-domain-configuration-api-route
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { withDeploymentAuth } from '@/lib/api/with-auth';
+import { validateCustomDomain } from '@/lib/customization/validate-domain';
+import { generateDnsConfiguration } from '@/lib/dns/dns-configuration';
+
+export const POST = withDeploymentAuth(async (req: NextRequest, { params, supabase }) => {
+    let body: unknown;
+    try {
+        body = await req.json();
+    } catch {
+        return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+    }
+
+    const rawDomain = (body as Record<string, unknown>)?.customDomain;
+    const validation = validateCustomDomain(rawDomain);
+
+    if (!validation.valid) {
+        return NextResponse.json(
+            { error: validation.message, field: validation.field, code: validation.code },
+            { status: 400 },
+        );
+    }
+
+    const { domain } = validation;
+
+    const { error: updateError } = await supabase
+        .from('deployments')
+        .update({ custom_domain: domain, updated_at: new Date().toISOString() })
+        .eq('id', params.id);
+
+    if (updateError) {
+        console.error(`[domains-post] Failed to save domain for ${params.id}:`, updateError.message);
+        return NextResponse.json({ error: 'Failed to save domain' }, { status: 500 });
+    }
+
+    const config = generateDnsConfiguration(domain);
+    return NextResponse.json(config);
+});


### PR DESCRIPTION
Closes #204

### What

Adds the POST /api/deployments/[id]/domains endpoint for attaching a custom domain to a 
deployment and receiving DNS configuration instructions.

### How

- Validates the customDomain field using the existing validateCustomDomain utility (rejects
reserved, malformed, and localhost domains)
- Enforces auth and deployment ownership via withDeploymentAuth (consistent with the DNS/
HTTPS routes)
- Persists custom_domain to the deployments table
- Returns DNS records and provider setup instructions via generateDnsConfiguration — same 
response shape as GET /dns

### Response codes

| Status | Reason |
|--------|--------|
| 200 | Domain saved; DNS config returned |
| 400 | Missing, malformed, or reserved domain (includes field + code) |
| 401 | Not authenticated |
| 403 | Deployment not owned by caller |
| 500 | Database write failure |

### Example

Request
json
POST /api/deployments/dep-123/domains
{ "customDomain": "app.myproject.io" }


Response
json
{
  "domain": "app.myproject.io",
  "records": [{ "type": "CNAME", "host": "app", "value": "cname.vercel-dns.com", "ttl": 3600 }],
  "providerInstructions": [...],
  "notes": [...]
}


### Notes

- No new dependencies — reuses validateCustomDomain, generateDnsConfiguration, and 
withDeploymentAuth introduced in prior PRs
- All 104 tests in the suite currently fail due to a pre-existing vitest.setup.ts path 
resolution issue unrelated to this change