### PR TITLE
feat: add domain deletion api route

### DIFF
--- a/apps/web/src/app/api/deployments/[id]/domains/[domain]/route.test.ts
+++ b/apps/web/src/app/api/deployments/[id]/domains/[domain]/route.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const mockGetUser = vi.fn();
+const mockFrom = vi.fn();
+const mockRemoveDomain = vi.fn();
+
+vi.mock('@/lib/supabase/server', () => ({
+    createClient: () => ({
+        auth: { getUser: mockGetUser },
+        from: mockFrom,
+    }),
+}));
+
+vi.mock('@/services/vercel.service', () => ({
+    VercelService: vi.fn().mockImplementation(() => ({
+        removeDomain: mockRemoveDomain,
+    })),
+    VercelApiError: class VercelApiError extends Error {
+        constructor(message: string, public code: string) {
+            super(message);
+        }
+    },
+}));
+
+const fakeUser = { id: 'user-1' };
+const params = { id: 'dep-1', domain: 'example.com' };
+
+function makeRequest() {
+    return new NextRequest(
+        'http://localhost/api/deployments/dep-1/domains/example.com',
+        { method: 'DELETE' },
+    );
+}
+
+type QueryResult = { data: Record<string, unknown> | null; error: { message: string } | null };
+
+function makeSupabaseQuery(results: QueryResult[], withUpdate = false) {
+    const chain: Record<string, unknown> = {
+        select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+                single: vi.fn().mockResolvedValue(results.shift() ?? { data: null, error: null }),
+            })),
+        })),
+    };
+    if (withUpdate) {
+        chain.update = vi.fn(() => ({ eq: vi.fn().mockResolvedValue({ error: null }) }));
+    }
+    return chain;
+}
+
+describe('DELETE /api/deployments/[id]/domains/[domain]', () => {
+    beforeEach(() => {
+        vi.resetAllMocks();
+        mockGetUser.mockResolvedValue({ data: { user: fakeUser }, error: null });
+    });
+
+    it('returns 401 when unauthenticated', async () => {
+        mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+        const { DELETE } = await import('./route');
+        expect((await DELETE(makeRequest(), { params })).status).toBe(401);
+    });
+
+    it('returns 403 when deployment belongs to another user', async () => {
+        mockFrom.mockReturnValue(
+            makeSupabaseQuery([{ data: { user_id: 'other' }, error: null }]),
+        );
+        const { DELETE } = await import('./route');
+        expect((await DELETE(makeRequest(), { params })).status).toBe(403);
+    });
+
+    it('returns 404 when deployment is not found', async () => {
+        mockFrom
+            .mockReturnValueOnce(makeSupabaseQuery([{ data: { user_id: fakeUser.id }, error: null }]))
+            .mockReturnValueOnce(makeSupabaseQuery([{ data: null, error: { message: 'not found' } }]));
+        const { DELETE } = await import('./route');
+        expect((await DELETE(makeRequest(), { params })).status).toBe(404);
+    });
+
+    it('returns 404 when no Vercel project is configured', async () => {
+        mockFrom
+            .mockReturnValueOnce(makeSupabaseQuery([{ data: { user_id: fakeUser.id }, error: null }]))
+            .mockReturnValueOnce(makeSupabaseQuery([{ data: { vercel_project_id: null, custom_domain: null }, error: null }]));
+        const { DELETE } = await import('./route');
+        const res = await DELETE(makeRequest(), { params });
+        expect(res.status).toBe(404);
+        expect((await res.json()).error).toMatch(/no vercel project/i);
+    });
+
+    it('returns 200 and clears custom_domain when it matches', async () => {
+        const mockUpdate = vi.fn(() => ({ eq: vi.fn().mockResolvedValue({ error: null }) }));
+        mockFrom
+            .mockReturnValueOnce(makeSupabaseQuery([{ data: { user_id: fakeUser.id }, error: null }]))
+            .mockReturnValueOnce({
+                select: vi.fn(() => ({
+                    eq: vi.fn(() => ({
+                        single: vi.fn().mockResolvedValue({
+                            data: { vercel_project_id: 'prj_1', custom_domain: 'example.com' },
+                            error: null,
+                        }),
+                    })),
+                })),
+            })
+            .mockReturnValueOnce({ update: mockUpdate });
+        mockRemoveDomain.mockResolvedValue(undefined);
+
+        const { DELETE } = await import('./route');
+        const res = await DELETE(makeRequest(), { params });
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.deleted).toBe(true);
+        expect(body.domain).toBe('example.com');
+        expect(mockUpdate).toHaveBeenCalledWith({ custom_domain: null });
+    });
+
+    it('returns 200 and does not clear custom_domain when it differs', async () => {
+        mockFrom
+            .mockReturnValueOnce(makeSupabaseQuery([{ data: { user_id: fakeUser.id }, error: null }]))
+            .mockReturnValueOnce({
+                select: vi.fn(() => ({
+                    eq: vi.fn(() => ({
+                        single: vi.fn().mockResolvedValue({
+                            data: { vercel_project_id: 'prj_1', custom_domain: 'other.com' },
+                            error: null,
+                        }),
+                    })),
+                })),
+            });
+        mockRemoveDomain.mockResolvedValue(undefined);
+
+        const { DELETE } = await import('./route');
+        const res = await DELETE(makeRequest(), { params });
+        expect(res.status).toBe(200);
+    });
+
+    it('returns 500 when removeDomain throws unexpectedly', async () => {
+        mockFrom
+            .mockReturnValueOnce(makeSupabaseQuery([{ data: { user_id: fakeUser.id }, error: null }]))
+            .mockReturnValueOnce({
+                select: vi.fn(() => ({
+                    eq: vi.fn(() => ({
+                        single: vi.fn().mockResolvedValue({
+                            data: { vercel_project_id: 'prj_1', custom_domain: null },
+                            error: null,
+                        }),
+                    })),
+                })),
+            });
+        mockRemoveDomain.mockRejectedValue(new Error('Vercel API error'));
+
+        const { DELETE } = await import('./route');
+        expect((await DELETE(makeRequest(), { params })).status).toBe(500);
+    });
+});

