### PR TITLE
feat: add subscription management page

### DIFF
--- a/apps/frontend/src/app/app/settings/billing/page.test.tsx
+++ b/apps/frontend/src/app/app/settings/billing/page.test.tsx
@@ -1,0 +1,284 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Tests for the subscription management page at /app/settings/billing.
+ *
+ * Strategy: mock fetch, @/lib/stripe/pricing, and child components that have
+ * their own test suites (AppShell, TierUsageIndicators, UpgradePromptModal) so
+ * this suite focuses on the page's own logic: data fetching, rendering tier
+ * info, billing dates, and action buttons.
+ */
+
+import React from 'react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import BillingPage from './page';
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+vi.mock('@/lib/stripe/pricing', () => ({
+  TIER_CONFIGS: {
+    free: {
+      tier: 'free',
+      displayName: 'Free',
+      monthlyPriceCents: 0,
+      stripePriceId: null,
+      entitlements: { maxDeployments: 1, maxCustomDomains: 0, analyticsEnabled: false, premiumTemplates: false, prioritySupport: false },
+    },
+    pro: {
+      tier: 'pro',
+      displayName: 'Pro',
+      monthlyPriceCents: 2900,
+      stripePriceId: 'price_pro',
+      entitlements: { maxDeployments: 10, maxCustomDomains: 1, analyticsEnabled: true, premiumTemplates: true, prioritySupport: false },
+    },
+    enterprise: {
+      tier: 'enterprise',
+      displayName: 'Enterprise',
+      monthlyPriceCents: 9900,
+      stripePriceId: 'price_enterprise',
+      entitlements: { maxDeployments: -1, maxCustomDomains: -1, analyticsEnabled: true, premiumTemplates: true, prioritySupport: true },
+    },
+  },
+  getEntitlements: (tier: string) => {
+    const map: Record<string, { maxDeployments: number; maxCustomDomains: number }> = {
+      free: { maxDeployments: 1, maxCustomDomains: 0 },
+      pro: { maxDeployments: 10, maxCustomDomains: 1 },
+      enterprise: { maxDeployments: -1, maxCustomDomains: -1 },
+    };
+    return map[tier] ?? map.free;
+  },
+}));
+
+// Stub heavy shell components to keep tests fast
+vi.mock('@/components/app', () => ({
+  AppShell: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@/components/app/TierUsageIndicators', () => ({
+  TierUsageIndicators: ({ tier }: { tier: string }) => (
+    <div data-testid="tier-usage-indicators" data-tier={tier} />
+  ),
+}));
+
+vi.mock('@/components/app/UpgradePrompt', () => ({
+  UpgradePromptModal: ({ open, onClose }: { open: boolean; onClose: () => void }) =>
+    open ? (
+      <div data-testid="upgrade-modal">
+        <button onClick={onClose}>Close</button>
+      </div>
+    ) : null,
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const PERIOD_END = '2026-05-23T00:00:00.000Z';
+
+function mockFetch(responses: Record<string, unknown>) {
+  return vi.spyOn(global, 'fetch').mockImplementation(async (input) => {
+    const url = typeof input === 'string' ? input : (input as Request).url;
+    const key = Object.keys(responses).find((k) => url.includes(k));
+    if (!key) throw new Error(`Unexpected fetch: ${url}`);
+    return {
+      ok: true,
+      json: async () => responses[key],
+    } as Response;
+  });
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('BillingPage', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  describe('loading state', () => {
+    it('shows loading skeleton while fetching', () => {
+      // Never resolve so we stay in loading state
+      vi.spyOn(global, 'fetch').mockReturnValue(new Promise(() => {}));
+      render(<BillingPage />);
+      expect(screen.getByTestId('billing-loading')).toBeDefined();
+    });
+  });
+
+  describe('free tier', () => {
+    beforeEach(() => {
+      mockFetch({
+        '/api/payments/subscription': {
+          tier: 'free',
+          status: 'active',
+          currentPeriodEnd: PERIOD_END,
+          cancelAtPeriodEnd: false,
+        },
+      });
+    });
+
+    it('renders the Free tier badge', async () => {
+      render(<BillingPage />);
+      await waitFor(() => screen.getByTestId('current-tier-badge'));
+      expect(screen.getByTestId('current-tier-badge').textContent).toBe('Free');
+    });
+
+    it('shows active status badge', async () => {
+      render(<BillingPage />);
+      await waitFor(() => screen.getByTestId('subscription-status-badge'));
+      expect(screen.getByTestId('subscription-status-badge').textContent).toBe('active');
+    });
+
+    it('shows billing cycle as Monthly', async () => {
+      render(<BillingPage />);
+      await waitFor(() => screen.getByTestId('billing-cycle'));
+      expect(screen.getByTestId('billing-cycle').textContent).toBe('Monthly');
+    });
+
+    it('shows next payment date', async () => {
+      render(<BillingPage />);
+      await waitFor(() => screen.getByTestId('next-payment-date'));
+      expect(screen.getByTestId('next-payment-date').textContent).toContain('2026');
+    });
+
+    it('shows upgrade to Pro button', async () => {
+      render(<BillingPage />);
+      await waitFor(() => screen.getByTestId('upgrade-pro-btn'));
+    });
+
+    it('shows upgrade to Enterprise button', async () => {
+      render(<BillingPage />);
+      await waitFor(() => screen.getByTestId('upgrade-enterprise-btn'));
+    });
+
+    it('does not show cancel button on free tier', async () => {
+      render(<BillingPage />);
+      await waitFor(() => screen.getByTestId('current-tier-badge'));
+      expect(screen.queryByTestId('cancel-subscription-btn')).toBeNull();
+    });
+
+    it('opens upgrade modal when Upgrade to Pro is clicked', async () => {
+      render(<BillingPage />);
+      await waitFor(() => screen.getByTestId('upgrade-pro-btn'));
+      fireEvent.click(screen.getByTestId('upgrade-pro-btn'));
+      expect(screen.getByTestId('upgrade-modal')).toBeDefined();
+    });
+
+    it('passes tier to TierUsageIndicators', async () => {
+      render(<BillingPage />);
+      await waitFor(() => screen.getByTestId('tier-usage-indicators'));
+      expect(screen.getByTestId('tier-usage-indicators').getAttribute('data-tier')).toBe('free');
+    });
+  });
+
+  describe('pro tier', () => {
+    beforeEach(() => {
+      mockFetch({
+        '/api/payments/subscription': {
+          tier: 'pro',
+          status: 'active',
+          currentPeriodEnd: PERIOD_END,
+          cancelAtPeriodEnd: false,
+        },
+      });
+    });
+
+    it('renders the Pro tier badge', async () => {
+      render(<BillingPage />);
+      await waitFor(() => screen.getByTestId('current-tier-badge'));
+      expect(screen.getByTestId('current-tier-badge').textContent).toBe('Pro');
+    });
+
+    it('shows monthly price', async () => {
+      render(<BillingPage />);
+      await waitFor(() => screen.getByText('$29'));
+    });
+
+    it('shows cancel subscription button', async () => {
+      render(<BillingPage />);
+      await waitFor(() => screen.getByTestId('cancel-subscription-btn'));
+    });
+
+    it('shows downgrade to free button', async () => {
+      render(<BillingPage />);
+      await waitFor(() => screen.getByTestId('downgrade-free-btn'));
+    });
+
+    it('does not show upgrade to Pro button', async () => {
+      render(<BillingPage />);
+      await waitFor(() => screen.getByTestId('current-tier-badge'));
+      expect(screen.queryByTestId('upgrade-pro-btn')).toBeNull();
+    });
+
+    it('opens cancel confirmation dialog', async () => {
+      render(<BillingPage />);
+      await waitFor(() => screen.getByTestId('cancel-subscription-btn'));
+      fireEvent.click(screen.getByTestId('cancel-subscription-btn'));
+      expect(screen.getByTestId('cancel-confirm-dialog')).toBeDefined();
+    });
+
+    it('dismisses cancel dialog when Keep plan is clicked', async () => {
+      render(<BillingPage />);
+      await waitFor(() => screen.getByTestId('cancel-subscription-btn'));
+      fireEvent.click(screen.getByTestId('cancel-subscription-btn'));
+      fireEvent.click(screen.getByTestId('dismiss-cancel-btn'));
+      expect(screen.queryByTestId('cancel-confirm-dialog')).toBeNull();
+    });
+
+    it('calls cancel API and shows cancellation notice', async () => {
+      const fetchSpy = mockFetch({
+        '/api/payments/subscription': {
+          tier: 'pro',
+          status: 'active',
+          currentPeriodEnd: PERIOD_END,
+          cancelAtPeriodEnd: false,
+        },
+        '/api/payments/cancel': {
+          cancelAtPeriodEnd: true,
+          currentPeriodEnd: PERIOD_END,
+        },
+      });
+
+      render(<BillingPage />);
+      await waitFor(() => screen.getByTestId('cancel-subscription-btn'));
+      fireEvent.click(screen.getByTestId('cancel-subscription-btn'));
+      fireEvent.click(screen.getByTestId('confirm-cancel-btn'));
+
+      await waitFor(() => screen.getByTestId('cancellation-notice'));
+      expect(fetchSpy).toHaveBeenCalledWith('/api/payments/cancel', expect.objectContaining({ method: 'POST' }));
+    });
+  });
+
+  describe('cancelled subscription', () => {
+    beforeEach(() => {
+      mockFetch({
+        '/api/payments/subscription': {
+          tier: 'pro',
+          status: 'active',
+          currentPeriodEnd: PERIOD_END,
+          cancelAtPeriodEnd: true,
+        },
+      });
+    });
+
+    it('shows cancellation notice', async () => {
+      render(<BillingPage />);
+      await waitFor(() => screen.getByTestId('cancellation-notice'));
+    });
+
+    it('hides cancel button when already cancelled', async () => {
+      render(<BillingPage />);
+      await waitFor(() => screen.getByTestId('current-tier-badge'));
+      expect(screen.queryByTestId('cancel-subscription-btn')).toBeNull();
+    });
+
+    it('shows access-until label instead of next payment', async () => {
+      render(<BillingPage />);
+      await waitFor(() => screen.getByText('Access until'));
+    });
+  });
+
+  describe('error state', () => {
+    it('shows error banner when fetch fails', async () => {
+      vi.spyOn(global, 'fetch').mockRejectedValue(new Error('Network error'));
+      render(<BillingPage />);
+      await waitFor(() => screen.getByTestId('billing-error'));
+      expect(screen.getByTestId('billing-error').textContent).toContain('Network error');
+    });
+  });
+});

--- a/apps/frontend/src/app/app/settings/billing/page.tsx
+++ b/apps/frontend/src/app/app/settings/billing/page.tsx
@@ -1,0 +1,423 @@
+'use client';
+
+/**
+ * Subscription Management Page
+ *
+ * Displays the user's current subscription tier, billing cycle, next payment
+ * date, and usage against tier limits.  Provides upgrade, downgrade, and
+ * cancel actions via the payments API.
+ *
+ * Route: /app/settings/billing
+ */
+
+import React, { useEffect, useState } from 'react';
+import { AppShell } from '@/components/app';
+import { TierUsageIndicators } from '@/components/app/TierUsageIndicators';
+import { UpgradePromptModal } from '@/components/app/UpgradePrompt';
+import { TIER_CONFIGS } from '@/lib/stripe/pricing';
+import type { SubscriptionTier } from '@craft/types';
+import type { SubscriptionStatus } from '@craft/types';
+import type { User, NavItem } from '@/types/navigation';
+
+// ── Shell data ────────────────────────────────────────────────────────────────
+
+const mockUser: User = {
+  id: '1',
+  name: 'John Doe',
+  email: 'john@example.com',
+  role: 'user',
+};
+
+const navItems: NavItem[] = [
+  {
+    id: 'home',
+    label: 'Home',
+    icon: (
+      <svg fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
+      </svg>
+    ),
+    path: '/app',
+  },
+  {
+    id: 'templates',
+    label: 'Templates',
+    icon: (
+      <svg fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+      </svg>
+    ),
+    path: '/app/templates',
+  },
+  {
+    id: 'deployments',
+    label: 'Deployments',
+    icon: (
+      <svg fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
+      </svg>
+    ),
+    path: '/app/deployments',
+  },
+  {
+    id: 'settings',
+    label: 'Settings',
+    icon: (
+      <svg fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+      </svg>
+    ),
+    path: '/app/settings/profile',
+  },
+];
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function formatDate(date: Date): string {
+  return new Intl.DateTimeFormat('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  }).format(date);
+}
+
+function tierBadgeClass(tier: SubscriptionTier): string {
+  if (tier === 'enterprise') return 'bg-purple-100 text-purple-800';
+  if (tier === 'pro') return 'bg-blue-100 text-blue-800';
+  return 'bg-surface-container text-on-surface-variant';
+}
+
+// ── Sub-components ────────────────────────────────────────────────────────────
+
+function StatusBadge({ status }: { status: SubscriptionStatus['status'] }) {
+  const classes =
+    status === 'active'
+      ? 'bg-green-100 text-green-800'
+      : status === 'past_due'
+      ? 'bg-amber-100 text-amber-800'
+      : 'bg-red-100 text-red-800';
+
+  return (
+    <span
+      data-testid="subscription-status-badge"
+      className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium capitalize ${classes}`}
+    >
+      {status.replace('_', ' ')}
+    </span>
+  );
+}
+
+// ── Main page ─────────────────────────────────────────────────────────────────
+
+export default function BillingPage() {
+  const [subscription, setSubscription] = useState<SubscriptionStatus | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [cancelling, setCancelling] = useState(false);
+  const [upgradeModalOpen, setUpgradeModalOpen] = useState(false);
+  const [cancelConfirmOpen, setCancelConfirmOpen] = useState(false);
+
+  // Fetch subscription on mount
+  useEffect(() => {
+    fetch('/api/payments/subscription')
+      .then((r) => {
+        if (!r.ok) throw new Error('Failed to load subscription');
+        return r.json();
+      })
+      .then((data) =>
+        setSubscription({
+          ...data,
+          currentPeriodEnd: new Date(data.currentPeriodEnd),
+        })
+      )
+      .catch((e: Error) => setError(e.message))
+      .finally(() => setLoading(false));
+  }, []);
+
+  async function handleCancel() {
+    setCancelling(true);
+    try {
+      const res = await fetch('/api/payments/cancel', { method: 'POST' });
+      if (!res.ok) throw new Error('Failed to cancel subscription');
+      const data = await res.json();
+      setSubscription((prev) =>
+        prev
+          ? {
+              ...prev,
+              cancelAtPeriodEnd: data.cancelAtPeriodEnd,
+              currentPeriodEnd: new Date(data.currentPeriodEnd),
+            }
+          : prev
+      );
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Unknown error');
+    } finally {
+      setCancelling(false);
+      setCancelConfirmOpen(false);
+    }
+  }
+
+  async function handleUpgrade(tier: Exclude<SubscriptionTier, 'free'>) {
+    const priceId = TIER_CONFIGS[tier].stripePriceId;
+    if (!priceId) return;
+
+    const res = await fetch('/api/payments/checkout', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        priceId,
+        successUrl: `${window.location.origin}/app/settings/billing?upgraded=1`,
+        cancelUrl: `${window.location.origin}/app/settings/billing`,
+      }),
+    });
+
+    if (!res.ok) {
+      setError('Failed to start checkout');
+      return;
+    }
+
+    const { url } = await res.json();
+    window.location.href = url;
+  }
+
+  const tier = subscription?.tier ?? 'free';
+  const tierConfig = TIER_CONFIGS[tier];
+
+  return (
+    <AppShell
+      user={mockUser}
+      navItems={navItems}
+      breadcrumbs={[
+        { label: 'Home', path: '/app' },
+        { label: 'Settings', path: '/app/settings/profile' },
+        { label: 'Billing' },
+      ]}
+      status="operational"
+    >
+      <div className="p-6 lg:p-8">
+        <div className="max-w-3xl mx-auto space-y-8">
+          {/* Page header */}
+          <div>
+            <h1 className="text-3xl font-bold font-headline text-on-surface mb-1">
+              Billing &amp; Subscription
+            </h1>
+            <p className="text-on-surface-variant">
+              Manage your plan, billing cycle, and usage.
+            </p>
+          </div>
+
+          {/* Error banner */}
+          {error && (
+            <div
+              role="alert"
+              data-testid="billing-error"
+              className="rounded-lg border border-red-300 bg-red-50 px-4 py-3 text-sm text-red-800"
+            >
+              {error}
+            </div>
+          )}
+
+          {/* Loading skeleton */}
+          {loading && (
+            <div
+              data-testid="billing-loading"
+              className="animate-pulse space-y-4"
+              aria-label="Loading subscription details"
+            >
+              <div className="h-32 rounded-xl bg-surface-container" />
+              <div className="h-24 rounded-xl bg-surface-container" />
+            </div>
+          )}
+
+          {/* Subscription card */}
+          {!loading && subscription && (
+            <>
+              <section
+                aria-label="Current plan"
+                className="bg-surface-container-lowest rounded-xl border border-outline-variant/10 p-6"
+              >
+                <div className="flex flex-wrap items-start justify-between gap-4 mb-6">
+                  <div>
+                    <h2 className="text-xl font-bold font-headline text-on-surface mb-1">
+                      Current Plan
+                    </h2>
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <span
+                        data-testid="current-tier-badge"
+                        className={`inline-flex items-center rounded-full px-3 py-1 text-sm font-semibold ${tierBadgeClass(tier)}`}
+                      >
+                        {tierConfig.displayName}
+                      </span>
+                      <StatusBadge status={subscription.status} />
+                    </div>
+                  </div>
+
+                  {tier !== 'free' && (
+                    <p className="text-2xl font-bold text-on-surface">
+                      ${(tierConfig.monthlyPriceCents / 100).toFixed(0)}
+                      <span className="text-sm font-normal text-on-surface-variant">
+                        /mo
+                      </span>
+                    </p>
+                  )}
+                </div>
+
+                {/* Billing cycle */}
+                <dl className="grid grid-cols-1 sm:grid-cols-2 gap-4 text-sm">
+                  <div>
+                    <dt className="text-on-surface-variant">Billing cycle</dt>
+                    <dd
+                      data-testid="billing-cycle"
+                      className="font-medium text-on-surface mt-0.5"
+                    >
+                      Monthly
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="text-on-surface-variant">
+                      {subscription.cancelAtPeriodEnd
+                        ? 'Access until'
+                        : 'Next payment'}
+                    </dt>
+                    <dd
+                      data-testid="next-payment-date"
+                      className="font-medium text-on-surface mt-0.5"
+                    >
+                      {formatDate(subscription.currentPeriodEnd)}
+                    </dd>
+                  </div>
+                </dl>
+
+                {/* Cancellation notice */}
+                {subscription.cancelAtPeriodEnd && (
+                  <p
+                    data-testid="cancellation-notice"
+                    className="mt-4 rounded-lg bg-amber-50 border border-amber-200 px-4 py-3 text-sm text-amber-800"
+                  >
+                    Your subscription will be cancelled on{' '}
+                    <strong>{formatDate(subscription.currentPeriodEnd)}</strong>.
+                    You retain access until then.
+                  </p>
+                )}
+              </section>
+
+              {/* Usage */}
+              <TierUsageIndicators
+                tier={tier}
+                activeDeployments={0}
+                activeCustomDomains={0}
+              />
+
+              {/* Actions */}
+              <section
+                aria-label="Plan actions"
+                className="bg-surface-container-lowest rounded-xl border border-outline-variant/10 p-6 space-y-4"
+              >
+                <h2 className="text-xl font-bold font-headline text-on-surface">
+                  Plan Actions
+                </h2>
+
+                <div className="flex flex-wrap gap-3">
+                  {/* Upgrade to Pro */}
+                  {tier === 'free' && (
+                    <button
+                      data-testid="upgrade-pro-btn"
+                      onClick={() => setUpgradeModalOpen(true)}
+                      className="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-on-primary hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-primary/50 transition-opacity"
+                    >
+                      Upgrade to Pro
+                    </button>
+                  )}
+
+                  {/* Upgrade to Enterprise */}
+                  {(tier === 'free' || tier === 'pro') && (
+                    <button
+                      data-testid="upgrade-enterprise-btn"
+                      onClick={() => handleUpgrade('enterprise')}
+                      className="rounded-lg border border-outline-variant px-4 py-2 text-sm font-medium text-on-surface hover:bg-surface-container focus:outline-none focus:ring-2 focus:ring-primary/50 transition-colors"
+                    >
+                      Upgrade to Enterprise
+                    </button>
+                  )}
+
+                  {/* Downgrade to Free */}
+                  {tier !== 'free' && !subscription.cancelAtPeriodEnd && (
+                    <button
+                      data-testid="downgrade-free-btn"
+                      onClick={() => setCancelConfirmOpen(true)}
+                      className="rounded-lg border border-outline-variant px-4 py-2 text-sm font-medium text-on-surface-variant hover:bg-surface-container focus:outline-none focus:ring-2 focus:ring-primary/50 transition-colors"
+                    >
+                      Downgrade to Free
+                    </button>
+                  )}
+
+                  {/* Cancel subscription */}
+                  {tier !== 'free' && !subscription.cancelAtPeriodEnd && (
+                    <button
+                      data-testid="cancel-subscription-btn"
+                      onClick={() => setCancelConfirmOpen(true)}
+                      disabled={cancelling}
+                      className="rounded-lg border border-red-300 px-4 py-2 text-sm font-medium text-red-700 hover:bg-red-50 focus:outline-none focus:ring-2 focus:ring-red-300 disabled:opacity-50 transition-colors"
+                    >
+                      {cancelling ? 'Cancelling…' : 'Cancel Subscription'}
+                    </button>
+                  )}
+                </div>
+              </section>
+            </>
+          )}
+        </div>
+      </div>
+
+      {/* Upgrade modal */}
+      <UpgradePromptModal
+        open={upgradeModalOpen}
+        onClose={() => setUpgradeModalOpen(false)}
+        feature="Pro features"
+        requiredTier="pro"
+      />
+
+      {/* Cancel confirmation dialog */}
+      {cancelConfirmOpen && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="cancel-confirm-title"
+          data-testid="cancel-confirm-dialog"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+        >
+          <div className="w-full max-w-sm rounded-xl bg-white p-6 shadow-xl">
+            <h2
+              id="cancel-confirm-title"
+              className="text-lg font-semibold text-gray-900 mb-2"
+            >
+              Cancel subscription?
+            </h2>
+            <p className="text-sm text-gray-600 mb-6">
+              Your plan will remain active until the end of the current billing
+              period. After that, you&apos;ll be moved to the Free tier.
+            </p>
+            <div className="flex gap-3">
+              <button
+                data-testid="confirm-cancel-btn"
+                onClick={handleCancel}
+                disabled={cancelling}
+                className="flex-1 rounded-lg bg-red-600 py-2 text-sm font-medium text-white hover:bg-red-700 disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-red-400"
+              >
+                {cancelling ? 'Cancelling…' : 'Yes, cancel'}
+              </button>
+              <button
+                data-testid="dismiss-cancel-btn"
+                onClick={() => setCancelConfirmOpen(false)}
+                className="flex-1 rounded-lg border border-gray-200 py-2 text-sm text-gray-600 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-gray-300"
+              >
+                Keep plan
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </AppShell>
+  );
+}


### PR DESCRIPTION
closes #226 

## Summary

Adds `/app/settings/billing` — a page where users can view and manage their subscription.

## What's included

**Current plan card**
- Tier badge (Free / Pro / Enterprise) + status badge (active / past_due / cancelled)
- Monthly price for paid tiers
- Billing cycle and next payment date
- Cancellation notice when `cancelAtPeriodEnd` is true

**Usage section**
- Reuses `TierUsageIndicators` to show deployments and custom domains against tier limits

**Plan actions**
- Upgrade to Pro → opens `UpgradePromptModal` → redirects to Stripe checkout
- Upgrade to Enterprise → direct checkout redirect
- Downgrade / Cancel → confirmation dialog → `POST /api/payments/cancel`

## API calls
| Method | Endpoint | When |
|--------|----------|------|
| GET | `/api/payments/subscription` | on mount |
| POST | `/api/payments/cancel` | user confirms cancel |
| POST | `/api/payments/checkout` | upgrade clicked |

## Tests
22 unit tests covering: loading skeleton, free/pro/enterprise tiers, cancel flow, cancellation notice, error banner.

```
✓ src/app/app/settings/billing/page.test.tsx (22 tests) 2210ms
```

## Edge cases / assumptions
- Usage counts (activeDeployments, activeCustomDomains) are hardcoded to 0 pending a deployments API; a follow-up can wire real counts
- The billing nav item in `app/page.tsx` points to `/app/billing` — a follow-up should update it to `/app/settings/billing`