### PR TITLE
audit(rls): audit, test, and document all RLS policies (#235)

### DIFF
--- a/apps/web/src/lib/rls/rls-policies.test.ts
+++ b/apps/web/src/lib/rls/rls-policies.test.ts
@@ -1,0 +1,328 @@
+/**
+ * RLS Policy Tests — Issue #235
+ *
+ * These tests simulate the Supabase RLS layer by applying the same
+ * USING / WITH CHECK predicates that the real policies enforce.
+ * Each table section covers:
+ *   (a) owner access → allowed
+ *   (b) other-user access → denied
+ *   (c) unauthenticated access → denied
+ *
+ * Where a policy has a known finding (overly-permissive INSERT WITH CHECK (true))
+ * the test documents the current behaviour AND the expected hardened behaviour.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Minimal in-process RLS simulator
+// ---------------------------------------------------------------------------
+
+type Row = Record<string, unknown>;
+
+/**
+ * Evaluates a USING / WITH CHECK predicate given a simulated auth context.
+ * Returns true if the row passes the policy (access granted).
+ */
+function applyUsing(
+    predicate: (row: Row, uid: string | null) => boolean,
+    row: Row,
+    uid: string | null
+): boolean {
+    return predicate(row, uid);
+}
+
+// ---------------------------------------------------------------------------
+// Shared fixtures
+// ---------------------------------------------------------------------------
+
+const USER_A = 'aaaaaaaa-0000-0000-0000-000000000001';
+const USER_B = 'bbbbbbbb-0000-0000-0000-000000000002';
+const ANON = null; // unauthenticated
+
+const DEPLOYMENT_A = 'dddddddd-0000-0000-0000-000000000001';
+const DEPLOYMENT_B = 'dddddddd-0000-0000-0000-000000000002';
+
+/** Simulates the deployments table for indirect-join policies. */
+const deploymentsTable: Row[] = [
+    { id: DEPLOYMENT_A, user_id: USER_A },
+    { id: DEPLOYMENT_B, user_id: USER_B },
+];
+
+function deploymentsBelongingTo(uid: string | null): string[] {
+    if (!uid) return [];
+    return deploymentsTable
+        .filter((d) => d.user_id === uid)
+        .map((d) => d.id as string);
+}
+
+// ---------------------------------------------------------------------------
+// Predicates — mirror the SQL USING / WITH CHECK expressions exactly
+// ---------------------------------------------------------------------------
+
+const policies = {
+    // profiles
+    profiles_select: (row: Row, uid: string | null) => uid !== null && uid === row.id,
+    profiles_update: (row: Row, uid: string | null) => uid !== null && uid === row.id,
+    profiles_insert: (row: Row, uid: string | null) => uid !== null && uid === row.id,
+
+    // deployments
+    deployments_select: (row: Row, uid: string | null) => uid !== null && uid === row.user_id,
+    deployments_insert: (row: Row, uid: string | null) => uid !== null && uid === row.user_id,
+    deployments_update: (row: Row, uid: string | null) => uid !== null && uid === row.user_id,
+    deployments_delete: (row: Row, uid: string | null) => uid !== null && uid === row.user_id,
+
+    // deployment_logs — SELECT uses indirect join
+    deployment_logs_select: (row: Row, uid: string | null) =>
+        deploymentsBelongingTo(uid).includes(row.deployment_id as string),
+
+    // FINDING F-1: current INSERT policy is WITH CHECK (true)
+    deployment_logs_insert_current: (_row: Row, _uid: string | null) => true,
+
+    // Hardened INSERT (recommended fix)
+    deployment_logs_insert_hardened: (row: Row, uid: string | null) =>
+        deploymentsBelongingTo(uid).includes(row.deployment_id as string),
+
+    // customization_drafts
+    drafts_select: (row: Row, uid: string | null) => uid !== null && uid === row.user_id,
+    drafts_insert: (row: Row, uid: string | null) => uid !== null && uid === row.user_id,
+    drafts_update: (row: Row, uid: string | null) => uid !== null && uid === row.user_id,
+    drafts_delete: (row: Row, uid: string | null) => uid !== null && uid === row.user_id,
+
+    // deployment_analytics — SELECT uses indirect join
+    analytics_select: (row: Row, uid: string | null) =>
+        deploymentsBelongingTo(uid).includes(row.deployment_id as string),
+
+    // FINDING F-2: current INSERT policy is WITH CHECK (true)
+    analytics_insert_current: (_row: Row, _uid: string | null) => true,
+
+    // Hardened INSERT (recommended fix)
+    analytics_insert_hardened: (row: Row, uid: string | null) =>
+        deploymentsBelongingTo(uid).includes(row.deployment_id as string),
+
+    // templates
+    templates_select: (row: Row, _uid: string | null) => row.is_active === true,
+    templates_service_role: (_row: Row, role: string | null) => role === 'service_role',
+};
+
+// ---------------------------------------------------------------------------
+// profiles
+// ---------------------------------------------------------------------------
+
+describe('RLS: profiles', () => {
+    const ownRow: Row = { id: USER_A };
+    const otherRow: Row = { id: USER_B };
+
+    describe('SELECT', () => {
+        it('(a) owner can read own profile', () => {
+            expect(applyUsing(policies.profiles_select, ownRow, USER_A)).toBe(true);
+        });
+        it('(b) other user cannot read another profile', () => {
+            expect(applyUsing(policies.profiles_select, otherRow, USER_A)).toBe(false);
+        });
+        it('(c) unauthenticated request is denied', () => {
+            expect(applyUsing(policies.profiles_select, ownRow, ANON)).toBe(false);
+        });
+    });
+
+    describe('UPDATE', () => {
+        it('(a) owner can update own profile', () => {
+            expect(applyUsing(policies.profiles_update, ownRow, USER_A)).toBe(true);
+        });
+        it('(b) other user cannot update another profile', () => {
+            expect(applyUsing(policies.profiles_update, otherRow, USER_A)).toBe(false);
+        });
+        it('(c) unauthenticated request is denied', () => {
+            expect(applyUsing(policies.profiles_update, ownRow, ANON)).toBe(false);
+        });
+    });
+
+    describe('INSERT', () => {
+        it('(a) user can insert their own profile row', () => {
+            expect(applyUsing(policies.profiles_insert, ownRow, USER_A)).toBe(true);
+        });
+        it('(b) user cannot insert a profile row for another user', () => {
+            expect(applyUsing(policies.profiles_insert, otherRow, USER_A)).toBe(false);
+        });
+        it('(c) unauthenticated request is denied', () => {
+            expect(applyUsing(policies.profiles_insert, ownRow, ANON)).toBe(false);
+        });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// deployments
+// ---------------------------------------------------------------------------
+
+describe('RLS: deployments', () => {
+    const ownRow: Row = { id: DEPLOYMENT_A, user_id: USER_A };
+    const otherRow: Row = { id: DEPLOYMENT_B, user_id: USER_B };
+
+    for (const [op, policy] of [
+        ['SELECT', policies.deployments_select],
+        ['INSERT', policies.deployments_insert],
+        ['UPDATE', policies.deployments_update],
+        ['DELETE', policies.deployments_delete],
+    ] as const) {
+        describe(op, () => {
+            it('(a) owner can access own deployment', () => {
+                expect(applyUsing(policy, ownRow, USER_A)).toBe(true);
+            });
+            it('(b) other user cannot access another deployment', () => {
+                expect(applyUsing(policy, otherRow, USER_A)).toBe(false);
+            });
+            it('(c) unauthenticated request is denied', () => {
+                expect(applyUsing(policy, ownRow, ANON)).toBe(false);
+            });
+        });
+    }
+});
+
+// ---------------------------------------------------------------------------
+// deployment_logs
+// ---------------------------------------------------------------------------
+
+describe('RLS: deployment_logs', () => {
+    const ownLog: Row = { id: 'log-1', deployment_id: DEPLOYMENT_A };
+    const otherLog: Row = { id: 'log-2', deployment_id: DEPLOYMENT_B };
+
+    describe('SELECT', () => {
+        it('(a) owner can read logs for own deployment', () => {
+            expect(applyUsing(policies.deployment_logs_select, ownLog, USER_A)).toBe(true);
+        });
+        it('(b) other user cannot read logs for another deployment', () => {
+            expect(applyUsing(policies.deployment_logs_select, otherLog, USER_A)).toBe(false);
+        });
+        it('(c) unauthenticated request is denied', () => {
+            expect(applyUsing(policies.deployment_logs_select, ownLog, ANON)).toBe(false);
+        });
+    });
+
+    describe('INSERT — current policy (WITH CHECK (true)) [FINDING F-1]', () => {
+        it('allows any authenticated user to insert a log for any deployment_id', () => {
+            // Documents the current (permissive) behaviour — this is the finding.
+            expect(applyUsing(policies.deployment_logs_insert_current, otherLog, USER_A)).toBe(true);
+        });
+        it('even allows unauthenticated inserts at the policy level', () => {
+            expect(applyUsing(policies.deployment_logs_insert_current, ownLog, ANON)).toBe(true);
+        });
+    });
+
+    describe('INSERT — hardened policy (recommended fix)', () => {
+        it('(a) owner can insert a log for own deployment', () => {
+            expect(applyUsing(policies.deployment_logs_insert_hardened, ownLog, USER_A)).toBe(true);
+        });
+        it('(b) other user cannot insert a log for another deployment', () => {
+            expect(applyUsing(policies.deployment_logs_insert_hardened, otherLog, USER_A)).toBe(false);
+        });
+        it('(c) unauthenticated request is denied', () => {
+            expect(applyUsing(policies.deployment_logs_insert_hardened, ownLog, ANON)).toBe(false);
+        });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// customization_drafts
+// ---------------------------------------------------------------------------
+
+describe('RLS: customization_drafts', () => {
+    const ownDraft: Row = { id: 'draft-1', user_id: USER_A };
+    const otherDraft: Row = { id: 'draft-2', user_id: USER_B };
+
+    for (const [op, policy] of [
+        ['SELECT', policies.drafts_select],
+        ['INSERT', policies.drafts_insert],
+        ['UPDATE', policies.drafts_update],
+        ['DELETE', policies.drafts_delete],
+    ] as const) {
+        describe(op, () => {
+            it('(a) owner can access own draft', () => {
+                expect(applyUsing(policy, ownDraft, USER_A)).toBe(true);
+            });
+            it('(b) other user cannot access another draft', () => {
+                expect(applyUsing(policy, otherDraft, USER_A)).toBe(false);
+            });
+            it('(c) unauthenticated request is denied', () => {
+                expect(applyUsing(policy, ownDraft, ANON)).toBe(false);
+            });
+        });
+    }
+});
+
+// ---------------------------------------------------------------------------
+// deployment_analytics
+// ---------------------------------------------------------------------------
+
+describe('RLS: deployment_analytics', () => {
+    const ownMetric: Row = { id: 'metric-1', deployment_id: DEPLOYMENT_A };
+    const otherMetric: Row = { id: 'metric-2', deployment_id: DEPLOYMENT_B };
+
+    describe('SELECT', () => {
+        it('(a) owner can read analytics for own deployment', () => {
+            expect(applyUsing(policies.analytics_select, ownMetric, USER_A)).toBe(true);
+        });
+        it('(b) other user cannot read analytics for another deployment', () => {
+            expect(applyUsing(policies.analytics_select, otherMetric, USER_A)).toBe(false);
+        });
+        it('(c) unauthenticated request is denied', () => {
+            expect(applyUsing(policies.analytics_select, ownMetric, ANON)).toBe(false);
+        });
+    });
+
+    describe('INSERT — current policy (WITH CHECK (true)) [FINDING F-2]', () => {
+        it('allows any authenticated user to insert a metric for any deployment_id', () => {
+            expect(applyUsing(policies.analytics_insert_current, otherMetric, USER_A)).toBe(true);
+        });
+        it('even allows unauthenticated inserts at the policy level', () => {
+            expect(applyUsing(policies.analytics_insert_current, ownMetric, ANON)).toBe(true);
+        });
+    });
+
+    describe('INSERT — hardened policy (recommended fix)', () => {
+        it('(a) owner can insert a metric for own deployment', () => {
+            expect(applyUsing(policies.analytics_insert_hardened, ownMetric, USER_A)).toBe(true);
+        });
+        it('(b) other user cannot insert a metric for another deployment', () => {
+            expect(applyUsing(policies.analytics_insert_hardened, otherMetric, USER_A)).toBe(false);
+        });
+        it('(c) unauthenticated request is denied', () => {
+            expect(applyUsing(policies.analytics_insert_hardened, ownMetric, ANON)).toBe(false);
+        });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// templates (public read, service-role write)
+// ---------------------------------------------------------------------------
+
+describe('RLS: templates', () => {
+    const activeTemplate: Row = { id: 'tmpl-1', is_active: true };
+    const inactiveTemplate: Row = { id: 'tmpl-2', is_active: false };
+
+    describe('SELECT (public — no auth required)', () => {
+        it('active template is visible to any user', () => {
+            expect(applyUsing(policies.templates_select, activeTemplate, USER_A)).toBe(true);
+        });
+        it('active template is visible even when unauthenticated', () => {
+            expect(applyUsing(policies.templates_select, activeTemplate, ANON)).toBe(true);
+        });
+        it('inactive template is hidden from all users', () => {
+            expect(applyUsing(policies.templates_select, inactiveTemplate, USER_A)).toBe(false);
+        });
+        it('inactive template is hidden from unauthenticated requests', () => {
+            expect(applyUsing(policies.templates_select, inactiveTemplate, ANON)).toBe(false);
+        });
+    });
+
+    describe('ALL (service_role only)', () => {
+        it('service_role can manage templates', () => {
+            expect(applyUsing(policies.templates_service_role, activeTemplate, 'service_role')).toBe(true);
+        });
+        it('regular authenticated user cannot manage templates', () => {
+            expect(applyUsing(policies.templates_service_role, activeTemplate, USER_A)).toBe(false);
+        });
+        it('unauthenticated request cannot manage templates', () => {
+            expect(applyUsing(policies.templates_service_role, activeTemplate, ANON)).toBe(false);
+        });
+    });
+});

--- a/docs/rls-audit.md
+++ b/docs/rls-audit.md
@@ -1,0 +1,112 @@
+# RLS Audit — CRAFT Platform
+
+> Issue #235 · Audited 2026-03-29
+
+## Summary Table
+
+| Table                  | RLS Enabled | Policies (ops)                                      | Findings                                                                                  |
+|------------------------|-------------|-----------------------------------------------------|-------------------------------------------------------------------------------------------|
+| `profiles`             | ✅           | SELECT, UPDATE, INSERT (own row only)               | No DELETE policy — intentional (cascade from auth.users). ✅                              |
+| `deployments`          | ✅           | SELECT, INSERT, UPDATE, DELETE (own rows only)      | Full CRUD covered. ✅                                                                      |
+| `deployment_logs`      | ✅           | SELECT (own deployments), INSERT `WITH CHECK (true)`| ⚠️ **FINDING F-1**: INSERT allows any authed user to write logs for any deployment_id.    |
+| `customization_drafts` | ✅           | SELECT, INSERT, UPDATE, DELETE (own rows only)      | Full CRUD covered. ✅                                                                      |
+| `deployment_analytics` | ✅           | SELECT (own deployments), INSERT `WITH CHECK (true)`| ⚠️ **FINDING F-2**: INSERT allows any authed user to write metrics for any deployment_id. |
+| `templates`            | ✅           | SELECT (active only), ALL (service_role only)       | Intentionally public read. Service-role write is correct. ✅                               |
+
+---
+
+## Findings
+
+### F-1 — `deployment_logs`: overly-permissive INSERT
+
+**Policy**: `"System can insert deployment logs"` — `WITH CHECK (true)`
+
+**Risk**: Any authenticated user can insert a log row with an arbitrary `deployment_id`, including one belonging to another user. This could pollute another user's log stream or be used to inject misleading log entries.
+
+**Mitigation in practice**: All log writes in the application go through the service_role key, which bypasses RLS entirely. The policy is therefore never exercised by normal application code.
+
+**Recommendation**: Either drop the policy entirely (rely on service_role bypass) or tighten it:
+
+```sql
+-- Option A: drop — service_role writes bypass RLS anyway
+DROP POLICY "System can insert deployment logs" ON deployment_logs;
+
+-- Option B: restrict to own deployments (if user-side inserts are ever needed)
+CREATE POLICY "Users can insert logs for own deployments" ON deployment_logs
+    FOR INSERT WITH CHECK (
+        deployment_id IN (SELECT id FROM deployments WHERE user_id = auth.uid())
+    );
+```
+
+---
+
+### F-2 — `deployment_analytics`: overly-permissive INSERT
+
+**Policy**: `"System can insert analytics"` — `WITH CHECK (true)`
+
+Same risk and recommendation as F-1. All analytics writes are server-side via service_role.
+
+---
+
+## Policy Details
+
+### `profiles`
+
+| Policy name                  | Op     | Expression                  |
+|------------------------------|--------|-----------------------------|
+| Users can view own profile   | SELECT | `auth.uid() = id`           |
+| Users can update own profile | UPDATE | `auth.uid() = id`           |
+| Users can insert own profile | INSERT | `auth.uid() = id`           |
+
+User identity: `auth.uid()` compared to the row's primary key (`id`, which mirrors `auth.users.id`).
+
+---
+
+### `deployments`
+
+| Policy name                    | Op     | Expression                  |
+|--------------------------------|--------|-----------------------------|
+| Users can view own deployments | SELECT | `auth.uid() = user_id`      |
+| Users can create own deployments | INSERT | `auth.uid() = user_id`    |
+| Users can update own deployments | UPDATE | `auth.uid() = user_id`    |
+| Users can delete own deployments | DELETE | `auth.uid() = user_id`    |
+
+---
+
+### `deployment_logs`
+
+| Policy name                              | Op     | Expression                                                                 |
+|------------------------------------------|--------|----------------------------------------------------------------------------|
+| Users can view logs for own deployments  | SELECT | `deployment_id IN (SELECT id FROM deployments WHERE user_id = auth.uid())` |
+| System can insert deployment logs ⚠️     | INSERT | `true`                                                                     |
+
+---
+
+### `customization_drafts`
+
+| Policy name                  | Op     | Expression                  |
+|------------------------------|--------|-----------------------------|
+| Users can view own drafts    | SELECT | `auth.uid() = user_id`      |
+| Users can create own drafts  | INSERT | `auth.uid() = user_id`      |
+| Users can update own drafts  | UPDATE | `auth.uid() = user_id`      |
+| Users can delete own drafts  | DELETE | `auth.uid() = user_id`      |
+
+---
+
+### `deployment_analytics`
+
+| Policy name                                    | Op     | Expression                                                                 |
+|------------------------------------------------|--------|----------------------------------------------------------------------------|
+| Users can view analytics for own deployments   | SELECT | `deployment_id IN (SELECT id FROM deployments WHERE user_id = auth.uid())` |
+| System can insert analytics ⚠️                 | INSERT | `true`                                                                     |
+
+---
+
+### `templates`
+
+| Policy name                      | Op  | Expression                                  |
+|----------------------------------|-----|---------------------------------------------|
+| Anyone can view active templates | SELECT | `is_active = true`                     |
+| Service role can manage templates | ALL | `auth.jwt()->>'role' = 'service_role'`  |
+
+Intentionally public: templates are platform-managed catalogue data, not user-specific.

--- a/supabase/migrations/002_row_level_security.sql
+++ b/supabase/migrations/002_row_level_security.sql
@@ -1,56 +1,140 @@
+-- ============================================================
+-- Migration 002: Row-Level Security Policies
+-- ============================================================
+-- User identity is established via auth.uid() which returns the
+-- UUID of the currently authenticated Supabase/JWT user.
+-- The service_role key bypasses ALL RLS policies by design —
+-- server-side API routes use it for writes that cross user
+-- boundaries (e.g. inserting deployment logs on behalf of a user).
+-- ============================================================
+
 -- Enable Row Level Security on all tables
 ALTER TABLE profiles ENABLE ROW LEVEL SECURITY;
 ALTER TABLE deployments ENABLE ROW LEVEL SECURITY;
 ALTER TABLE deployment_logs ENABLE ROW LEVEL SECURITY;
 ALTER TABLE customization_drafts ENABLE ROW LEVEL SECURITY;
 ALTER TABLE deployment_analytics ENABLE ROW LEVEL SECURITY;
--- Profiles policies
-CREATE POLICY "Users can view own profile" ON profiles FOR
-SELECT USING (auth.uid() = id);
-CREATE POLICY "Users can update own profile" ON profiles FOR
-UPDATE USING (auth.uid() = id);
-CREATE POLICY "Users can insert own profile" ON profiles FOR
-INSERT WITH CHECK (auth.uid() = id);
--- Deployments policies
-CREATE POLICY "Users can view own deployments" ON deployments FOR
-SELECT USING (auth.uid() = user_id);
-CREATE POLICY "Users can create own deployments" ON deployments FOR
-INSERT WITH CHECK (auth.uid() = user_id);
-CREATE POLICY "Users can update own deployments" ON deployments FOR
-UPDATE USING (auth.uid() = user_id);
-CREATE POLICY "Users can delete own deployments" ON deployments FOR DELETE USING (auth.uid() = user_id);
--- Deployment logs policies
-CREATE POLICY "Users can view logs for own deployments" ON deployment_logs FOR
-SELECT USING (
+
+-- ============================================================
+-- profiles
+-- Protects: personal subscription info, Stripe IDs, GitHub token.
+-- Identity: auth.uid() must equal the row's primary key (id).
+-- Edge cases:
+--   • No DELETE policy — profiles are deleted via CASCADE from
+--     auth.users, not directly by the user.
+--   • Service role can read/write all rows for webhook handlers.
+-- ============================================================
+CREATE POLICY "Users can view own profile" ON profiles
+    FOR SELECT USING (auth.uid() = id);
+
+CREATE POLICY "Users can update own profile" ON profiles
+    FOR UPDATE USING (auth.uid() = id);
+
+CREATE POLICY "Users can insert own profile" ON profiles
+    FOR INSERT WITH CHECK (auth.uid() = id);
+
+-- ============================================================
+-- deployments
+-- Protects: per-user deployment records including repo/Vercel IDs.
+-- Identity: auth.uid() must equal user_id foreign key.
+-- Edge cases: all four DML operations are covered.
+-- ============================================================
+CREATE POLICY "Users can view own deployments" ON deployments
+    FOR SELECT USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can create own deployments" ON deployments
+    FOR INSERT WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can update own deployments" ON deployments
+    FOR UPDATE USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can delete own deployments" ON deployments
+    FOR DELETE USING (auth.uid() = user_id);
+
+-- ============================================================
+-- deployment_logs
+-- Protects: build/runtime logs that may contain secrets.
+-- Identity: indirect — row's deployment_id must belong to a
+--   deployment owned by auth.uid().
+-- Edge cases:
+--   • INSERT uses WITH CHECK (true) so the server-side pipeline
+--     (running with service_role) can write logs without needing
+--     to impersonate the user.  This is intentional: the service
+--     role is trusted; anon/authenticated roles cannot insert
+--     because service_role bypasses RLS entirely.
+--   • No UPDATE or DELETE policies — logs are append-only.
+-- ============================================================
+CREATE POLICY "Users can view logs for own deployments" ON deployment_logs
+    FOR SELECT USING (
         deployment_id IN (
-            SELECT id
-            FROM deployments
-            WHERE user_id = auth.uid()
+            SELECT id FROM deployments WHERE user_id = auth.uid()
         )
     );
-CREATE POLICY "System can insert deployment logs" ON deployment_logs FOR
-INSERT WITH CHECK (true);
--- Customization drafts policies
-CREATE POLICY "Users can view own drafts" ON customization_drafts FOR
-SELECT USING (auth.uid() = user_id);
-CREATE POLICY "Users can create own drafts" ON customization_drafts FOR
-INSERT WITH CHECK (auth.uid() = user_id);
-CREATE POLICY "Users can update own drafts" ON customization_drafts FOR
-UPDATE USING (auth.uid() = user_id);
-CREATE POLICY "Users can delete own drafts" ON customization_drafts FOR DELETE USING (auth.uid() = user_id);
--- Deployment analytics policies
-CREATE POLICY "Users can view analytics for own deployments" ON deployment_analytics FOR
-SELECT USING (
+
+-- FINDING: WITH CHECK (true) allows any authenticated user to insert
+-- logs for any deployment_id.  Mitigated in practice by the fact that
+-- all log writes go through the service_role path, but a compromised
+-- authenticated token could pollute another user's logs.
+-- Recommendation: tighten to match the SELECT policy, or rely solely
+-- on service_role for inserts and drop this policy.
+CREATE POLICY "System can insert deployment logs" ON deployment_logs
+    FOR INSERT WITH CHECK (true);
+
+-- ============================================================
+-- customization_drafts
+-- Protects: saved UI customization state per user/template.
+-- Identity: auth.uid() must equal user_id.
+-- Edge cases: full CRUD covered.
+-- ============================================================
+CREATE POLICY "Users can view own drafts" ON customization_drafts
+    FOR SELECT USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can create own drafts" ON customization_drafts
+    FOR INSERT WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can update own drafts" ON customization_drafts
+    FOR UPDATE USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can delete own drafts" ON customization_drafts
+    FOR DELETE USING (auth.uid() = user_id);
+
+-- ============================================================
+-- deployment_analytics
+-- Protects: per-deployment metrics.
+-- Identity: indirect — deployment_id must belong to auth.uid().
+-- Edge cases:
+--   • INSERT WITH CHECK (true) — same trade-off as deployment_logs.
+--     Any authenticated user can insert a metric row for any
+--     deployment_id.  Acceptable only because analytics writes are
+--     server-side (service_role); flag as a finding for hardening.
+--   • No UPDATE or DELETE — metrics are immutable once recorded.
+-- ============================================================
+CREATE POLICY "Users can view analytics for own deployments" ON deployment_analytics
+    FOR SELECT USING (
         deployment_id IN (
-            SELECT id
-            FROM deployments
-            WHERE user_id = auth.uid()
+            SELECT id FROM deployments WHERE user_id = auth.uid()
         )
     );
-CREATE POLICY "System can insert analytics" ON deployment_analytics FOR
-INSERT WITH CHECK (true);
--- Templates are publicly readable (no RLS needed, but enable for consistency)
+
+-- FINDING: same overly-permissive INSERT as deployment_logs above.
+CREATE POLICY "System can insert analytics" ON deployment_analytics
+    FOR INSERT WITH CHECK (true);
+
+-- ============================================================
+-- templates
+-- Protects: template catalogue (not user-specific data).
+-- Identity: none required for SELECT — intentionally public.
+-- Edge cases:
+--   • Only active templates are visible to regular users.
+--   • The service_role policy uses auth.jwt()->>'role' = 'service_role'
+--     which is set by Supabase when the service key is used.
+--   • No authenticated-user write policies — templates are
+--     platform-managed, not user-managed.
+-- ============================================================
 ALTER TABLE templates ENABLE ROW LEVEL SECURITY;
-CREATE POLICY "Anyone can view active templates" ON templates FOR
-SELECT USING (is_active = true);
-CREATE POLICY "Service role can manage templates" ON templates FOR ALL USING (auth.jwt()->>'role' = 'service_role');
+
+CREATE POLICY "Anyone can view active templates" ON templates
+    FOR SELECT USING (is_active = true);
+
+CREATE POLICY "Service role can manage templates" ON templates
+    FOR ALL USING (auth.jwt()->>'role' = 'service_role');


### PR DESCRIPTION
closes #235 

Resolves #235 — full audit of all Row-Level Security policies across the CRAFT platform database.

## Changes

### `supabase/migrations/002_row_level_security.sql`
Added comment blocks above every policy explaining what it protects, how user identity is verified (`auth.uid()`), and any edge cases or assumptions (e.g. service_role bypass, append-only tables, intentional public access).

### `apps/web/src/lib/rls/rls-policies.test.ts`
56 tests covering all 6 RLS-enabled tables × all operations × 3 scenarios:
- (a) Authenticated user accessing their own data → allowed
- (b) Authenticated user accessing another user's data → denied
- (c) Unauthenticated request → denied

Also documents and tests the two findings below (current permissive behaviour + hardened predicate).

### `docs/rls-audit.md`
Audit document with summary table, per-table policy breakdown, and findings with recommended SQL fixes.

## Findings

| # | Table | Policy | Issue |
|---|-------|--------|-------|
| F-1 | `deployment_logs` | `"System can insert deployment logs"` | `WITH CHECK (true)` — any authenticated user can insert logs for any `deployment_id` |
| F-2 | `deployment_analytics` | `"System can insert analytics"` | `WITH CHECK (true)` — same issue for metric rows |

Both are mitigated in practice (all writes go through `service_role` which bypasses RLS), but the policies themselves are overly permissive. Recommended fix: either drop the policies entirely, or tighten to match the corresponding SELECT predicate. See `docs/rls-audit.md` for the exact SQL.

## Test results


Test Files  1 passed (1)
    Tests  56 passed (56)



- Annotate every policy in 002_row_level_security.sql with comment blocks explaining what it protects, how identity is verified, and known edge cases
- Add 56-test suite covering all 6 tables × all operations × 3 scenarios (own data, other-user data, unauthenticated)
- Flag two overly-permissive INSERT WITH CHECK (true) policies on deployment_logs and deployment_analytics as findings F-1 and F-2
- Add docs/rls-audit.md with summary table, findings, and recommended SQL fixes