### PR TITLE
feat: implement branding form components for customization

### DIFF
--- a/apps/web/src/components/app/branding/AppNameInput.tsx
+++ b/apps/web/src/components/app/branding/AppNameInput.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import React from 'react';
+
+interface AppNameInputProps {
+    value: string;
+    onChange: (value: string) => void;
+    error?: string;
+    maxLength?: number;
+}
+
+const MAX_APP_NAME = 60;
+
+export function AppNameInput({
+    value,
+    onChange,
+    error,
+    maxLength = MAX_APP_NAME,
+}: AppNameInputProps) {
+    const remaining = maxLength - value.length;
+    const hasError = !!error;
+
+    return (
+        <div className="flex flex-col gap-1.5">
+            <label
+                htmlFor="branding-app-name"
+                className="text-sm font-medium text-on-surface"
+            >
+                App name
+            </label>
+            <input
+                id="branding-app-name"
+                type="text"
+                value={value}
+                onChange={(e) => onChange(e.target.value.slice(0, maxLength))}
+                placeholder="My DeFi App"
+                aria-invalid={hasError}
+                aria-describedby={hasError ? 'app-name-error' : undefined}
+                className={`w-full rounded-lg border px-3 py-2 text-sm text-on-surface bg-surface-container-lowest placeholder:text-on-surface-variant/50 focus:outline-none focus:ring-2 transition-colors ${
+                    hasError
+                        ? 'border-error focus:ring-error/40'
+                        : 'border-outline-variant/30 focus:ring-primary/40'
+                }`}
+            />
+            <div className="flex justify-between">
+                {hasError ? (
+                    <p id="app-name-error" role="alert" className="text-xs text-error">
+                        {error}
+                    </p>
+                ) : (
+                    <span />
+                )}
+                <p
+                    className={`text-xs ${
+                        remaining < 10 ? 'text-error' : 'text-on-surface-variant/50'
+                    }`}
+                >
+                    {remaining} remaining
+                </p>
+            </div>
+        </div>
+    );
+}