--- a/apps/web/src/app/api/deployments/[id]/domains/[domain]/route.ts
+++ b/apps/web/src/app/api/deployments/[id]/domains/[domain]/route.ts
@@ -1,0 +1,64 @@
+/**
+ * DELETE /api/deployments/[id]/domains/[domain]
+ *
+ * Removes a custom domain from a deployment: deletes it from the Vercel
+ * project and clears the custom_domain field in the database when it matches.
+ *
+ * Authentication & ownership:
+ *   Requires a valid session (401) and ownership of the deployment (403).
+ *
+ * Responses:
+ *   200 — Domain removed successfully
+ *   404 — Deployment not found or no Vercel project configured
+ *   401 — Not authenticated
+ *   403 — Not authorized for this deployment
+ *   500 — Unexpected error
+ *
+ * Feature: domain-deletion
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { withDeploymentAuth } from '@/lib/api/with-auth';
+import { VercelService } from '@/services/vercel.service';
+
+const vercel = new VercelService();
+
+export const DELETE = withDeploymentAuth<{ id: string; domain: string }>(
+    async (_req: NextRequest, { params, supabase }) => {
+        const { data: deployment, error } = await supabase
+            .from('deployments')
+            .select('vercel_project_id, custom_domain')
+            .eq('id', params.id)
+            .single();
+
+        if (error || !deployment) {
+            return NextResponse.json({ error: 'Deployment not found' }, { status: 404 });
+        }
+
+        if (!deployment.vercel_project_id) {
+            return NextResponse.json(
+                { error: 'No Vercel project configured for this deployment' },
+                { status: 404 },
+            );
+        }
+
+        try {
+            await vercel.removeDomain(params.domain, deployment.vercel_project_id);
+        } catch (err: unknown) {
+            return NextResponse.json(
+                { error: (err as Error).message ?? 'Failed to remove domain' },
+                { status: 500 },
+            );
+        }
+
+        // Clear the stored custom_domain if it matches the deleted domain
+        if (deployment.custom_domain === params.domain) {
+            await supabase
+                .from('deployments')
+                .update({ custom_domain: null })
+                .eq('id', params.id);
+        }
+
+        return NextResponse.json({ domain: params.domain, deleted: true });
+    },
+);


### PR DESCRIPTION
Closes #206

## What

Removes a custom domain from a deployment — deletes it from the Vercel project and clears 
the custom_domain field in the database when it matches.

## Changes

- DELETE /api/deployments/[id]/domains/[domain] — new endpoint, auth + ownership protected
- DB custom_domain is nulled only when it matches the deleted domain (no-op otherwise)

## Response shape

json
{ "domain": "example.com", "deleted": true }


## Edge cases

- Domain already removed from Vercel → still returns 200 (removeDomain treats 
DOMAIN_NOT_FOUND as a no-op, making the endpoint idempotent)
- Domain in the path differs from custom_domain in the DB → Vercel removal proceeds, DB 
field left untouched

## Tests

7 tests — 401, 403, 404 (not found + no Vercel project), 200 with DB cleared, 200 without 
DB change, 500. All pass.