### PR TITLE
feat: add deployment count limits

### DIFF
--- a/apps/web/src/app/api/deployments/route.test.ts
+++ b/apps/web/src/app/api/deployments/route.test.ts
@@ -11,7 +11,34 @@ vi.mock('@/lib/supabase/server', () => ({
   }),
 }));
 
+vi.mock('@/lib/stripe/pricing', () => ({
+  getEntitlements: (tier: string) => {
+    if (tier === 'pro') return { maxDeployments: 10 };
+    if (tier === 'enterprise') return { maxDeployments: -1 };
+    return { maxDeployments: 1 }; // free
+  },
+}));
+
 const fakeUser = { id: 'user-1', email: 'user@example.com' };
+
+const validConfig = {
+  branding: {
+    appName: 'App',
+    primaryColor: '#000000',
+    secondaryColor: '#111111',
+    fontFamily: 'Inter',
+  },
+  features: {
+    enableCharts: true,
+    enableTransactionHistory: true,
+    enableAnalytics: false,
+    enableNotifications: false,
+  },
+  stellar: {
+    network: 'testnet',
+    horizonUrl: 'https://horizon-testnet.stellar.org',
+  },
+};
 
 function post(url: string, body?: unknown) {
   return new NextRequest(url, {
@@ -21,25 +48,34 @@ function post(url: string, body?: unknown) {
   });
 }
 
-function makeSupabaseQuery(selectResults: any[]) {
-  const insert = vi.fn(() => ({
-    select: vi
-      .fn()
-      .mockResolvedValue(selectResults.shift() ?? { data: null, error: null }),
-  }));
-  const select = vi.fn(() => ({
-    eq: vi.fn(() => ({
-      single: vi
-        .fn()
-        .mockResolvedValue(
-          selectResults.shift() ?? { data: null, error: null }
-        ),
+/** Minimal chainable Supabase mock. Each table gets its own result queue. */
+function makeTableMock(results: { data: unknown; error: unknown; count?: number }[]) {
+  const pop = () => results.shift() ?? { data: null, error: null, count: null };
+
+  const eqChain = (result: ReturnType<typeof pop>) => ({
+    eq: vi.fn(() => Promise.resolve(result)),
+    single: vi.fn().mockResolvedValue(result),
+  });
+
+  return {
+    select: vi.fn((_cols?: string, opts?: { count?: string; head?: boolean }) => {
+      const result = pop();
+      if (opts?.head) {
+        // count query: .select(..., {count, head}).eq().eq()
+        return { eq: vi.fn(() => eqChain(result)) };
+      }
+      return {
+        eq: vi.fn(() => ({
+          eq: vi.fn(() => ({ single: vi.fn().mockResolvedValue(result) })),
+          single: vi.fn().mockResolvedValue(result),
+        })),
+      };
+    }),
+    insert: vi.fn(() => ({
+      select: vi.fn(() => ({ single: vi.fn().mockResolvedValue(pop()) })),
     })),
-  }));
-  const update = vi.fn(() => ({
-    eq: vi.fn().mockResolvedValue({ data: null, error: null }),
-  }));
-  return { insert, select, update };
+    update: vi.fn(() => ({ eq: vi.fn().mockResolvedValue({ data: null, error: null }) })),
+  };
 }
 
 describe('POST /api/deployments', () => {
@@ -51,21 +87,13 @@ describe('POST /api/deployments', () => {
   it('returns 401 when unauthenticated', async () => {
     mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
     const { POST } = await import('./route');
-
-    const res = await POST(post('http://localhost/api/deployments'), {
-      params: {} as any,
-    });
+    const res = await POST(post('http://localhost/api/deployments'), { params: {} as any });
     expect(res.status).toBe(401);
   });
 
   it('returns 400 for invalid JSON', async () => {
-    mockGetUser.mockResolvedValue({ data: { user: fakeUser }, error: null });
     const { POST } = await import('./route');
-    const req = new NextRequest('http://localhost/api/deployments', {
-      method: 'POST',
-      body: 'not-json',
-    });
-
+    const req = new NextRequest('http://localhost/api/deployments', { method: 'POST', body: 'not-json' });
     const res = await POST(req, { params: {} as any });
     expect(res.status).toBe(400);
     expect((await res.json()).error).toBe('Invalid JSON');
@@ -73,126 +101,98 @@ describe('POST /api/deployments', () => {
 
   it('returns 400 for missing templateId', async () => {
     const { POST } = await import('./route');
-    const res = await POST(
-      post('http://localhost/api/deployments', { customizationConfig: {} }),
-      { params: {} as any }
-    );
+    const res = await POST(post('http://localhost/api/deployments', { customizationConfig: {} }), { params: {} as any });
     expect(res.status).toBe(400);
   });
 
   it('returns 404 when template not found', async () => {
-    const templatesTable = makeSupabaseQuery([
-      { data: null, error: { message: 'not found' } },
-    ]);
     mockFrom.mockImplementation((table: string) => {
-      expect(table).toBe('templates');
-      return templatesTable;
+      if (table === 'templates') return makeTableMock([{ data: null, error: { message: 'not found' } }]);
+      return makeTableMock([]);
     });
-
     const { POST } = await import('./route');
-    const res = await POST(
-      post('http://localhost/api/deployments', { templateId: 'tpl-1' }),
-      { params: {} as any }
-    );
-
+    const res = await POST(post('http://localhost/api/deployments', { templateId: 'tpl-1' }), { params: {} as any });
     expect(res.status).toBe(404);
   });
 
-  it('returns 422 for invalid customization config', async () => {
-    const templatesTable = makeSupabaseQuery([
-      { data: { id: 'tpl-1', name: 'My Template' }, error: null },
-    ]);
-    const deploymentsTable = makeSupabaseQuery([]);
+  it('returns 403 with upgradeUrl when free-tier limit is reached', async () => {
     mockFrom.mockImplementation((table: string) => {
-      if (table === 'templates') return templatesTable;
-      if (table === 'deployments') return deploymentsTable;
-      return makeSupabaseQuery([]);
+      if (table === 'templates') return makeTableMock([{ data: { id: 'tpl-1', name: 'T' }, error: null }]);
+      if (table === 'profiles') return makeTableMock([{ data: { subscription_tier: 'free' }, error: null }]);
+      if (table === 'deployments') return makeTableMock([{ data: null, error: null, count: 1 }]); // at limit
+      return makeTableMock([]);
     });
-
-    const invalidConfig = {
-      branding: {
-        appName: '',
-        primaryColor: '#fff',
-        secondaryColor: '#fff',
-        fontFamily: 'Inter',
-      },
-      features: {
-        enableCharts: true,
-        enableTransactionHistory: true,
-        enableAnalytics: false,
-        enableNotifications: false,
-      },
-      stellar: {
-        network: 'testnet',
-        horizonUrl: 'https://horizon-testnet.stellar.org',
-      },
-    };
-
     const { POST } = await import('./route');
-    const res = await POST(
-      post('http://localhost/api/deployments', {
-        templateId: 'tpl-1',
-        customizationConfig: invalidConfig,
-      }),
-      { params: {} as any }
-    );
+    const res = await POST(post('http://localhost/api/deployments', { templateId: 'tpl-1', customizationConfig: validConfig }), { params: {} as any });
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.upgradeUrl).toBe('/pricing');
+    expect(body.error).toMatch(/limit reached/i);
+  });
 
+  it('returns 403 when pro-tier limit (10) is reached', async () => {
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'templates') return makeTableMock([{ data: { id: 'tpl-1', name: 'T' }, error: null }]);
+      if (table === 'profiles') return makeTableMock([{ data: { subscription_tier: 'pro' }, error: null }]);
+      if (table === 'deployments') return makeTableMock([{ data: null, error: null, count: 10 }]);
+      return makeTableMock([]);
+    });
+    const { POST } = await import('./route');
+    const res = await POST(post('http://localhost/api/deployments', { templateId: 'tpl-1', customizationConfig: validConfig }), { params: {} as any });
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.upgradeUrl).toBe('/pricing');
+  });
+
+  it('does not enforce a limit for enterprise tier', async () => {
+    const insertedDeployment = {
+      id: 'dep-1', template_id: 'tpl-1', user_id: fakeUser.id,
+      name: 'T', customization_config: {}, created_at: new Date().toISOString(),
+    };
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'templates') return makeTableMock([{ data: { id: 'tpl-1', name: 'T' }, error: null }]);
+      if (table === 'profiles') return makeTableMock([{ data: { subscription_tier: 'enterprise' }, error: null }]);
+      if (table === 'deployments') return makeTableMock([{ data: insertedDeployment, error: null }]);
+      return makeTableMock([]);
+    });
+    const { POST } = await import('./route');
+    const res = await POST(post('http://localhost/api/deployments', { templateId: 'tpl-1', customizationConfig: validConfig }), { params: {} as any });
+    // Should proceed past limit check — may fail at insert mock but not at 403
+    expect(res.status).not.toBe(403);
+  });
+
+  it('returns 422 for invalid customization config', async () => {
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'templates') return makeTableMock([{ data: { id: 'tpl-1', name: 'T' }, error: null }]);
+      if (table === 'profiles') return makeTableMock([{ data: { subscription_tier: 'free' }, error: null }]);
+      if (table === 'deployments') return makeTableMock([{ data: null, error: null, count: 0 }]);
+      return makeTableMock([]);
+    });
+    const invalidConfig = { ...validConfig, branding: { ...validConfig.branding, appName: '' } };
+    const { POST } = await import('./route');
+    const res = await POST(post('http://localhost/api/deployments', { templateId: 'tpl-1', customizationConfig: invalidConfig }), { params: {} as any });
     expect(res.status).toBe(422);
-    const json = await res.json();
-    expect(json.details).toBeDefined();
+    expect((await res.json()).details).toBeDefined();
   });
 
   it('creates deployment and returns 201', async () => {
-    const templatesTable = makeSupabaseQuery([
-      { data: { id: 'tpl-1', name: 'My Template' }, error: null },
+    const insertedDeployment = {
+      id: 'dep-1', template_id: 'tpl-1', user_id: fakeUser.id,
+      name: 'My Template', customization_config: {}, created_at: new Date().toISOString(),
+    };
+    // deployments table is called twice: count check, then insert+update
+    const deploymentsTable = makeTableMock([
+      { data: null, error: null, count: 0 },        // count check
+      { data: insertedDeployment, error: null },     // insert
     ]);
-    const deploymentsInsertResult = {
-      data: {
-        id: 'dep-1',
-        template_id: 'tpl-1',
-        user_id: fakeUser.id,
-        name: 'My Template',
-        customization_config: {},
-        created_at: new Date().toISOString(),
-      },
-      error: null,
-    };
-    const deploymentsTable = makeSupabaseQuery([deploymentsInsertResult]);
-
     mockFrom.mockImplementation((table: string) => {
-      if (table === 'templates') return templatesTable;
+      if (table === 'templates') return makeTableMock([{ data: { id: 'tpl-1', name: 'My Template' }, error: null }]);
+      if (table === 'profiles') return makeTableMock([{ data: { subscription_tier: 'free' }, error: null }]);
       if (table === 'deployments') return deploymentsTable;
-      return makeSupabaseQuery([]);
+      return makeTableMock([]);
     });
-
-    const validConfig = {
-      branding: {
-        appName: 'App',
-        primaryColor: '#000000',
-        secondaryColor: '#111111',
-        fontFamily: 'Inter',
-      },
-      features: {
-        enableCharts: true,
-        enableTransactionHistory: true,
-        enableAnalytics: false,
-        enableNotifications: false,
-      },
-      stellar: {
-        network: 'testnet',
-        horizonUrl: 'https://horizon-testnet.stellar.org',
-      },
-    };
-
     const { POST } = await import('./route');
-    const res = await POST(
-      post('http://localhost/api/deployments', {
-        templateId: 'tpl-1',
-        customizationConfig: validConfig,
-      }),
-      { params: {} as any }
-    );
-
+    const res = await POST(post('http://localhost/api/deployments', { templateId: 'tpl-1', customizationConfig: validConfig }), { params: {} as any });
     expect(res.status).toBe(201);
     const body = await res.json();
     expect(body.id).toBe('dep-1');

--- a/apps/web/src/app/api/deployments/route.ts
+++ b/apps/web/src/app/api/deployments/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 import { withAuth } from '@/lib/api/with-auth';
+import { getEntitlements } from '@/lib/stripe/pricing';
+import type { SubscriptionTier } from '@craft/types';
 import {
   validateCustomizationConfig,
   validateStellarEndpoints,
@@ -52,6 +54,34 @@ export const POST = withAuth(async (req: NextRequest, { supabase, user }) => {
 
   if (tplErr || !template) {
     return NextResponse.json({ error: 'Template not found' }, { status: 404 });
+  }
+
+  // Enforce deployment count limit based on subscription tier
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('subscription_tier')
+    .eq('id', user.id)
+    .single();
+
+  const tier = ((profile?.subscription_tier as SubscriptionTier) ?? 'free');
+  const { maxDeployments } = getEntitlements(tier);
+
+  if (maxDeployments !== -1) {
+    const { count } = await supabase
+      .from('deployments')
+      .select('id', { count: 'exact', head: true })
+      .eq('user_id', user.id)
+      .eq('is_active', true);
+
+    if ((count ?? 0) >= maxDeployments) {
+      return NextResponse.json(
+        {
+          error: `Deployment limit reached. Your ${tier} plan allows ${maxDeployments} active deployment${maxDeployments !== 1 ? 's' : ''}.`,
+          upgradeUrl: '/pricing',
+        },
+        { status: 403 }
+      );
+    }
   }
 
   const customization = body.customizationConfig ?? {};


### PR DESCRIPTION
Check active deployment count against subscription tier limits before creating a new deployment.

- free: 1 deployment, pro: 10, enterprise: unlimited (-1)
- Returns 403 + upgradeUrl:/pricing when limit is reached
- Missing profile rows default to free tier (safe fallback)
- Limits sourced from TIER_CONFIGS via getEntitlements() — single source of truth

closes #218 