--- a/apps/web/src/components/app/branding/BrandingForm.test.tsx
+++ b/apps/web/src/components/app/branding/BrandingForm.test.tsx
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { BrandingForm } from './BrandingForm';
+import type { BrandingFormReturn, BrandingFormState } from './useBrandingForm';
+
+const INITIAL_STATE: BrandingFormState = {
+    branding: {
+        appName: 'My App',
+        primaryColor: '#000519',
+        secondaryColor: '#545f73',
+        fontFamily: 'Inter',
+    },
+    features: {
+        enableCharts: true,
+        enableTransactionHistory: false,
+        enableAnalytics: false,
+        enableNotifications: false,
+    },
+};
+
+function createMockForm(overrides: Partial<BrandingFormReturn> = {}): BrandingFormReturn {
+    return {
+        state: INITIAL_STATE,
+        errors: new Map(),
+        isDirty: false,
+        setBranding: vi.fn(),
+        setFeatures: vi.fn(),
+        validate: vi.fn(() => []),
+        reset: vi.fn(),
+        ...overrides,
+    };
+}
+
+describe('BrandingForm', () => {
+    it('renders branding and features sections', () => {
+        render(<BrandingForm form={createMockForm()} onSubmit={vi.fn()} />);
+        expect(screen.getByText('Branding')).toBeDefined();
+        expect(screen.getByText('Features')).toBeDefined();
+    });
+
+    it('renders app name, color, and font inputs', () => {
+        render(<BrandingForm form={createMockForm()} onSubmit={vi.fn()} />);
+        expect(screen.getByLabelText('App name')).toBeDefined();
+        expect(screen.getByLabelText('Primary color')).toBeDefined();
+        expect(screen.getByLabelText('Secondary color')).toBeDefined();
+        expect(screen.getByLabelText('Font family')).toBeDefined();
+    });
+
+    it('renders feature toggles', () => {
+        render(<BrandingForm form={createMockForm()} onSubmit={vi.fn()} />);
+        expect(screen.getByText('Charts')).toBeDefined();
+        expect(screen.getByText('Transaction history')).toBeDefined();
+        expect(screen.getByText('Analytics')).toBeDefined();
+        expect(screen.getByText('Notifications')).toBeDefined();
+    });
+
+    it('disables submit and reset when not dirty', () => {
+        render(<BrandingForm form={createMockForm()} onSubmit={vi.fn()} />);
+        const submit = screen.getByRole('button', { name: 'Save changes' }) as HTMLButtonElement;
+        const reset = screen.getByRole('button', { name: 'Reset' }) as HTMLButtonElement;
+        expect(submit.disabled).toBe(true);
+        expect(reset.disabled).toBe(true);
+    });
+
+    it('enables submit and reset when dirty', () => {
+        render(
+            <BrandingForm form={createMockForm({ isDirty: true })} onSubmit={vi.fn()} />,
+        );
+        const submit = screen.getByRole('button', { name: 'Save changes' }) as HTMLButtonElement;
+        const reset = screen.getByRole('button', { name: 'Reset' }) as HTMLButtonElement;
+        expect(submit.disabled).toBe(false);
+        expect(reset.disabled).toBe(false);
+    });
+
+    it('calls validate then onSubmit when form is submitted with no errors', () => {
+        const onSubmit = vi.fn();
+        const validate = vi.fn(() => []);
+        render(
+            <BrandingForm
+                form={createMockForm({ isDirty: true, validate })}
+                onSubmit={onSubmit}
+            />,
+        );
+        fireEvent.click(screen.getByRole('button', { name: 'Save changes' }));
+        expect(validate).toHaveBeenCalledOnce();
+        expect(onSubmit).toHaveBeenCalledOnce();
+    });
+
+    it('does not call onSubmit when validation fails', () => {
+        const onSubmit = vi.fn();
+        const validate = vi.fn(() => [
+            { field: 'branding.appName', message: 'Required', code: 'TOO_SMALL' },
+        ]);
+        render(
+            <BrandingForm
+                form={createMockForm({ isDirty: true, validate })}
+                onSubmit={onSubmit}
+            />,
+        );
+        fireEvent.click(screen.getByRole('button', { name: 'Save changes' }));
+        expect(validate).toHaveBeenCalledOnce();
+        expect(onSubmit).not.toHaveBeenCalled();
+    });
+
+    it('calls reset when Reset button is clicked', () => {
+        const reset = vi.fn();
+        render(
+            <BrandingForm
+                form={createMockForm({ isDirty: true, reset })}
+                onSubmit={vi.fn()}
+            />,
+        );
+        fireEvent.click(screen.getByRole('button', { name: 'Reset' }));
+        expect(reset).toHaveBeenCalledOnce();
+    });
+
+    it('shows custom submit label', () => {
+        render(
+            <BrandingForm
+                form={createMockForm({ isDirty: true })}
+                onSubmit={vi.fn()}
+                submitLabel="Deploy now"
+            />,
+        );
+        expect(screen.getByRole('button', { name: 'Deploy now' })).toBeDefined();
+    });
+
+    it('shows submitting state', () => {
+        render(
+            <BrandingForm
+                form={createMockForm({ isDirty: true })}
+                onSubmit={vi.fn()}
+                isSubmitting
+            />,
+        );
+        expect(screen.getByRole('button', { name: 'Saving…' })).toBeDefined();
+    });
+
+    it('displays validation errors on inputs', () => {
+        const errors = new Map([['branding.appName', 'App name is required']]);
+        render(
+            <BrandingForm form={createMockForm({ errors })} onSubmit={vi.fn()} />,
+        );
+        expect(screen.getByText('App name is required')).toBeDefined();
+        expect(screen.getByLabelText('App name').getAttribute('aria-invalid')).toBe('true');
+    });
+
+    it('renders feature toggles with correct aria-checked state', () => {
+        render(<BrandingForm form={createMockForm()} onSubmit={vi.fn()} />);
+        const chartsToggle = screen.getByRole('switch', { name: /Charts/ });
+        expect(chartsToggle.getAttribute('aria-checked')).toBe('true');
+        const analyticsToggle = screen.getByRole('switch', { name: /Analytics/ });
+        expect(analyticsToggle.getAttribute('aria-checked')).toBe('false');
+    });
+});

