### PR TITLE
feat: add domain tier restrictions

### DIFF
--- a/apps/web/src/app/api/deployments/[id]/dns/route.test.ts
+++ b/apps/web/src/app/api/deployments/[id]/dns/route.test.ts
@@ -11,6 +11,10 @@ vi.mock('@/lib/supabase/server', () => ({
     }),
 }));
 
+vi.mock('@/lib/stripe/pricing', () => ({
+    canConfigureCustomDomain: (tier: string) => tier === 'pro' || tier === 'enterprise',
+}));
+
 const fakeUser = { id: 'user-1', email: 'user@example.com' };
 const params = { id: 'dep-1' };
 
@@ -57,10 +61,26 @@ describe('GET /api/deployments/[id]/dns', () => {
         expect(res.status).toBe(403);
     });
 
-    it('returns 404 when the deployment is not found', async () => {
+    it('returns 403 with upgradeUrl for free-tier users', async () => {
+        mockFrom
+            .mockReturnValueOnce(makeSupabaseQuery([{ data: { user_id: fakeUser.id }, error: null }]))
+            .mockReturnValueOnce(makeSupabaseQuery([{ data: { subscription_tier: 'free' }, error: null }]));
+        const { GET } = await import('./route');
+
+        const res = await GET(makeRequest(), { params });
+
+        expect(res.status).toBe(403);
+        const body = await res.json();
+        expect(body.upgradeUrl).toBe('/pricing');
+    });
+
+    it('returns 404 when the deployment is not found (pro user)', async () => {
         mockFrom
             .mockReturnValueOnce(
                 makeSupabaseQuery([{ data: { user_id: fakeUser.id }, error: null }]),
+            )
+            .mockReturnValueOnce(
+                makeSupabaseQuery([{ data: { subscription_tier: 'pro' }, error: null }]),
             )
             .mockReturnValueOnce(
                 makeSupabaseQuery([{ data: null, error: { message: 'not found' } }]),
@@ -72,10 +92,13 @@ describe('GET /api/deployments/[id]/dns', () => {
         expect(res.status).toBe(404);
     });
 
-    it('returns 404 when no custom domain is configured', async () => {
+    it('returns 404 when no custom domain is configured (pro user)', async () => {
         mockFrom
             .mockReturnValueOnce(
                 makeSupabaseQuery([{ data: { user_id: fakeUser.id }, error: null }]),
+            )
+            .mockReturnValueOnce(
+                makeSupabaseQuery([{ data: { subscription_tier: 'pro' }, error: null }]),
             )
             .mockReturnValueOnce(
                 makeSupabaseQuery([{ data: { custom_domain: null }, error: null }]),
@@ -89,10 +112,13 @@ describe('GET /api/deployments/[id]/dns', () => {
         expect(body.error).toMatch(/no custom domain/i);
     });
 
-    it('returns 200 with DNS config for an apex domain', async () => {
+    it('returns 200 with DNS config for an apex domain (pro user)', async () => {
         mockFrom
             .mockReturnValueOnce(
                 makeSupabaseQuery([{ data: { user_id: fakeUser.id }, error: null }]),
+            )
+            .mockReturnValueOnce(
+                makeSupabaseQuery([{ data: { subscription_tier: 'pro' }, error: null }]),
             )
             .mockReturnValueOnce(
                 makeSupabaseQuery([{ data: { custom_domain: 'example.com' }, error: null }]),
@@ -110,10 +136,13 @@ describe('GET /api/deployments/[id]/dns', () => {
         expect(Array.isArray(body.notes)).toBe(true);
     });
 
-    it('returns 200 with a CNAME record for a subdomain', async () => {
+    it('returns 200 with a CNAME record for a subdomain (enterprise user)', async () => {
         mockFrom
             .mockReturnValueOnce(
                 makeSupabaseQuery([{ data: { user_id: fakeUser.id }, error: null }]),
+            )
+            .mockReturnValueOnce(
+                makeSupabaseQuery([{ data: { subscription_tier: 'enterprise' }, error: null }]),
             )
             .mockReturnValueOnce(
                 makeSupabaseQuery([

--- a/apps/web/src/app/api/deployments/[id]/dns/route.ts
+++ b/apps/web/src/app/api/deployments/[id]/dns/route.ts
@@ -20,10 +20,10 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { withDeploymentAuth } from '@/lib/api/with-auth';
+import { withDomainTierCheck } from '@/lib/api/with-auth';
 import { generateDnsConfiguration } from '@/lib/dns/dns-configuration';
 
-export const GET = withDeploymentAuth(async (_req: NextRequest, { params, supabase }) => {
+export const GET = withDomainTierCheck(async (_req: NextRequest, { params, supabase }) => {
     const { data: deployment, error } = await supabase
         .from('deployments')
         .select('custom_domain')

--- a/apps/web/src/app/api/deployments/[id]/dns/verify/route.test.ts
+++ b/apps/web/src/app/api/deployments/[id]/dns/verify/route.test.ts
@@ -18,6 +18,10 @@ vi.mock('@/lib/dns/domain-verification', () => ({
     verifyViaCname: mockVerifyViaCname,
 }));
 
+vi.mock('@/lib/stripe/pricing', () => ({
+    canConfigureCustomDomain: (tier: string) => tier === 'pro' || tier === 'enterprise',
+}));
+
 const fakeUser = { id: 'user-1', email: 'user@example.com' };
 const params = { id: 'dep-1' };
 
@@ -39,6 +43,15 @@ function makeSupabaseQuery(results: QueryResult[]) {
             })),
         })),
     };
+}
+
+/** Ownership + pro-tier profile queries prepended automatically. */
+function withProTier(extraResults: QueryResult[]) {
+    return makeSupabaseQuery([
+        { data: { user_id: fakeUser.id }, error: null },
+        { data: { subscription_tier: 'pro' }, error: null },
+        ...extraResults,
+    ]);
 }
 
 describe('POST /api/deployments/[id]/dns/verify', () => {
@@ -63,37 +76,47 @@ describe('POST /api/deployments/[id]/dns/verify', () => {
         expect(res.status).toBe(403);
     });
 
-    it('returns 400 for invalid method value', async () => {
+    it('returns 403 with upgradeUrl for free-tier users', async () => {
         mockFrom.mockReturnValue(
-            makeSupabaseQuery([{ data: { user_id: fakeUser.id }, error: null }]),
+            makeSupabaseQuery([
+                { data: { user_id: fakeUser.id }, error: null },
+                { data: { subscription_tier: 'free' }, error: null },
+            ]),
         );
+        const { POST } = await import('./route');
+        const res = await POST(makeRequest({ method: 'txt', token: 'tok' }), { params });
+        expect(res.status).toBe(403);
+        const body = await res.json();
+        expect(body.upgradeUrl).toBe('/pricing');
+    });
+
+    it('returns 400 for invalid method value', async () => {
+        mockFrom.mockReturnValue(withProTier([]));
         const { POST } = await import('./route');
         const res = await POST(makeRequest({ method: 'invalid' }), { params });
         expect(res.status).toBe(400);
     });
 
     it('returns 400 when method is txt but token is missing', async () => {
-        mockFrom.mockReturnValue(
-            makeSupabaseQuery([{ data: { user_id: fakeUser.id }, error: null }]),
-        );
+        mockFrom.mockReturnValue(withProTier([]));
         const { POST } = await import('./route');
         const res = await POST(makeRequest({ method: 'txt' }), { params });
         expect(res.status).toBe(400);
     });
 
     it('returns 404 when deployment has no custom domain', async () => {
-        mockFrom
-            .mockReturnValueOnce(makeSupabaseQuery([{ data: { user_id: fakeUser.id }, error: null }]))
-            .mockReturnValueOnce(makeSupabaseQuery([{ data: { custom_domain: null }, error: null }]));
+        mockFrom.mockReturnValue(
+            withProTier([{ data: { custom_domain: null }, error: null }]),
+        );
         const { POST } = await import('./route');
         const res = await POST(makeRequest({ method: 'txt', token: 'tok' }), { params });
         expect(res.status).toBe(404);
     });
 
     it('calls verifyViaTxt and returns result for method=txt', async () => {
-        mockFrom
-            .mockReturnValueOnce(makeSupabaseQuery([{ data: { user_id: fakeUser.id }, error: null }]))
-            .mockReturnValueOnce(makeSupabaseQuery([{ data: { custom_domain: 'example.com' }, error: null }]));
+        mockFrom.mockReturnValue(
+            withProTier([{ data: { custom_domain: 'example.com' }, error: null }]),
+        );
         mockVerifyViaTxt.mockResolvedValue({ verified: true, method: 'txt', domain: 'example.com' });
 
         const { POST } = await import('./route');
@@ -106,9 +129,9 @@ describe('POST /api/deployments/[id]/dns/verify', () => {
     });
 
     it('calls verifyViaCname and returns result for method=cname', async () => {
-        mockFrom
-            .mockReturnValueOnce(makeSupabaseQuery([{ data: { user_id: fakeUser.id }, error: null }]))
-            .mockReturnValueOnce(makeSupabaseQuery([{ data: { custom_domain: 'www.example.com' }, error: null }]));
+        mockFrom.mockReturnValue(
+            withProTier([{ data: { custom_domain: 'www.example.com' }, error: null }]),
+        );
         mockVerifyViaCname.mockResolvedValue({ verified: false, method: 'cname', domain: 'www.example.com', errorCode: 'NOT_FOUND' });
 
         const { POST } = await import('./route');

--- a/apps/web/src/app/api/deployments/[id]/dns/verify/route.ts
+++ b/apps/web/src/app/api/deployments/[id]/dns/verify/route.ts
@@ -27,7 +27,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { withDeploymentAuth } from '@/lib/api/with-auth';
+import { withDomainTierCheck } from '@/lib/api/with-auth';
 import { verifyViaTxt, verifyViaCname } from '@/lib/dns/domain-verification';
 
 interface RequestBody {
@@ -46,7 +46,7 @@ function normalizeBody(raw: unknown): RequestBody | null {
     return body as RequestBody;
 }
 
-export const POST = withDeploymentAuth(async (req: NextRequest, { params, supabase }) => {
+export const POST = withDomainTierCheck(async (req: NextRequest, { params, supabase }) => {
     let body: RequestBody;
     try {
         const raw = await req.json();

--- a/apps/web/src/app/api/deployments/[id]/https/route.test.ts
+++ b/apps/web/src/app/api/deployments/[id]/https/route.test.ts
@@ -25,6 +25,10 @@ vi.mock('@/services/vercel.service', () => ({
     },
 }));
 
+vi.mock('@/lib/stripe/pricing', () => ({
+    canConfigureCustomDomain: (tier: string) => tier === 'pro' || tier === 'enterprise',
+}));
+
 const fakeUser = { id: 'user-1' };
 const params = { id: 'dep-1' };
 
@@ -50,6 +54,15 @@ const fullDeployment = {
     vercel_project_id: 'prj_1',
 };
 
+/** Ownership + pro-tier profile queries prepended automatically. */
+function withProTier(extraResults: QueryResult[]) {
+    return makeSupabaseQuery([
+        { data: { user_id: fakeUser.id }, error: null },
+        { data: { subscription_tier: 'pro' }, error: null },
+        ...extraResults,
+    ]);
+}
+
 describe('POST /api/deployments/[id]/https', () => {
     beforeEach(() => {
         vi.clearAllMocks();
@@ -70,26 +83,38 @@ describe('POST /api/deployments/[id]/https', () => {
         expect((await POST(makeRequest('POST'), { params })).status).toBe(403);
     });
 
+    it('returns 403 with upgradeUrl for free-tier users', async () => {
+        mockFrom.mockReturnValue(
+            makeSupabaseQuery([
+                { data: { user_id: fakeUser.id }, error: null },
+                { data: { subscription_tier: 'free' }, error: null },
+            ]),
+        );
+        const { POST } = await import('./route');
+        const res = await POST(makeRequest('POST'), { params });
+        expect(res.status).toBe(403);
+        const body = await res.json();
+        expect(body.upgradeUrl).toBe('/pricing');
+    });
+
     it('returns 404 when no custom_domain configured', async () => {
-        mockFrom
-            .mockReturnValueOnce(makeSupabaseQuery([{ data: { user_id: fakeUser.id }, error: null }]))
-            .mockReturnValueOnce(makeSupabaseQuery([{ data: { custom_domain: null, vercel_project_id: 'prj_1' }, error: null }]));
+        mockFrom.mockReturnValue(
+            withProTier([{ data: { custom_domain: null, vercel_project_id: 'prj_1' }, error: null }]),
+        );
         const { POST } = await import('./route');
         expect((await POST(makeRequest('POST'), { params })).status).toBe(404);
     });
 
     it('returns 404 when no vercel_project_id configured', async () => {
-        mockFrom
-            .mockReturnValueOnce(makeSupabaseQuery([{ data: { user_id: fakeUser.id }, error: null }]))
-            .mockReturnValueOnce(makeSupabaseQuery([{ data: { custom_domain: 'example.com', vercel_project_id: null }, error: null }]));
+        mockFrom.mockReturnValue(
+            withProTier([{ data: { custom_domain: 'example.com', vercel_project_id: null }, error: null }]),
+        );
         const { POST } = await import('./route');
         expect((await POST(makeRequest('POST'), { params })).status).toBe(404);
     });
 
     it('returns 409 when domain already added', async () => {
-        mockFrom
-            .mockReturnValueOnce(makeSupabaseQuery([{ data: { user_id: fakeUser.id }, error: null }]))
-            .mockReturnValueOnce(makeSupabaseQuery([{ data: fullDeployment, error: null }]));
+        mockFrom.mockReturnValue(withProTier([{ data: fullDeployment, error: null }]));
         const { VercelApiError } = await import('@/services/vercel.service');
         mockAddDomain.mockRejectedValue(new VercelApiError('exists', 'DOMAIN_EXISTS'));
         const { POST } = await import('./route');
@@ -97,9 +122,7 @@ describe('POST /api/deployments/[id]/https', () => {
     });
 
     it('returns 429 with Retry-After when rate limited', async () => {
-        mockFrom
-            .mockReturnValueOnce(makeSupabaseQuery([{ data: { user_id: fakeUser.id }, error: null }]))
-            .mockReturnValueOnce(makeSupabaseQuery([{ data: fullDeployment, error: null }]));
+        mockFrom.mockReturnValue(withProTier([{ data: fullDeployment, error: null }]));
         const { VercelApiError } = await import('@/services/vercel.service');
         mockAddDomain.mockRejectedValue(new VercelApiError('rate limited', 'RATE_LIMITED', 30_000));
         const { POST } = await import('./route');
@@ -109,9 +132,7 @@ describe('POST /api/deployments/[id]/https', () => {
     });
 
     it('returns 200 with cert state on success', async () => {
-        mockFrom
-            .mockReturnValueOnce(makeSupabaseQuery([{ data: { user_id: fakeUser.id }, error: null }]))
-            .mockReturnValueOnce(makeSupabaseQuery([{ data: fullDeployment, error: null }]));
+        mockFrom.mockReturnValue(withProTier([{ data: fullDeployment, error: null }]));
         mockAddDomain.mockResolvedValue(undefined);
         mockGetCertificate.mockResolvedValue({ domain: 'example.com', state: 'pending' });
         const { POST } = await import('./route');
@@ -130,17 +151,15 @@ describe('GET /api/deployments/[id]/https', () => {
     });
 
     it('returns 404 when no custom domain configured', async () => {
-        mockFrom
-            .mockReturnValueOnce(makeSupabaseQuery([{ data: { user_id: fakeUser.id }, error: null }]))
-            .mockReturnValueOnce(makeSupabaseQuery([{ data: { custom_domain: null, vercel_project_id: 'prj_1' }, error: null }]));
+        mockFrom.mockReturnValue(
+            withProTier([{ data: { custom_domain: null, vercel_project_id: 'prj_1' }, error: null }]),
+        );
         const { GET } = await import('./route');
         expect((await GET(makeRequest('GET'), { params })).status).toBe(404);
     });
 
     it('returns 200 with active cert state', async () => {
-        mockFrom
-            .mockReturnValueOnce(makeSupabaseQuery([{ data: { user_id: fakeUser.id }, error: null }]))
-            .mockReturnValueOnce(makeSupabaseQuery([{ data: fullDeployment, error: null }]));
+        mockFrom.mockReturnValue(withProTier([{ data: fullDeployment, error: null }]));
         mockGetCertificate.mockResolvedValue({
             domain: 'example.com',
             state: 'active',

--- a/apps/web/src/app/api/deployments/[id]/https/route.ts
+++ b/apps/web/src/app/api/deployments/[id]/https/route.ts
@@ -27,7 +27,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { withDeploymentAuth } from '@/lib/api/with-auth';
+import { withDomainTierCheck } from '@/lib/api/with-auth';
 import { VercelService, VercelApiError } from '@/services/vercel.service';
 
 const vercel = new VercelService();
@@ -44,7 +44,7 @@ async function fetchDeploymentDomainFields(
         .single();
 }
 
-export const POST = withDeploymentAuth(async (_req: NextRequest, { params, supabase }) => {
+export const POST = withDomainTierCheck(async (_req: NextRequest, { params, supabase }) => {
     const { data: deployment, error } = await fetchDeploymentDomainFields(supabase, params.id);
 
     if (error || !deployment) {
@@ -86,7 +86,7 @@ export const POST = withDeploymentAuth(async (_req: NextRequest, { params, supab
     return NextResponse.json(cert);
 });
 
-export const GET = withDeploymentAuth(async (_req: NextRequest, { params, supabase }) => {
+export const GET = withDomainTierCheck(async (_req: NextRequest, { params, supabase }) => {
     const { data: deployment, error } = await fetchDeploymentDomainFields(supabase, params.id);
 
     if (error || !deployment) {

--- a/apps/web/src/lib/api/with-auth.domain-tier.test.ts
+++ b/apps/web/src/lib/api/with-auth.domain-tier.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Tests for withDomainTierCheck middleware.
+ * Verifies that free-tier users are blocked from custom-domain endpoints
+ * and that pro/enterprise users are allowed through.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest, NextResponse } from 'next/server';
+
+const mockGetUser = vi.fn();
+const mockFrom = vi.fn();
+
+vi.mock('@/lib/supabase/server', () => ({
+    createClient: () => ({ auth: { getUser: mockGetUser }, from: mockFrom }),
+}));
+
+// Stub pricing so tests don't depend on env vars
+vi.mock('@/lib/stripe/pricing', () => ({
+    canConfigureCustomDomain: (tier: string) => tier === 'pro' || tier === 'enterprise',
+}));
+
+const fakeUser = { id: 'user-1' };
+const params = { id: 'dep-1' };
+
+function makeRequest() {
+    return new NextRequest('http://localhost/test', { method: 'GET' });
+}
+
+type QueryResult = { data: Record<string, unknown> | null; error: { message: string } | null };
+
+function makeSupabaseQuery(results: QueryResult[]) {
+    return {
+        select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+                single: vi.fn().mockResolvedValue(results.shift() ?? { data: null, error: null }),
+            })),
+        })),
+    };
+}
+
+describe('withDomainTierCheck', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockGetUser.mockResolvedValue({ data: { user: fakeUser }, error: null });
+    });
+
+    it('returns 401 when unauthenticated', async () => {
+        mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+        const { withDomainTierCheck } = await import('./with-auth');
+        const handler = vi.fn().mockResolvedValue(NextResponse.json({ ok: true }));
+        const route = withDomainTierCheck(handler);
+        const res = await route(makeRequest(), { params });
+        expect(res.status).toBe(401);
+        expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('returns 403 when deployment belongs to another user', async () => {
+        mockFrom.mockReturnValue(
+            makeSupabaseQuery([{ data: { user_id: 'other-user' }, error: null }]),
+        );
+        const { withDomainTierCheck } = await import('./with-auth');
+        const handler = vi.fn().mockResolvedValue(NextResponse.json({ ok: true }));
+        const route = withDomainTierCheck(handler);
+        const res = await route(makeRequest(), { params });
+        expect(res.status).toBe(403);
+        expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('returns 403 with upgradeUrl for free-tier users', async () => {
+        mockFrom
+            .mockReturnValueOnce(makeSupabaseQuery([{ data: { user_id: fakeUser.id }, error: null }]))
+            .mockReturnValueOnce(makeSupabaseQuery([{ data: { subscription_tier: 'free' }, error: null }]));
+        const { withDomainTierCheck } = await import('./with-auth');
+        const handler = vi.fn().mockResolvedValue(NextResponse.json({ ok: true }));
+        const route = withDomainTierCheck(handler);
+        const res = await route(makeRequest(), { params });
+        expect(res.status).toBe(403);
+        const body = await res.json();
+        expect(body.upgradeUrl).toBe('/pricing');
+        expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('falls back to free tier when profile is missing and blocks access', async () => {
+        mockFrom
+            .mockReturnValueOnce(makeSupabaseQuery([{ data: { user_id: fakeUser.id }, error: null }]))
+            .mockReturnValueOnce(makeSupabaseQuery([{ data: null, error: { message: 'not found' } }]));
+        const { withDomainTierCheck } = await import('./with-auth');
+        const handler = vi.fn().mockResolvedValue(NextResponse.json({ ok: true }));
+        const route = withDomainTierCheck(handler);
+        const res = await route(makeRequest(), { params });
+        expect(res.status).toBe(403);
+        expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('calls handler for pro-tier users', async () => {
+        mockFrom
+            .mockReturnValueOnce(makeSupabaseQuery([{ data: { user_id: fakeUser.id }, error: null }]))
+            .mockReturnValueOnce(makeSupabaseQuery([{ data: { subscription_tier: 'pro' }, error: null }]));
+        const { withDomainTierCheck } = await import('./with-auth');
+        const handler = vi.fn().mockResolvedValue(NextResponse.json({ ok: true }));
+        const route = withDomainTierCheck(handler);
+        const res = await route(makeRequest(), { params });
+        expect(res.status).toBe(200);
+        expect(handler).toHaveBeenCalledOnce();
+    });
+
+    it('calls handler for enterprise-tier users', async () => {
+        mockFrom
+            .mockReturnValueOnce(makeSupabaseQuery([{ data: { user_id: fakeUser.id }, error: null }]))
+            .mockReturnValueOnce(makeSupabaseQuery([{ data: { subscription_tier: 'enterprise' }, error: null }]));
+        const { withDomainTierCheck } = await import('./with-auth');
+        const handler = vi.fn().mockResolvedValue(NextResponse.json({ ok: true }));
+        const route = withDomainTierCheck(handler);
+        const res = await route(makeRequest(), { params });
+        expect(res.status).toBe(200);
+        expect(handler).toHaveBeenCalledOnce();
+    });
+});

--- a/apps/web/src/lib/api/with-auth.ts
+++ b/apps/web/src/lib/api/with-auth.ts
@@ -1,7 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
+import { canConfigureCustomDomain } from '@/lib/stripe/pricing';
 import type { User } from '@supabase/supabase-js';
 import type { SupabaseClient } from '@supabase/supabase-js';
+import type { SubscriptionTier } from '@craft/types';
 
 export type AuthedRouteContext = {
     user: User;
@@ -47,6 +49,38 @@ export function withDeploymentAuth<TParams extends { id: string }>(
 
         if (!deployment || deployment.user_id !== ctx.user.id) {
             return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+        }
+
+        return handler(req, ctx);
+    });
+}
+
+/**
+ * Wraps a route handler with auth + deployment ownership + custom-domain tier check.
+ * Returns 403 with an upgrade prompt if the user's subscription tier does not
+ * include custom domain support (i.e. free tier).
+ * Requires `params.id` to be the deployment ID.
+ */
+export function withDomainTierCheck<TParams extends { id: string }>(
+    handler: RouteHandler<TParams>
+) {
+    return withDeploymentAuth<TParams>(async (req, ctx) => {
+        const { data: profile } = await ctx.supabase
+            .from('profiles')
+            .select('subscription_tier')
+            .eq('id', ctx.user.id)
+            .single();
+
+        const tier = (profile?.subscription_tier ?? 'free') as SubscriptionTier;
+
+        if (!canConfigureCustomDomain(tier)) {
+            return NextResponse.json(
+                {
+                    error: 'Custom domains require a Pro or Enterprise subscription.',
+                    upgradeUrl: '/pricing',
+                },
+                { status: 403 },
+            );
         }
 
         return handler(req, ctx);

--- a/apps/web/src/lib/stripe/pricing.ts
+++ b/apps/web/src/lib/stripe/pricing.ts
@@ -134,6 +134,14 @@ export function getEntitlements(tier: SubscriptionTier): TierEntitlements {
   return TIER_CONFIGS[tier].entitlements;
 }
 
+/**
+ * Returns true if the given tier is allowed to configure custom domains.
+ * Only pro and enterprise tiers have maxCustomDomains > 0.
+ */
+export function canConfigureCustomDomain(tier: SubscriptionTier): boolean {
+  return TIER_CONFIGS[tier].entitlements.maxCustomDomains !== 0;
+}
+
 // ── Startup validation ────────────────────────────────────────────────────────
 
 /**


### PR DESCRIPTION
Restrict custom domain configuration (DNS, HTTPS, domain verification) to pro and enterprise tiers only.

Changes:
- pricing.ts: add canConfigureCustomDomain(tier) helper
- with-auth.ts: add withDomainTierCheck middleware that checks the user's subscription_tier from profiles before allowing access; returns 403 + upgradeUrl:/pricing for free-tier users
- dns/route.ts, https/route.ts, dns/verify/route.ts: swap withDeploymentAuth → withDomainTierCheck
- Tests: new with-auth.domain-tier.test.ts covers all middleware branches; existing route tests updated to include tier mock and new 403-upgrade-prompt assertions

closes #219 