--- a/apps/web/src/components/app/branding/BrandingForm.tsx
+++ b/apps/web/src/components/app/branding/BrandingForm.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import React from 'react';
+import { AppNameInput } from './AppNameInput';
+import { ColorInput } from './ColorInput';
+import { FontSelector } from './FontSelector';
+import { FeatureToggles } from './FeatureToggles';
+import type { BrandingFormReturn } from './useBrandingForm';
+
+interface BrandingFormProps {
+    form: BrandingFormReturn;
+    onSubmit: () => void;
+    submitLabel?: string;
+    isSubmitting?: boolean;
+}
+
+export function BrandingForm({
+    form,
+    onSubmit,
+    submitLabel = 'Save changes',
+    isSubmitting = false,
+}: BrandingFormProps) {
+    const { state, errors, isDirty, setBranding, setFeatures, validate, reset } = form;
+
+    function handleSubmit(e: React.FormEvent) {
+        e.preventDefault();
+        const validationErrors = validate();
+        if (validationErrors.length === 0) {
+            onSubmit();
+        }
+    }
+
+    return (
+        <form onSubmit={handleSubmit} className="flex flex-col gap-8" noValidate>
+            <BrandingSection title="Branding">
+                <AppNameInput
+                    value={state.branding.appName}
+                    onChange={(v) => setBranding('appName', v)}
+                    error={errors.get('branding.appName')}
+                />
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                    <ColorInput
+                        id="branding-primary-color"
+                        label="Primary color"
+                        value={state.branding.primaryColor}
+                        onChange={(v) => setBranding('primaryColor', v)}
+                        error={errors.get('branding.primaryColor')}
+                    />
+                    <ColorInput
+                        id="branding-secondary-color"
+                        label="Secondary color"
+                        value={state.branding.secondaryColor}
+                        onChange={(v) => setBranding('secondaryColor', v)}
+                        error={errors.get('branding.secondaryColor')}
+                    />
+                </div>
+                <FontSelector
+                    value={state.branding.fontFamily}
+                    onChange={(v) => setBranding('fontFamily', v)}
+                    error={errors.get('branding.fontFamily')}
+                />
+            </BrandingSection>
+
+            <BrandingSection title="Features">
+                <FeatureToggles value={state.features} onChange={setFeatures} />
+            </BrandingSection>
+
+            <div className="flex gap-3 justify-end border-t border-outline-variant/20 pt-6">
+                <button
+                    type="button"
+                    onClick={reset}
+                    disabled={!isDirty || isSubmitting}
+                    className="px-4 py-2.5 rounded-lg text-sm font-semibold text-on-surface-variant border border-outline-variant/20 hover:bg-surface-container-low transition-all disabled:opacity-40 disabled:cursor-not-allowed"
+                >
+                    Reset
+                </button>
+                <button
+                    type="submit"
+                    disabled={!isDirty || isSubmitting}
+                    className="primary-gradient text-on-primary px-5 py-2.5 rounded-lg text-sm font-semibold shadow-md hover:shadow-lg transition-all active:scale-95 disabled:opacity-60 disabled:cursor-not-allowed disabled:active:scale-100"
+                >
+                    {isSubmitting ? 'Saving…' : submitLabel}
+                </button>
+            </div>
+        </form>
+    );
+}
+
+function BrandingSection({
+    title,
+    children,
+}: {
+    title: string;
+    children: React.ReactNode;
+}) {
+    return (
+        <section className="flex flex-col gap-5">
+            <h3 className="text-lg font-bold font-headline text-on-surface">
+                {title}
+            </h3>
+            <div className="flex flex-col gap-4">{children}</div>
+        </section>
+    );
+}

--- a/apps/web/src/components/app/branding/ColorInput.tsx
+++ b/apps/web/src/components/app/branding/ColorInput.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import React from 'react';
+
+interface ColorInputProps {
+    id: string;
+    label: string;
+    value: string;
+    onChange: (value: string) => void;
+    error?: string;
+}
+
+const HEX_COLOR = /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/;
+
+export function ColorInput({ id, label, value, onChange, error }: ColorInputProps) {
+    const hasError = !!error;
+    const isValidHex = HEX_COLOR.test(value);
+
+    return (
+        <div className="flex flex-col gap-1.5">
+            <label htmlFor={id} className="text-sm font-medium text-on-surface">
+                {label}
+            </label>
+            <div className="flex items-center gap-2">
+                <input
+                    type="color"
+                    value={isValidHex ? (value.length === 4 ? expandShortHex(value) : value) : '#000000'}
+                    onChange={(e) => onChange(e.target.value)}
+                    aria-label={`${label} picker`}
+                    className="h-9 w-9 shrink-0 cursor-pointer rounded border border-outline-variant/30 bg-transparent p-0.5"
+                />
+                <input
+                    id={id}
+                    type="text"
+                    value={value}
+                    onChange={(e) => onChange(e.target.value)}
+                    placeholder="#000000"
+                    aria-invalid={hasError}
+                    aria-describedby={hasError ? `${id}-error` : undefined}
+                    className={`w-full rounded-lg border px-3 py-2 text-sm font-mono text-on-surface bg-surface-container-lowest placeholder:text-on-surface-variant/50 focus:outline-none focus:ring-2 transition-colors ${
+                        hasError
+                            ? 'border-error focus:ring-error/40'
+                            : 'border-outline-variant/30 focus:ring-primary/40'
+                    }`}
+                />
+            </div>
+            {hasError && (
+                <p id={`${id}-error`} role="alert" className="text-xs text-error">
+                    {error}
+                </p>
+            )}
+        </div>
+    );
+}
+
+function expandShortHex(hex: string): string {
+    const [, r, g, b] = hex.split('');
+    return `#${r}${r}${g}${g}${b}${b}`;
+}

--- a/apps/web/src/components/app/branding/FeatureToggles.tsx
+++ b/apps/web/src/components/app/branding/FeatureToggles.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import React from 'react';
+import type { FeatureConfig } from '@craft/types';
+
+interface FeatureTogglesProps {
+    value: FeatureConfig;
+    onChange: (value: FeatureConfig) => void;
+}
+
+interface ToggleItem {
+    key: keyof FeatureConfig;
+    label: string;
+    description: string;
+}
+
+const TOGGLES: ToggleItem[] = [
+    {
+        key: 'enableCharts',
+        label: 'Charts',
+        description: 'Display interactive price and volume charts',
+    },
+    {
+        key: 'enableTransactionHistory',
+        label: 'Transaction history',
+        description: 'Show a history of past transactions',
+    },
+    {
+        key: 'enableAnalytics',
+        label: 'Analytics',
+        description: 'Include analytics and performance dashboards',
+    },
+    {
+        key: 'enableNotifications',
+        label: 'Notifications',
+        description: 'Enable in-app notification system',
+    },
+];
+
+export function FeatureToggles({ value, onChange }: FeatureTogglesProps) {
+    function handleToggle(key: keyof FeatureConfig) {
+        onChange({ ...value, [key]: !value[key] });
+    }
+
+    return (
+        <fieldset className="flex flex-col gap-1">
+            <legend className="text-sm font-medium text-on-surface mb-3">
+                Feature toggles
+            </legend>
+            <div className="flex flex-col divide-y divide-outline-variant/20">
+                {TOGGLES.map(({ key, label, description }) => (
+                    <label
+                        key={key}
+                        htmlFor={`toggle-${key}`}
+                        className="flex items-center justify-between gap-4 py-3 cursor-pointer"
+                    >
+                        <div className="flex flex-col gap-0.5">
+                            <span className="text-sm font-medium text-on-surface">
+                                {label}
+                            </span>
+                            <span className="text-xs text-on-surface-variant">
+                                {description}
+                            </span>
+                        </div>
+                        <button
+                            id={`toggle-${key}`}
+                            type="button"
+                            role="switch"
+                            aria-checked={value[key]}
+                            onClick={() => handleToggle(key)}
+                            className={`relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-primary/40 focus:ring-offset-2 ${
+                                value[key]
+                                    ? 'bg-primary'
+                                    : 'bg-outline-variant/40'
+                            }`}
+                        >
+                            <span
+                                className={`inline-block h-4 w-4 rounded-full bg-white shadow transition-transform ${
+                                    value[key] ? 'translate-x-6' : 'translate-x-1'
+                                }`}
+                            />
+                        </button>
+                    </label>
+                ))}
+            </div>
+        </fieldset>
+    );
+}

--- a/apps/web/src/components/app/branding/FontSelector.tsx
+++ b/apps/web/src/components/app/branding/FontSelector.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import React from 'react';
+
+interface FontSelectorProps {
+    value: string;
+    onChange: (value: string) => void;
+    error?: string;
+}
+
+const FONT_OPTIONS = [
+    'Inter',
+    'Manrope',
+    'Roboto',
+    'Open Sans',
+    'Lato',
+    'Poppins',
+    'Montserrat',
+    'Source Sans 3',
+    'Nunito',
+    'Raleway',
+];
+
+export function FontSelector({ value, onChange, error }: FontSelectorProps) {
+    const hasError = !!error;
+
+    return (
+        <div className="flex flex-col gap-1.5">
+            <label
+                htmlFor="branding-font-family"
+                className="text-sm font-medium text-on-surface"
+            >
+                Font family
+            </label>
+            <select
+                id="branding-font-family"
+                value={value}
+                onChange={(e) => onChange(e.target.value)}
+                aria-invalid={hasError}
+                aria-describedby={hasError ? 'font-family-error' : undefined}
+                className={`w-full rounded-lg border px-3 py-2 text-sm text-on-surface bg-surface-container-lowest focus:outline-none focus:ring-2 transition-colors ${
+                    hasError
+                        ? 'border-error focus:ring-error/40'
+                        : 'border-outline-variant/30 focus:ring-primary/40'
+                }`}
+            >
+                <option value="">Select a font…</option>
+                {FONT_OPTIONS.map((font) => (
+                    <option key={font} value={font}>
+                        {font}
+                    </option>
+                ))}
+            </select>
+            {hasError && (
+                <p id="font-family-error" role="alert" className="text-xs text-error">
+                    {error}
+                </p>
+            )}
+            {value && (
+                <p
+                    className="text-sm text-on-surface-variant"
+                    style={{ fontFamily: value }}
+                >
+                    The quick brown fox jumps over the lazy dog
+                </p>
+            )}
+        </div>
+    );
+}
+
+export { FONT_OPTIONS };

--- a/apps/web/src/components/app/branding/index.ts
+++ b/apps/web/src/components/app/branding/index.ts
@@ -1,0 +1,7 @@
+export { AppNameInput } from './AppNameInput';
+export { ColorInput } from './ColorInput';
+export { FontSelector, FONT_OPTIONS } from './FontSelector';
+export { FeatureToggles } from './FeatureToggles';
+export { BrandingForm } from './BrandingForm';
+export { useBrandingForm } from './useBrandingForm';
+export type { BrandingFormState, BrandingFormReturn } from './useBrandingForm';

--- a/apps/web/src/components/app/branding/useBrandingForm.test.ts
+++ b/apps/web/src/components/app/branding/useBrandingForm.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useBrandingForm, type BrandingFormState } from './useBrandingForm';
+
+const INITIAL: BrandingFormState = {
+    branding: {
+        appName: 'My App',
+        primaryColor: '#000519',
+        secondaryColor: '#545f73',
+        fontFamily: 'Inter',
+    },
+    features: {
+        enableCharts: true,
+        enableTransactionHistory: true,
+        enableAnalytics: false,
+        enableNotifications: false,
+    },
+};
+
+describe('useBrandingForm', () => {
+    it('initializes with the given state', () => {
+        const { result } = renderHook(() => useBrandingForm(INITIAL));
+        expect(result.current.state).toEqual(INITIAL);
+        expect(result.current.isDirty).toBe(false);
+        expect(result.current.errors.size).toBe(0);
+    });
+
+    it('tracks dirty state when branding changes', () => {
+        const { result } = renderHook(() => useBrandingForm(INITIAL));
+        act(() => result.current.setBranding('appName', 'New Name'));
+        expect(result.current.isDirty).toBe(true);
+        expect(result.current.state.branding.appName).toBe('New Name');
+    });
+
+    it('tracks dirty state when features change', () => {
+        const { result } = renderHook(() => useBrandingForm(INITIAL));
+        act(() =>
+            result.current.setFeatures({ ...INITIAL.features, enableAnalytics: true }),
+        );
+        expect(result.current.isDirty).toBe(true);
+    });
+
+    it('is not dirty after reset', () => {
+        const { result } = renderHook(() => useBrandingForm(INITIAL));
+        act(() => result.current.setBranding('appName', 'Changed'));
+        expect(result.current.isDirty).toBe(true);
+        act(() => result.current.reset());
+        expect(result.current.isDirty).toBe(false);
+        expect(result.current.state).toEqual(INITIAL);
+    });
+
+    it('validates empty app name', () => {
+        const { result } = renderHook(() => useBrandingForm(INITIAL));
+        act(() => result.current.setBranding('appName', ''));
+        let errors: any[];
+        act(() => { errors = result.current.validate(); });
+        expect(errors!.some((e) => e.field === 'branding.appName')).toBe(true);
+        expect(result.current.errors.get('branding.appName')).toBe('App name is required');
+    });
+
+    it('validates invalid hex color', () => {
+        const { result } = renderHook(() => useBrandingForm(INITIAL));
+        act(() => result.current.setBranding('primaryColor', 'notahex'));
+        let errors: any[];
+        act(() => { errors = result.current.validate(); });
+        expect(errors!.some((e) => e.field === 'branding.primaryColor')).toBe(true);
+    });
+
+    it('validates duplicate colors', () => {
+        const { result } = renderHook(() => useBrandingForm(INITIAL));
+        act(() => {
+            result.current.setBranding('primaryColor', '#aabbcc');
+            result.current.setBranding('secondaryColor', '#aabbcc');
+        });
+        let errors: any[];
+        act(() => { errors = result.current.validate(); });
+        expect(errors!.some((e) => e.code === 'DUPLICATE_COLORS')).toBe(true);
+    });
+
+    it('validates empty font family', () => {
+        const { result } = renderHook(() => useBrandingForm(INITIAL));
+        act(() => result.current.setBranding('fontFamily', ''));
+        let errors: any[];
+        act(() => { errors = result.current.validate(); });
+        expect(errors!.some((e) => e.field === 'branding.fontFamily')).toBe(true);
+    });
+
+    it('returns no errors for valid state', () => {
+        const { result } = renderHook(() => useBrandingForm(INITIAL));
+        let errors: any[];
+        act(() => { errors = result.current.validate(); });
+        expect(errors!).toEqual([]);
+        expect(result.current.errors.size).toBe(0);
+    });
+
+    it('clears field error when that field changes', () => {
+        const { result } = renderHook(() => useBrandingForm(INITIAL));
+        act(() => result.current.setBranding('appName', ''));
+        act(() => { result.current.validate(); });
+        expect(result.current.errors.has('branding.appName')).toBe(true);
+        act(() => result.current.setBranding('appName', 'Fixed'));
+        expect(result.current.errors.has('branding.appName')).toBe(false);
+    });
+
+    it('clears all errors on reset', () => {
+        const { result } = renderHook(() => useBrandingForm(INITIAL));
+        act(() => result.current.setBranding('appName', ''));
+        act(() => { result.current.validate(); });
+        expect(result.current.errors.size).toBeGreaterThan(0);
+        act(() => result.current.reset());
+        expect(result.current.errors.size).toBe(0);
+    });
+});

--- a/apps/web/src/components/app/branding/useBrandingForm.ts
+++ b/apps/web/src/components/app/branding/useBrandingForm.ts
@@ -1,0 +1,109 @@
+'use client';
+
+import { useState, useCallback, useMemo, useRef } from 'react';
+import type { BrandingConfig, FeatureConfig, ValidationError } from '@craft/types';
+
+export interface BrandingFormState {
+    branding: BrandingConfig;
+    features: FeatureConfig;
+}
+
+export interface BrandingFormReturn {
+    state: BrandingFormState;
+    errors: Map<string, string>;
+    isDirty: boolean;
+    setBranding: <K extends keyof BrandingConfig>(key: K, value: BrandingConfig[K]) => void;
+    setFeatures: (features: FeatureConfig) => void;
+    validate: () => ValidationError[];
+    reset: () => void;
+}
+
+const HEX_COLOR = /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/;
+
+function validateBrandingFields(state: BrandingFormState): ValidationError[] {
+    const errors: ValidationError[] = [];
+    const { branding } = state;
+
+    if (!branding.appName.trim()) {
+        errors.push({ field: 'branding.appName', message: 'App name is required', code: 'TOO_SMALL' });
+    } else if (branding.appName.length > 60) {
+        errors.push({ field: 'branding.appName', message: 'App name must be 60 characters or fewer', code: 'TOO_BIG' });
+    }
+
+    if (!HEX_COLOR.test(branding.primaryColor)) {
+        errors.push({ field: 'branding.primaryColor', message: 'Primary color must be a valid hex color', code: 'INVALID_STRING' });
+    }
+
+    if (!HEX_COLOR.test(branding.secondaryColor)) {
+        errors.push({ field: 'branding.secondaryColor', message: 'Secondary color must be a valid hex color', code: 'INVALID_STRING' });
+    }
+
+    if (
+        HEX_COLOR.test(branding.primaryColor) &&
+        HEX_COLOR.test(branding.secondaryColor) &&
+        branding.primaryColor.toLowerCase() === branding.secondaryColor.toLowerCase()
+    ) {
+        errors.push({ field: 'branding.secondaryColor', message: 'Secondary color must differ from primary color', code: 'DUPLICATE_COLORS' });
+    }
+
+    if (!branding.fontFamily.trim()) {
+        errors.push({ field: 'branding.fontFamily', message: 'Font family is required', code: 'TOO_SMALL' });
+    }
+
+    return errors;
+}
+
+export function useBrandingForm(initial: BrandingFormState): BrandingFormReturn {
+    const [state, setState] = useState<BrandingFormState>(initial);
+    const [validationErrors, setValidationErrors] = useState<ValidationError[]>([]);
+    const initialRef = useRef(initial);
+
+    const isDirty = useMemo(() => {
+        const init = initialRef.current;
+        return (
+            state.branding.appName !== init.branding.appName ||
+            state.branding.primaryColor !== init.branding.primaryColor ||
+            state.branding.secondaryColor !== init.branding.secondaryColor ||
+            state.branding.fontFamily !== init.branding.fontFamily ||
+            state.branding.logoUrl !== init.branding.logoUrl ||
+            state.features.enableCharts !== init.features.enableCharts ||
+            state.features.enableTransactionHistory !== init.features.enableTransactionHistory ||
+            state.features.enableAnalytics !== init.features.enableAnalytics ||
+            state.features.enableNotifications !== init.features.enableNotifications
+        );
+    }, [state]);
+
+    const setBranding = useCallback(<K extends keyof BrandingConfig>(key: K, value: BrandingConfig[K]) => {
+        setState((prev) => ({
+            ...prev,
+            branding: { ...prev.branding, [key]: value },
+        }));
+        // Clear field error on change
+        setValidationErrors((prev) => prev.filter((e) => e.field !== `branding.${key}`));
+    }, []);
+
+    const setFeatures = useCallback((features: FeatureConfig) => {
+        setState((prev) => ({ ...prev, features }));
+    }, []);
+
+    const validate = useCallback((): ValidationError[] => {
+        const errors = validateBrandingFields(state);
+        setValidationErrors(errors);
+        return errors;
+    }, [state]);
+
+    const reset = useCallback(() => {
+        setState(initialRef.current);
+        setValidationErrors([]);
+    }, []);
+
+    const errors = useMemo(() => {
+        const map = new Map<string, string>();
+        for (const err of validationErrors) {
+            map.set(err.field, err.message);
+        }
+        return map;
+    }, [validationErrors]);
+
+    return { state, errors, isDirty, setBranding, setFeatures, validate, reset };
+}


### PR DESCRIPTION
## Summary

Implements the branding and feature-toggle form primitives for the customization studio, as described in #17.

- **AppNameInput** — Text input with 60-character limit, live character counter, and validation error display
- **ColorInput** — Paired native color picker + hex text input with hex format validation
- **FontSelector** — Dropdown of 10 web fonts with a live font preview sentence
- **FeatureToggles** — Accessible toggle switches (`role="switch"`, `aria-checked`) for charts, transaction history, analytics, and notifications
- **useBrandingForm** hook — Manages form state, dirty-state tracking (compares against initial values), field-level validation (required fields, hex format, duplicate color check), error clearing on edit, and full reset
- **BrandingForm** — Composable form section that composes all inputs into Branding + Features sections with submit/reset buttons, validation gating, and submitting state
- **Barrel export** via `index.ts` for clean imports

### Design decisions

- Validation rules mirror the existing Zod schema in `lib/customization/validate.ts` (hex regex, duplicate color business rule, required fields)
- Follows existing component patterns: `'use client'` directives, Tailwind design tokens, `aria-invalid`/`aria-describedby` accessibility attributes
- Dirty state disables Reset and Save buttons when the form is clean
- Field errors clear individually when edited, or all at once on reset

## Test plan

- [x] 11 unit tests for `useBrandingForm` — state init, dirty tracking, all validation rules, error clearing, reset
- [x] 12 unit tests for `BrandingForm` — rendering, submit/reset behavior, validation gating, error display, accessibility (aria-checked on toggles)
- [x] All 23 new tests pass (`vitest run src/components/app/branding/`)
- [x] No regressions in existing test suite

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)