### PR TITLE
feat: subscription comparison, upgrade flow, and comprehensive test coverage

### DIFF
--- a/apps/backend/src/lib/realtime/realtime-status-poller.ts
+++ b/apps/backend/src/lib/realtime/realtime-status-poller.ts
@@ -1,0 +1,195 @@
+/**
+ * RealtimeStatusPoller
+ *
+ * Wraps Supabase Realtime channel subscriptions to deliver deployment status
+ * updates to subscribers. This is the platform's "WebSocket" layer: Supabase
+ * Realtime uses WebSocket transport under the hood, and this utility provides
+ * the connection lifecycle, message ordering, reconnection with exponential
+ * backoff, and authentication that the issue requires.
+ *
+ * Architecture note:
+ *   There is no custom WebSocket server in this codebase. Real-time updates
+ *   flow through Supabase Realtime channels (postgres_changes events).
+ *   This class abstracts that into a testable interface.
+ */
+
+import type { SupabaseClient, RealtimeChannel } from '@supabase/supabase-js';
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export type DeploymentStatusPayload = {
+  deploymentId: string;
+  status: string;
+  sequenceNumber: number;
+  timestamp: string;
+};
+
+export type StatusHandler = (payload: DeploymentStatusPayload) => void;
+
+export type ConnectionState = 'disconnected' | 'connecting' | 'connected' | 'reconnecting' | 'closed';
+
+export interface PollerOptions {
+  /** Maximum number of reconnect attempts before giving up. Default: 5 */
+  maxRetries?: number;
+  /** Base delay in ms for exponential backoff. Default: 500 */
+  baseDelayMs?: number;
+  /** Maximum backoff delay in ms. Default: 30_000 */
+  maxDelayMs?: number;
+}
+
+// ── RealtimeStatusPoller ──────────────────────────────────────────────────────
+
+export class RealtimeStatusPoller {
+  private channel: RealtimeChannel | null = null;
+  private handlers = new Set<StatusHandler>();
+  private state: ConnectionState = 'disconnected';
+  private retryCount = 0;
+  private retryTimer: ReturnType<typeof setTimeout> | null = null;
+  private sequenceCounter = 0;
+  private readonly opts: Required<PollerOptions>;
+
+  constructor(
+    private readonly supabase: SupabaseClient,
+    private readonly deploymentId: string,
+    private readonly userId: string,
+    opts: PollerOptions = {},
+  ) {
+    this.opts = {
+      maxRetries: opts.maxRetries ?? 5,
+      baseDelayMs: opts.baseDelayMs ?? 500,
+      maxDelayMs: opts.maxDelayMs ?? 30_000,
+    };
+  }
+
+  // ── Public API ──────────────────────────────────────────────────────────────
+
+  get connectionState(): ConnectionState {
+    return this.state;
+  }
+
+  /**
+   * Subscribe to deployment status updates.
+   * Returns an unsubscribe function.
+   */
+  onStatus(handler: StatusHandler): () => void {
+    this.handlers.add(handler);
+    return () => this.handlers.delete(handler);
+  }
+
+  /**
+   * Establish the Supabase Realtime channel connection.
+   * Validates that the userId matches the deployment owner before subscribing.
+   */
+  async connect(): Promise<void> {
+    if (this.state === 'connected' || this.state === 'connecting') return;
+    this.setState('connecting');
+
+    // Authentication check: verify the user owns this deployment
+    const { data, error } = await this.supabase
+      .from('deployments')
+      .select('user_id')
+      .eq('id', this.deploymentId)
+      .single();
+
+    if (error || !data || data.user_id !== this.userId) {
+      this.setState('closed');
+      throw new Error('Unauthorized: deployment does not belong to this user');
+    }
+
+    this.openChannel();
+  }
+
+  /**
+   * Disconnect and clean up the channel.
+   */
+  async disconnect(): Promise<void> {
+    this.clearRetryTimer();
+    if (this.channel) {
+      await this.supabase.removeChannel(this.channel);
+      this.channel = null;
+    }
+    this.setState('closed');
+  }
+
+  // ── Internal ────────────────────────────────────────────────────────────────
+
+  private openChannel(): void {
+    const channelName = `deployment:${this.deploymentId}`;
+
+    this.channel = this.supabase
+      .channel(channelName)
+      .on(
+        'postgres_changes' as any,
+        {
+          event: 'UPDATE',
+          schema: 'public',
+          table: 'deployments',
+          filter: `id=eq.${this.deploymentId}`,
+        },
+        (payload: any) => {
+          this.sequenceCounter += 1;
+          const msg: DeploymentStatusPayload = {
+            deploymentId: this.deploymentId,
+            status: payload.new?.status ?? 'unknown',
+            sequenceNumber: this.sequenceCounter,
+            timestamp: new Date().toISOString(),
+          };
+          this.emit(msg);
+        },
+      )
+      .subscribe((status: string) => {
+        if (status === 'SUBSCRIBED') {
+          this.setState('connected');
+          this.retryCount = 0;
+        } else if (status === 'CHANNEL_ERROR' || status === 'TIMED_OUT') {
+          this.handleDisconnect();
+        } else if (status === 'CLOSED') {
+          if (this.state !== 'closed') {
+            this.handleDisconnect();
+          }
+        }
+      });
+  }
+
+  private handleDisconnect(): void {
+    if (this.state === 'closed') return;
+
+    if (this.retryCount >= this.opts.maxRetries) {
+      this.setState('closed');
+      return;
+    }
+
+    this.setState('reconnecting');
+    this.retryCount += 1;
+
+    const delay = Math.min(
+      this.opts.baseDelayMs * 2 ** (this.retryCount - 1),
+      this.opts.maxDelayMs,
+    );
+
+    this.retryTimer = setTimeout(() => {
+      if (this.channel) {
+        this.supabase.removeChannel(this.channel);
+        this.channel = null;
+      }
+      this.openChannel();
+    }, delay);
+  }
+
+  private clearRetryTimer(): void {
+    if (this.retryTimer !== null) {
+      clearTimeout(this.retryTimer);
+      this.retryTimer = null;
+    }
+  }
+
+  private setState(next: ConnectionState): void {
+    this.state = next;
+  }
+
+  private emit(payload: DeploymentStatusPayload): void {
+    for (const handler of this.handlers) {
+      handler(payload);
+    }
+  }
+}

--- a/apps/backend/tests/errors/error-handling.test.ts
+++ b/apps/backend/tests/errors/error-handling.test.ts
@@ -1,0 +1,617 @@
+/**
+ * Comprehensive Error Handling Tests (#338)
+ *
+ * Verifies that all critical error paths:
+ *   - Produce user-friendly messages (no raw stack traces or internal details)
+ *   - Include correlation IDs for traceability
+ *   - Log sufficient context without leaking sensitive data
+ *   - Recover gracefully or surface actionable guidance
+ *
+ * Coverage:
+ *   1. Error guidance library (all domains + fallbacks)
+ *   2. Structured logger (correlation IDs, sensitive-data exclusion)
+ *   3. withLogging middleware (unhandled throws → 500 + correlationId)
+ *   4. withAuth / withDeploymentAuth / withDomainTierCheck error paths
+ *   5. AuthService error paths (signIn / signUp)
+ *   6. HealthMonitorService error paths
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest, NextResponse } from 'next/server';
+
+// ── Hoisted mocks (must be declared before any vi.mock factory runs) ──────────
+
+const mockGetUser       = vi.hoisted(() => vi.fn());
+const mockFrom          = vi.hoisted(() => vi.fn());
+const mockSignUp        = vi.hoisted(() => vi.fn());
+const mockSignIn        = vi.hoisted(() => vi.fn());
+const mockProfileInsert = vi.hoisted(() => vi.fn());
+const mockProfileSelect = vi.hoisted(() => vi.fn());
+const mockAnalyticsRecord = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: () => ({
+    auth: {
+      getUser: mockGetUser,
+      signUp: mockSignUp,
+      signInWithPassword: mockSignIn,
+    },
+    from: mockFrom,
+  }),
+}));
+
+vi.mock('@/lib/stripe/pricing', () => ({
+  canConfigureCustomDomain: (tier: string) => tier !== 'free',
+  TIER_CONFIGS: {},
+}));
+
+vi.mock('@/services/analytics.service', () => ({
+  analyticsService: { recordUptimeCheck: mockAnalyticsRecord },
+}));
+
+vi.stubGlobal('fetch', vi.fn());
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 1. Error Guidance Library
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { getErrorGuidance, formatMessage } from '@/lib/errors/guidance';
+
+describe('Error guidance – user-friendly messages', () => {
+  it.each([
+    ['github', 'AUTH_FAILED'],
+    ['github', 'RATE_LIMITED'],
+    ['github', 'COLLISION'],
+    ['github', 'NETWORK_ERROR'],
+    ['github', 'CONFIGURATION_ERROR'],
+    ['vercel', 'AUTH_FAILED'],
+    ['vercel', 'RATE_LIMITED'],
+    ['vercel', 'PROJECT_EXISTS'],
+    ['vercel', 'NETWORK_ERROR'],
+    ['stripe', 'CARD_DECLINED'],
+    ['stripe', 'WEBHOOK_SIGNATURE_INVALID'],
+    ['stripe', 'SUBSCRIPTION_NOT_FOUND'],
+    ['stellar', 'INSUFFICIENT_BALANCE'],
+    ['stellar', 'NETWORK_MISMATCH'],
+    ['stellar', 'TRANSACTION_FAILED'],
+    ['stellar', 'ENDPOINT_UNREACHABLE'],
+    ['auth', 'INVALID_CREDENTIALS'],
+    ['auth', 'EMAIL_TAKEN'],
+  ] as const)('guidance for %s:%s has a non-empty title and message', (domain, code) => {
+    const g = getErrorGuidance(domain, code);
+    expect(g.template.title.length).toBeGreaterThan(0);
+    expect(g.template.message.length).toBeGreaterThan(0);
+  });
+
+  it.each([
+    ['github', 'AUTH_FAILED'],
+    ['github', 'COLLISION'],
+    ['github', 'CONFIGURATION_ERROR'],
+    ['vercel', 'AUTH_FAILED'],
+    ['vercel', 'PROJECT_EXISTS'],
+    ['stripe', 'WEBHOOK_SIGNATURE_INVALID'],
+    ['stripe', 'SUBSCRIPTION_NOT_FOUND'],
+    ['stellar', 'INSUFFICIENT_BALANCE'],
+    ['stellar', 'NETWORK_MISMATCH'],
+    ['stellar', 'TRANSACTION_FAILED'],
+    ['auth', 'EMAIL_TAKEN'],
+  ] as const)('non-retryable errors are marked retryable=false: %s:%s', (domain, code) => {
+    const g = getErrorGuidance(domain, code);
+    expect(g.template.retryable).toBe(false);
+  });
+
+  it.each([
+    ['github', 'RATE_LIMITED'],
+    ['github', 'NETWORK_ERROR'],
+    ['vercel', 'RATE_LIMITED'],
+    ['vercel', 'NETWORK_ERROR'],
+    ['stripe', 'CARD_DECLINED'],
+    ['stellar', 'ENDPOINT_UNREACHABLE'],
+    ['auth', 'INVALID_CREDENTIALS'],
+  ] as const)('transient errors are marked retryable=true: %s:%s', (domain, code) => {
+    const g = getErrorGuidance(domain, code);
+    expect(g.template.retryable).toBe(true);
+  });
+
+  it('every known error has at least one actionable step and one link', () => {
+    const cases: Array<[Parameters<typeof getErrorGuidance>[0], string]> = [
+      ['github', 'AUTH_FAILED'], ['github', 'RATE_LIMITED'], ['github', 'COLLISION'],
+      ['github', 'NETWORK_ERROR'], ['github', 'CONFIGURATION_ERROR'],
+      ['vercel', 'AUTH_FAILED'], ['vercel', 'RATE_LIMITED'], ['vercel', 'PROJECT_EXISTS'], ['vercel', 'NETWORK_ERROR'],
+      ['stripe', 'CARD_DECLINED'], ['stripe', 'WEBHOOK_SIGNATURE_INVALID'], ['stripe', 'SUBSCRIPTION_NOT_FOUND'],
+      ['stellar', 'INSUFFICIENT_BALANCE'], ['stellar', 'NETWORK_MISMATCH'],
+      ['stellar', 'TRANSACTION_FAILED'], ['stellar', 'ENDPOINT_UNREACHABLE'],
+      ['auth', 'INVALID_CREDENTIALS'], ['auth', 'EMAIL_TAKEN'],
+    ];
+    for (const [domain, code] of cases) {
+      const g = getErrorGuidance(domain, code);
+      expect(g.steps.length, `${domain}:${code} steps`).toBeGreaterThan(0);
+      expect(g.links.length, `${domain}:${code} links`).toBeGreaterThan(0);
+    }
+  });
+
+  it('falls back to general:UNKNOWN for an unrecognised code', () => {
+    const g = getErrorGuidance('github', 'TOTALLY_UNKNOWN');
+    expect(g.template.title).toBe('An unexpected error occurred');
+    expect(g.template.retryable).toBe(true);
+  });
+
+  it('falls back to general:UNKNOWN for an unrecognised domain', () => {
+    // @ts-expect-error intentional invalid domain
+    const g = getErrorGuidance('unknown_domain', 'SOME_CODE');
+    expect(g.template.title).toBe('An unexpected error occurred');
+  });
+
+  it('error messages do not contain raw stack traces or internal paths', () => {
+    const cases: Array<[Parameters<typeof getErrorGuidance>[0], string]> = [
+      ['github', 'AUTH_FAILED'], ['stripe', 'CARD_DECLINED'], ['auth', 'INVALID_CREDENTIALS'],
+    ];
+    for (const [domain, code] of cases) {
+      const g = getErrorGuidance(domain, code);
+      expect(g.template.message).not.toMatch(/Error:/);
+      expect(g.template.message).not.toMatch(/at \w+/);
+      expect(g.template.message).not.toMatch(/\/workspaces\//);
+    }
+  });
+});
+
+describe('formatMessage – placeholder interpolation', () => {
+  it('replaces a single placeholder', () => {
+    expect(formatMessage('Wait {retryAfter} seconds.', { retryAfter: '60' }))
+      .toBe('Wait 60 seconds.');
+  });
+
+  it('replaces multiple distinct placeholders', () => {
+    expect(formatMessage('{name} failed with {resultCode}.', { name: 'tx', resultCode: 'op_no_trust' }))
+      .toBe('tx failed with op_no_trust.');
+  });
+
+  it('leaves unknown placeholders intact (no data leakage)', () => {
+    expect(formatMessage('Error: {code}', {})).toBe('Error: {code}');
+  });
+
+  it('returns the template unchanged when values is omitted', () => {
+    expect(formatMessage('No placeholders.')).toBe('No placeholders.');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 2. Structured Logger – correlation IDs and sensitive-data exclusion
+// ─────────────────────────────────────────────────────────────────────────────
+
+import {
+  createLogger,
+  resolveCorrelationId,
+  withLogging,
+  CORRELATION_ID_HEADER,
+} from '@/lib/api/logger';
+
+interface LogEntry {
+  level: string;
+  message: string;
+  correlationId: string;
+  timestamp: string;
+  stack?: string;
+  metadata: Record<string, unknown>;
+}
+
+function lastEntry(spy: ReturnType<typeof vi.spyOn>): LogEntry {
+  const raw = (spy as any).mock.calls.at(-1)?.[0] as string;
+  return JSON.parse(raw);
+}
+
+describe('createLogger – structured output', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  it('includes correlationId in every log entry', () => {
+    const log = createLogger({ correlationId: 'test-cid-001' });
+    log.info('test message');
+    expect(lastEntry(console.log as any).correlationId).toBe('test-cid-001');
+  });
+
+  it('includes a valid ISO timestamp in every entry', () => {
+    const log = createLogger({ correlationId: 'cid-ts' });
+    log.info('ts check');
+    const ts = lastEntry(console.log as any).timestamp;
+    expect(new Date(ts).getTime()).toBeGreaterThan(0);
+  });
+
+  it('error entries include the stack trace for debugging', () => {
+    const log = createLogger({ correlationId: 'cid-stack' });
+    log.error('handler failed', new Error('something broke'));
+    const entry = lastEntry(console.error as any);
+    expect(entry.stack).toBeDefined();
+    expect(entry.stack).toContain('something broke');
+  });
+
+  it('does not include stack when the thrown value is not an Error', () => {
+    const log = createLogger({ correlationId: 'cid-nostack' });
+    log.error('plain string thrown', 'not an Error');
+    expect(lastEntry(console.error as any).stack).toBeUndefined();
+  });
+
+  it('does not leak correlationId into the metadata object', () => {
+    const log = createLogger({ correlationId: 'cid-leak', userId: 'u1' });
+    log.info('check');
+    const entry = lastEntry(console.log as any);
+    expect(entry.metadata.correlationId).toBeUndefined();
+    expect(entry.correlationId).toBe('cid-leak');
+  });
+
+  it('logger does not automatically inject password or token fields', () => {
+    const log = createLogger({ correlationId: 'cid-safe' });
+    log.info('user action', { action: 'login' });
+    const serialised = JSON.stringify(lastEntry(console.log as any));
+    // The logger itself must not add these fields
+    expect(serialised).not.toContain('"password"');
+    expect(serialised).not.toContain('"token"');
+  });
+
+  it('merges extra metadata with the base context', () => {
+    const log = createLogger({ correlationId: 'cid-meta', userId: 'u42' });
+    log.warn('degraded', { stage: 'push' });
+    const entry = lastEntry(console.warn as any);
+    expect(entry.metadata.userId).toBe('u42');
+    expect(entry.metadata.stage).toBe('push');
+  });
+});
+
+describe('resolveCorrelationId', () => {
+  it('returns the header value when present and valid', () => {
+    const req = new NextRequest('http://localhost/', {
+      headers: { [CORRELATION_ID_HEADER]: 'valid-corr-id-1234' },
+    });
+    expect(resolveCorrelationId(req)).toBe('valid-corr-id-1234');
+  });
+
+  it('generates a UUID when the header is absent', () => {
+    const req = new NextRequest('http://localhost/');
+    expect(resolveCorrelationId(req)).toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+  it('generates a new UUID when the header value is too short', () => {
+    const req = new NextRequest('http://localhost/', {
+      headers: { [CORRELATION_ID_HEADER]: 'short' },
+    });
+    const id = resolveCorrelationId(req);
+    expect(id).not.toBe('short');
+    expect(id.length).toBeGreaterThanOrEqual(36);
+  });
+
+  it('generates unique IDs on successive calls without a header', () => {
+    const req = new NextRequest('http://localhost/');
+    expect(resolveCorrelationId(req)).not.toBe(resolveCorrelationId(req));
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 3. withLogging middleware – unhandled errors → 500 + correlationId
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('withLogging – unhandled error recovery', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  it('returns 500 when the handler throws', async () => {
+    const handler = withLogging(async () => { throw new Error('boom'); });
+    const res = await handler(new NextRequest('http://localhost/api/test'), { params: {} });
+    expect(res.status).toBe(500);
+  });
+
+  it('includes correlationId in the 500 response body', async () => {
+    const handler = withLogging(async () => { throw new Error('boom'); });
+    const req = new NextRequest('http://localhost/api/test', {
+      headers: { [CORRELATION_ID_HEADER]: 'err-cid-9999' },
+    });
+    const body = await (await handler(req, { params: {} })).json();
+    expect(body.correlationId).toBe('err-cid-9999');
+  });
+
+  it('echoes correlationId in the response header on error', async () => {
+    const handler = withLogging(async () => { throw new Error('boom'); });
+    const req = new NextRequest('http://localhost/api/test', {
+      headers: { [CORRELATION_ID_HEADER]: 'hdr-cid-1234' },
+    });
+    const res = await handler(req, { params: {} });
+    expect(res.headers.get(CORRELATION_ID_HEADER)).toBe('hdr-cid-1234');
+  });
+
+  it('returns a generic error message without leaking internal details', async () => {
+    const handler = withLogging(async () => { throw new Error('db password is abc123'); });
+    const body = await (await handler(new NextRequest('http://localhost/api/test'), { params: {} })).json();
+    expect(body.error).toBe('Internal server error');
+    expect(JSON.stringify(body)).not.toContain('abc123');
+  });
+
+  it('echoes correlationId in the response header on success', async () => {
+    const handler = withLogging(async (_req, { correlationId }) =>
+      NextResponse.json({ correlationId })
+    );
+    const req = new NextRequest('http://localhost/api/test', {
+      headers: { [CORRELATION_ID_HEADER]: 'ok-cid-5678' },
+    });
+    expect((await handler(req, { params: {} })).headers.get(CORRELATION_ID_HEADER)).toBe('ok-cid-5678');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 4. withAuth / withDeploymentAuth / withDomainTierCheck error paths
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { withAuth, withDeploymentAuth, withDomainTierCheck } from '@/lib/api/with-auth';
+
+const makeReq = () => new NextRequest('http://localhost/api/test');
+
+describe('withAuth – authentication error paths', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns 401 when no session exists', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+    const res = await withAuth(async () => NextResponse.json({ ok: true }))(makeReq(), { params: {} });
+    expect(res.status).toBe(401);
+    expect((await res.json()).error).toBe('Unauthorized');
+  });
+
+  it('returns 401 when getUser returns an error', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: new Error('jwt expired') });
+    const res = await withAuth(async () => NextResponse.json({ ok: true }))(makeReq(), { params: {} });
+    expect(res.status).toBe(401);
+  });
+
+  it('attaches a correlationId header on 401', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+    const res = await withAuth(async () => NextResponse.json({ ok: true }))(makeReq(), { params: {} });
+    expect(res.headers.get(CORRELATION_ID_HEADER)).toBeTruthy();
+  });
+
+  it('does not leak user data in the 401 body', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+    const res = await withAuth(async () => NextResponse.json({ ok: true }))(makeReq(), { params: {} });
+    expect(Object.keys(await res.json())).toEqual(['error']);
+  });
+});
+
+describe('withDeploymentAuth – ownership error paths', () => {
+  const fakeUser = { id: 'user-1', email: 'a@b.com' };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetUser.mockResolvedValue({ data: { user: fakeUser }, error: null });
+  });
+
+  it('returns 403 when deployment not found', async () => {
+    mockFrom.mockReturnValue({
+      select: () => ({ eq: () => ({ single: () => Promise.resolve({ data: null }) }) }),
+    });
+    const res = await withDeploymentAuth(async () => NextResponse.json({ ok: true }))(
+      makeReq(), { params: { id: 'dep-1' } }
+    );
+    expect(res.status).toBe(403);
+    expect((await res.json()).error).toBe('Forbidden');
+  });
+
+  it('returns 403 when deployment belongs to a different user', async () => {
+    mockFrom.mockReturnValue({
+      select: () => ({ eq: () => ({ single: () => Promise.resolve({ data: { user_id: 'other' } }) }) }),
+    });
+    const res = await withDeploymentAuth(async () => NextResponse.json({ ok: true }))(
+      makeReq(), { params: { id: 'dep-1' } }
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 401 when unauthenticated (inherits withAuth)', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+    const res = await withDeploymentAuth(async () => NextResponse.json({ ok: true }))(
+      makeReq(), { params: { id: 'dep-1' } }
+    );
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('withDomainTierCheck – tier restriction error paths', () => {
+  const fakeUser = { id: 'user-1', email: 'a@b.com' };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetUser.mockResolvedValue({ data: { user: fakeUser }, error: null });
+  });
+
+  it('returns 403 with upgradeUrl when user is on free tier', async () => {
+    mockFrom
+      .mockReturnValueOnce({
+        select: () => ({ eq: () => ({ single: () => Promise.resolve({ data: { user_id: fakeUser.id } }) }) }),
+      })
+      .mockReturnValueOnce({
+        select: () => ({ eq: () => ({ single: () => Promise.resolve({ data: { subscription_tier: 'free' } }) }) }),
+      });
+    const res = await withDomainTierCheck(async () => NextResponse.json({ ok: true }))(
+      makeReq(), { params: { id: 'dep-1' } }
+    );
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.upgradeUrl).toBeDefined();
+    expect(body.error).toMatch(/Pro or Enterprise/);
+  });
+
+  it('403 body does not leak internal subscription details', async () => {
+    mockFrom
+      .mockReturnValueOnce({
+        select: () => ({ eq: () => ({ single: () => Promise.resolve({ data: { user_id: fakeUser.id } }) }) }),
+      })
+      .mockReturnValueOnce({
+        select: () => ({ eq: () => ({ single: () => Promise.resolve({ data: { subscription_tier: 'free' } }) }) }),
+      });
+    const res = await withDomainTierCheck(async () => NextResponse.json({ ok: true }))(
+      makeReq(), { params: { id: 'dep-1' } }
+    );
+    const serialised = JSON.stringify(await res.json());
+    expect(serialised).not.toContain('stripe');
+    expect(serialised).not.toContain('customer_id');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 5. AuthService – error paths
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { AuthService } from '@/services/auth.service';
+
+describe('AuthService – signIn error paths', () => {
+  let service: AuthService;
+  beforeEach(() => { vi.clearAllMocks(); service = new AuthService(); });
+
+  it('returns an error result (not a throw) on invalid credentials', async () => {
+    mockSignIn.mockResolvedValue({
+      data: { user: null, session: null },
+      error: { code: 'invalid_credentials', message: 'Invalid login credentials' },
+    });
+    const result = await service.signIn('bad@example.com', 'wrong');
+    expect(result.error).not.toBeNull();
+    expect(result.user).toBeNull();
+  });
+
+  it('converts "Invalid login credentials" to a user-friendly message', async () => {
+    mockSignIn.mockResolvedValue({
+      data: { user: null, session: null },
+      error: { code: 'invalid_credentials', message: 'Invalid login credentials' },
+    });
+    const result = await service.signIn('bad@example.com', 'wrong');
+    expect(result.error!.message).not.toBe('Invalid login credentials');
+    expect(result.error!.message.length).toBeGreaterThan(0);
+  });
+
+  it('does not include the attempted password in the error message', async () => {
+    mockSignIn.mockResolvedValue({
+      data: { user: null, session: null },
+      error: { code: 'invalid_credentials', message: 'Invalid login credentials' },
+    });
+    const result = await service.signIn('user@example.com', 'supersecret123');
+    expect(result.error!.message).not.toContain('supersecret123');
+  });
+});
+
+describe('AuthService – signUp error paths', () => {
+  let service: AuthService;
+  beforeEach(() => { vi.clearAllMocks(); service = new AuthService(); });
+
+  it('returns an error result when Supabase signUp fails', async () => {
+    mockSignUp.mockResolvedValue({
+      data: { user: null, session: null },
+      error: { code: 'email_taken', message: 'User already registered' },
+    });
+    const result = await service.signUp('taken@example.com', 'pass123');
+    expect(result.error).not.toBeNull();
+    expect(result.user).toBeNull();
+  });
+
+  it('returns an error result when profile creation fails', async () => {
+    const fakeUser = { id: 'u1', email: 'new@example.com', created_at: '2024-01-01T00:00:00Z' };
+    mockSignUp.mockResolvedValue({ data: { user: fakeUser, session: null }, error: null });
+    mockFrom.mockReturnValue({ insert: () => Promise.resolve({ error: { message: 'duplicate key' } }) });
+    const result = await service.signUp('new@example.com', 'pass123');
+    expect(result.error).not.toBeNull();
+    expect(result.user).toBeNull();
+  });
+
+  it('returns an error result when no user is returned', async () => {
+    mockSignUp.mockResolvedValue({ data: { user: null, session: null }, error: null });
+    const result = await service.signUp('ghost@example.com', 'pass123');
+    expect(result.error).not.toBeNull();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 6. HealthMonitorService – error paths
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { HealthMonitorService } from '@/services/health-monitor.service';
+
+// Helper: build a chainable Supabase query mock for checkAllDeployments
+// which calls .select().eq().eq()
+function makeDeploymentListMock(data: unknown[] | null) {
+  return {
+    select: () => ({
+      eq: () => ({
+        eq: () => Promise.resolve({ data }),
+      }),
+    }),
+  };
+}
+
+// Helper: build a single-row mock for checkDeploymentHealth which calls
+// .select().eq().single()
+function makeDeploymentRowMock(row: unknown) {
+  return {
+    select: () => ({
+      eq: () => ({
+        single: () => Promise.resolve({ data: row }),
+      }),
+    }),
+  };
+}
+
+describe('HealthMonitorService – error paths', () => {
+  let service: HealthMonitorService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new HealthMonitorService();
+    mockAnalyticsRecord.mockResolvedValue(undefined);
+  });
+
+  it('returns isHealthy=false when deployment URL is not found', async () => {
+    mockFrom.mockReturnValue(makeDeploymentRowMock(null));
+    const result = await service.checkDeploymentHealth('dep-missing');
+    expect(result.isHealthy).toBe(false);
+    expect(result.error).toBeTruthy();
+  });
+
+  it('error message for missing URL is user-readable (not a stack trace)', async () => {
+    mockFrom.mockReturnValue(makeDeploymentRowMock(null));
+    const result = await service.checkDeploymentHealth('dep-missing');
+    expect(result.error).not.toMatch(/Error:/);
+    expect(result.error).not.toMatch(/at \w+/);
+  });
+
+  it('returns isHealthy=false and records downtime when fetch throws', async () => {
+    mockFrom.mockReturnValue(makeDeploymentRowMock({ deployment_url: 'https://example.com' }));
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('ECONNREFUSED'));
+    const result = await service.checkDeploymentHealth('dep-1');
+    expect(result.isHealthy).toBe(false);
+    expect(mockAnalyticsRecord).toHaveBeenCalledWith('dep-1', false);
+  });
+
+  it('returns isHealthy=false for non-2xx responses', async () => {
+    mockFrom.mockReturnValue(makeDeploymentRowMock({ deployment_url: 'https://example.com' }));
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({ ok: false, status: 503 });
+    const result = await service.checkDeploymentHealth('dep-1');
+    expect(result.isHealthy).toBe(false);
+    expect(result.statusCode).toBe(503);
+  });
+
+  it('records downtime analytics on fetch failure', async () => {
+    mockFrom.mockReturnValue(makeDeploymentRowMock({ deployment_url: 'https://example.com' }));
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('timeout'));
+    await service.checkDeploymentHealth('dep-2');
+    expect(mockAnalyticsRecord).toHaveBeenCalledWith('dep-2', false);
+  });
+
+  it('returns empty array (not a throw) when no active deployments exist', async () => {
+    mockFrom.mockReturnValue(makeDeploymentListMock([]));
+    const results = await service.checkAllDeployments();
+    expect(Array.isArray(results)).toBe(true);
+    expect(results).toHaveLength(0);
+  });
+
+  it('returns empty array (not a throw) when deployments query returns null', async () => {
+    mockFrom.mockReturnValue(makeDeploymentListMock(null));
+    const results = await service.checkAllDeployments();
+    expect(Array.isArray(results)).toBe(true);
+  });
+});

--- a/apps/backend/tests/websocket/realtime.test.ts
+++ b/apps/backend/tests/websocket/realtime.test.ts
@@ -1,0 +1,513 @@
+/**
+ * Real-time WebSocket Connection Tests (#339)
+ *
+ * Tests the RealtimeStatusPoller which wraps Supabase Realtime channels
+ * (WebSocket transport) for deployment status updates.
+ *
+ * Coverage:
+ *   1. Connection lifecycle (connect, disconnect, state transitions)
+ *   2. Authentication (ownership check before subscribing)
+ *   3. Message delivery and ordering (sequence numbers)
+ *   4. Reconnection with exponential backoff
+ *   5. Concurrent connections (multiple pollers for different deployments)
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { RealtimeStatusPoller } from '@/lib/realtime/realtime-status-poller';
+import type { DeploymentStatusPayload } from '@/lib/realtime/realtime-status-poller';
+
+// ── Supabase channel mock factory ─────────────────────────────────────────────
+
+type SubscribeCallback = (status: string) => void;
+type ChangeCallback = (payload: any) => void;
+
+interface MockChannel {
+  on: ReturnType<typeof vi.fn>;
+  subscribe: ReturnType<typeof vi.fn>;
+  _triggerSubscribe: (status: string) => void;
+  _triggerChange: (payload: any) => void;
+}
+
+function makeMockChannel(): MockChannel {
+  let subscribeCb: SubscribeCallback = () => {};
+  let changeCb: ChangeCallback = () => {};
+
+  const channel: MockChannel = {
+    on: vi.fn().mockImplementation((_event: any, _filter: any, cb: ChangeCallback) => {
+      changeCb = cb;
+      return channel;
+    }),
+    subscribe: vi.fn().mockImplementation((cb: SubscribeCallback) => {
+      subscribeCb = cb;
+      return channel;
+    }),
+    _triggerSubscribe: (status: string) => subscribeCb(status),
+    _triggerChange: (payload: any) => changeCb(payload),
+  };
+  return channel;
+}
+
+function makeSupabaseMock(opts: {
+  deploymentUserId?: string;
+  queryError?: boolean;
+} = {}) {
+  const channel = makeMockChannel();
+
+  const supabase = {
+    from: vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          single: vi.fn().mockResolvedValue(
+            opts.queryError
+              ? { data: null, error: new Error('db error') }
+              : { data: { user_id: opts.deploymentUserId ?? 'user-1' }, error: null }
+          ),
+        }),
+      }),
+    }),
+    channel: vi.fn().mockReturnValue(channel),
+    removeChannel: vi.fn().mockResolvedValue(undefined),
+    _channel: channel,
+  };
+
+  return supabase;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 1. Connection lifecycle
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('RealtimeStatusPoller – connection lifecycle', () => {
+  it('starts in disconnected state', () => {
+    const supabase = makeSupabaseMock();
+    const poller = new RealtimeStatusPoller(supabase as any, 'dep-1', 'user-1');
+    expect(poller.connectionState).toBe('disconnected');
+  });
+
+  it('transitions to connecting then connected on successful subscribe', async () => {
+    const supabase = makeSupabaseMock({ deploymentUserId: 'user-1' });
+    const poller = new RealtimeStatusPoller(supabase as any, 'dep-1', 'user-1');
+
+    const connectPromise = poller.connect();
+    await connectPromise;
+    supabase._channel._triggerSubscribe('SUBSCRIBED');
+
+    expect(poller.connectionState).toBe('connected');
+  });
+
+  it('transitions to closed on disconnect()', async () => {
+    const supabase = makeSupabaseMock({ deploymentUserId: 'user-1' });
+    const poller = new RealtimeStatusPoller(supabase as any, 'dep-1', 'user-1');
+
+    await poller.connect();
+    supabase._channel._triggerSubscribe('SUBSCRIBED');
+
+    await poller.disconnect();
+    expect(poller.connectionState).toBe('closed');
+  });
+
+  it('calls supabase.removeChannel on disconnect', async () => {
+    const supabase = makeSupabaseMock({ deploymentUserId: 'user-1' });
+    const poller = new RealtimeStatusPoller(supabase as any, 'dep-1', 'user-1');
+
+    await poller.connect();
+    supabase._channel._triggerSubscribe('SUBSCRIBED');
+
+    await poller.disconnect();
+    expect(supabase.removeChannel).toHaveBeenCalledOnce();
+  });
+
+  it('does not open a second channel if already connected', async () => {
+    const supabase = makeSupabaseMock({ deploymentUserId: 'user-1' });
+    const poller = new RealtimeStatusPoller(supabase as any, 'dep-1', 'user-1');
+
+    await poller.connect();
+    supabase._channel._triggerSubscribe('SUBSCRIBED');
+
+    await poller.connect(); // second call — should be a no-op
+    expect(supabase.channel).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not open a second channel if already connecting', async () => {
+    const supabase = makeSupabaseMock({ deploymentUserId: 'user-1' });
+    const poller = new RealtimeStatusPoller(supabase as any, 'dep-1', 'user-1');
+
+    // Start connecting but don't trigger SUBSCRIBED yet
+    const p1 = poller.connect();
+    const p2 = poller.connect();
+    await Promise.all([p1, p2]);
+    supabase._channel._triggerSubscribe('SUBSCRIBED');
+
+    expect(supabase.channel).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 2. Authentication
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('RealtimeStatusPoller – authentication', () => {
+  it('throws and sets state=closed when deployment belongs to a different user', async () => {
+    const supabase = makeSupabaseMock({ deploymentUserId: 'other-user' });
+    const poller = new RealtimeStatusPoller(supabase as any, 'dep-1', 'user-1');
+
+    await expect(poller.connect()).rejects.toThrow('Unauthorized');
+    expect(poller.connectionState).toBe('closed');
+  });
+
+  it('throws and sets state=closed when the DB query errors', async () => {
+    const supabase = makeSupabaseMock({ queryError: true });
+    const poller = new RealtimeStatusPoller(supabase as any, 'dep-1', 'user-1');
+
+    await expect(poller.connect()).rejects.toThrow('Unauthorized');
+    expect(poller.connectionState).toBe('closed');
+  });
+
+  it('does not open a channel when auth fails', async () => {
+    const supabase = makeSupabaseMock({ deploymentUserId: 'other-user' });
+    const poller = new RealtimeStatusPoller(supabase as any, 'dep-1', 'user-1');
+
+    await expect(poller.connect()).rejects.toThrow();
+    expect(supabase.channel).not.toHaveBeenCalled();
+  });
+
+  it('opens the channel when auth succeeds', async () => {
+    const supabase = makeSupabaseMock({ deploymentUserId: 'user-1' });
+    const poller = new RealtimeStatusPoller(supabase as any, 'dep-1', 'user-1');
+
+    await poller.connect();
+    supabase._channel._triggerSubscribe('SUBSCRIBED');
+
+    expect(supabase.channel).toHaveBeenCalledWith('deployment:dep-1');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 3. Message delivery and ordering
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('RealtimeStatusPoller – message delivery and ordering', () => {
+  async function connectedPoller() {
+    const supabase = makeSupabaseMock({ deploymentUserId: 'user-1' });
+    const poller = new RealtimeStatusPoller(supabase as any, 'dep-1', 'user-1');
+    await poller.connect();
+    supabase._channel._triggerSubscribe('SUBSCRIBED');
+    return { poller, supabase };
+  }
+
+  it('delivers status updates to registered handlers', async () => {
+    const { poller, supabase } = await connectedPoller();
+    const received: DeploymentStatusPayload[] = [];
+    poller.onStatus((msg) => received.push(msg));
+
+    supabase._channel._triggerChange({ new: { status: 'building' } });
+
+    expect(received).toHaveLength(1);
+    expect(received[0].status).toBe('building');
+    expect(received[0].deploymentId).toBe('dep-1');
+  });
+
+  it('assigns monotonically increasing sequence numbers', async () => {
+    const { poller, supabase } = await connectedPoller();
+    const received: DeploymentStatusPayload[] = [];
+    poller.onStatus((msg) => received.push(msg));
+
+    supabase._channel._triggerChange({ new: { status: 'building' } });
+    supabase._channel._triggerChange({ new: { status: 'deploying' } });
+    supabase._channel._triggerChange({ new: { status: 'completed' } });
+
+    expect(received.map((m) => m.sequenceNumber)).toEqual([1, 2, 3]);
+  });
+
+  it('delivers messages to multiple handlers', async () => {
+    const { poller, supabase } = await connectedPoller();
+    const a: string[] = [];
+    const b: string[] = [];
+    poller.onStatus((m) => a.push(m.status));
+    poller.onStatus((m) => b.push(m.status));
+
+    supabase._channel._triggerChange({ new: { status: 'completed' } });
+
+    expect(a).toEqual(['completed']);
+    expect(b).toEqual(['completed']);
+  });
+
+  it('stops delivering to a handler after unsubscribe', async () => {
+    const { poller, supabase } = await connectedPoller();
+    const received: string[] = [];
+    const unsub = poller.onStatus((m) => received.push(m.status));
+
+    supabase._channel._triggerChange({ new: { status: 'building' } });
+    unsub();
+    supabase._channel._triggerChange({ new: { status: 'completed' } });
+
+    expect(received).toEqual(['building']);
+  });
+
+  it('includes a timestamp on every message', async () => {
+    const { poller, supabase } = await connectedPoller();
+    const received: DeploymentStatusPayload[] = [];
+    poller.onStatus((m) => received.push(m));
+
+    supabase._channel._triggerChange({ new: { status: 'building' } });
+
+    expect(new Date(received[0].timestamp).getTime()).toBeGreaterThan(0);
+  });
+
+  it('handles unknown status gracefully', async () => {
+    const { poller, supabase } = await connectedPoller();
+    const received: DeploymentStatusPayload[] = [];
+    poller.onStatus((m) => received.push(m));
+
+    supabase._channel._triggerChange({ new: {} }); // no status field
+
+    expect(received[0].status).toBe('unknown');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 4. Reconnection with exponential backoff
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('RealtimeStatusPoller – reconnection with exponential backoff', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('transitions to reconnecting on CHANNEL_ERROR', async () => {
+    const supabase = makeSupabaseMock({ deploymentUserId: 'user-1' });
+    const poller = new RealtimeStatusPoller(supabase as any, 'dep-1', 'user-1', { baseDelayMs: 100 });
+
+    await poller.connect();
+    supabase._channel._triggerSubscribe('SUBSCRIBED');
+
+    supabase._channel._triggerSubscribe('CHANNEL_ERROR');
+    expect(poller.connectionState).toBe('reconnecting');
+  });
+
+  it('transitions to reconnecting on TIMED_OUT', async () => {
+    const supabase = makeSupabaseMock({ deploymentUserId: 'user-1' });
+    const poller = new RealtimeStatusPoller(supabase as any, 'dep-1', 'user-1', { baseDelayMs: 100 });
+
+    await poller.connect();
+    supabase._channel._triggerSubscribe('SUBSCRIBED');
+
+    supabase._channel._triggerSubscribe('TIMED_OUT');
+    expect(poller.connectionState).toBe('reconnecting');
+  });
+
+  it('reopens the channel after the backoff delay', async () => {
+    const supabase = makeSupabaseMock({ deploymentUserId: 'user-1' });
+    const poller = new RealtimeStatusPoller(supabase as any, 'dep-1', 'user-1', { baseDelayMs: 100 });
+
+    await poller.connect();
+    supabase._channel._triggerSubscribe('SUBSCRIBED');
+
+    supabase._channel._triggerSubscribe('CHANNEL_ERROR');
+    expect(supabase.channel).toHaveBeenCalledTimes(1);
+
+    // Advance past the first backoff window (100ms * 2^0 = 100ms)
+    await vi.advanceTimersByTimeAsync(150);
+    expect(supabase.channel).toHaveBeenCalledTimes(2);
+  });
+
+  it('uses exponential backoff: delay doubles on each retry', async () => {
+    const supabase = makeSupabaseMock({ deploymentUserId: 'user-1' });
+    const poller = new RealtimeStatusPoller(supabase as any, 'dep-1', 'user-1', {
+      baseDelayMs: 100,
+      maxRetries: 5,
+    });
+
+    await poller.connect();
+    supabase._channel._triggerSubscribe('SUBSCRIBED');
+
+    // Retry 1: delay = 100ms
+    supabase._channel._triggerSubscribe('CHANNEL_ERROR');
+    await vi.advanceTimersByTimeAsync(110);
+    supabase._channel._triggerSubscribe('CHANNEL_ERROR');
+
+    // Retry 2: delay = 200ms — should NOT fire at 110ms
+    expect(supabase.channel).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(210);
+    expect(supabase.channel).toHaveBeenCalledTimes(3);
+  });
+
+  it('caps backoff at maxDelayMs', async () => {
+    const supabase = makeSupabaseMock({ deploymentUserId: 'user-1' });
+    const poller = new RealtimeStatusPoller(supabase as any, 'dep-1', 'user-1', {
+      baseDelayMs: 1000,
+      maxDelayMs: 2000,
+      maxRetries: 10,
+    });
+
+    await poller.connect();
+    supabase._channel._triggerSubscribe('SUBSCRIBED');
+
+    // Force several retries to push past the cap
+    for (let i = 0; i < 5; i++) {
+      supabase._channel._triggerSubscribe('CHANNEL_ERROR');
+      await vi.advanceTimersByTimeAsync(2100);
+      supabase._channel._triggerSubscribe('SUBSCRIBED');
+    }
+
+    // All retries should have fired (not stuck waiting for > maxDelayMs)
+    expect(supabase.channel.mock.calls.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it('transitions to closed after maxRetries exhausted', async () => {
+    const supabase = makeSupabaseMock({ deploymentUserId: 'user-1' });
+    const poller = new RealtimeStatusPoller(supabase as any, 'dep-1', 'user-1', {
+      baseDelayMs: 10,
+      maxRetries: 2,
+    });
+
+    await poller.connect();
+    supabase._channel._triggerSubscribe('SUBSCRIBED');
+
+    // Exhaust all retries
+    for (let i = 0; i < 3; i++) {
+      supabase._channel._triggerSubscribe('CHANNEL_ERROR');
+      await vi.advanceTimersByTimeAsync(500);
+    }
+
+    expect(poller.connectionState).toBe('closed');
+  });
+
+  it('resets retry count after a successful reconnect', async () => {
+    const supabase = makeSupabaseMock({ deploymentUserId: 'user-1' });
+    const poller = new RealtimeStatusPoller(supabase as any, 'dep-1', 'user-1', {
+      baseDelayMs: 10,
+      maxRetries: 3,
+    });
+
+    await poller.connect();
+    supabase._channel._triggerSubscribe('SUBSCRIBED');
+
+    // Disconnect and reconnect successfully
+    supabase._channel._triggerSubscribe('CHANNEL_ERROR');
+    await vi.advanceTimersByTimeAsync(50);
+    supabase._channel._triggerSubscribe('SUBSCRIBED');
+
+    // Should still be connected (retry count reset)
+    expect(poller.connectionState).toBe('connected');
+  });
+
+  it('cancels pending retry timer on explicit disconnect', async () => {
+    const supabase = makeSupabaseMock({ deploymentUserId: 'user-1' });
+    const poller = new RealtimeStatusPoller(supabase as any, 'dep-1', 'user-1', {
+      baseDelayMs: 1000,
+      maxRetries: 5,
+    });
+
+    await poller.connect();
+    supabase._channel._triggerSubscribe('SUBSCRIBED');
+
+    supabase._channel._triggerSubscribe('CHANNEL_ERROR');
+    expect(poller.connectionState).toBe('reconnecting');
+
+    await poller.disconnect();
+    expect(poller.connectionState).toBe('closed');
+
+    // Advance past the retry window — no new channel should open
+    const callsBefore = supabase.channel.mock.calls.length;
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(supabase.channel.mock.calls.length).toBe(callsBefore);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 5. Concurrent connections
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('RealtimeStatusPoller – concurrent connections', () => {
+  it('creates independent channels for different deployments', async () => {
+    const s1 = makeSupabaseMock({ deploymentUserId: 'user-1' });
+    const s2 = makeSupabaseMock({ deploymentUserId: 'user-1' });
+
+    const p1 = new RealtimeStatusPoller(s1 as any, 'dep-A', 'user-1');
+    const p2 = new RealtimeStatusPoller(s2 as any, 'dep-B', 'user-1');
+
+    await p1.connect();
+    s1._channel._triggerSubscribe('SUBSCRIBED');
+
+    await p2.connect();
+    s2._channel._triggerSubscribe('SUBSCRIBED');
+
+    expect(s1.channel).toHaveBeenCalledWith('deployment:dep-A');
+    expect(s2.channel).toHaveBeenCalledWith('deployment:dep-B');
+  });
+
+  it('messages from one channel do not reach handlers of another', async () => {
+    const s1 = makeSupabaseMock({ deploymentUserId: 'user-1' });
+    const s2 = makeSupabaseMock({ deploymentUserId: 'user-1' });
+
+    const p1 = new RealtimeStatusPoller(s1 as any, 'dep-A', 'user-1');
+    const p2 = new RealtimeStatusPoller(s2 as any, 'dep-B', 'user-1');
+
+    const msgs1: string[] = [];
+    const msgs2: string[] = [];
+    p1.onStatus((m) => msgs1.push(m.deploymentId));
+    p2.onStatus((m) => msgs2.push(m.deploymentId));
+
+    await p1.connect();
+    s1._channel._triggerSubscribe('SUBSCRIBED');
+
+    await p2.connect();
+    s2._channel._triggerSubscribe('SUBSCRIBED');
+
+    s1._channel._triggerChange({ new: { status: 'building' } });
+    s2._channel._triggerChange({ new: { status: 'completed' } });
+
+    expect(msgs1).toEqual(['dep-A']);
+    expect(msgs2).toEqual(['dep-B']);
+  });
+
+  it('disconnecting one poller does not affect another', async () => {
+    const s1 = makeSupabaseMock({ deploymentUserId: 'user-1' });
+    const s2 = makeSupabaseMock({ deploymentUserId: 'user-1' });
+
+    const p1 = new RealtimeStatusPoller(s1 as any, 'dep-A', 'user-1');
+    const p2 = new RealtimeStatusPoller(s2 as any, 'dep-B', 'user-1');
+
+    await p1.connect();
+    s1._channel._triggerSubscribe('SUBSCRIBED');
+
+    await p2.connect();
+    s2._channel._triggerSubscribe('SUBSCRIBED');
+
+    await p1.disconnect();
+
+    expect(p1.connectionState).toBe('closed');
+    expect(p2.connectionState).toBe('connected');
+  });
+
+  it('sequence numbers are independent per poller instance', async () => {
+    const s1 = makeSupabaseMock({ deploymentUserId: 'user-1' });
+    const s2 = makeSupabaseMock({ deploymentUserId: 'user-1' });
+
+    const p1 = new RealtimeStatusPoller(s1 as any, 'dep-A', 'user-1');
+    const p2 = new RealtimeStatusPoller(s2 as any, 'dep-B', 'user-1');
+
+    const seqs1: number[] = [];
+    const seqs2: number[] = [];
+    p1.onStatus((m) => seqs1.push(m.sequenceNumber));
+    p2.onStatus((m) => seqs2.push(m.sequenceNumber));
+
+    await p1.connect();
+    s1._channel._triggerSubscribe('SUBSCRIBED');
+
+    await p2.connect();
+    s2._channel._triggerSubscribe('SUBSCRIBED');
+
+    s1._channel._triggerChange({ new: { status: 'building' } });
+    s1._channel._triggerChange({ new: { status: 'deploying' } });
+    s2._channel._triggerChange({ new: { status: 'completed' } });
+
+    expect(seqs1).toEqual([1, 2]);
+    expect(seqs2).toEqual([1]); // independent counter
+  });
+});

--- a/apps/frontend/src/app/app/subscription/page.tsx
+++ b/apps/frontend/src/app/app/subscription/page.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+/**
+ * Subscription Comparison Page
+ *
+ * Authenticated route that shows a side-by-side comparison of all subscription
+ * tiers, highlights the user's current plan, and provides upgrade/downgrade CTAs.
+ *
+ * Route: /app/subscription
+ */
+
+import React, { useEffect, useState } from 'react';
+import { AppShell } from '@/components/app';
+import { SubscriptionComparison } from '@/components/app/SubscriptionComparison';
+import type { SubscriptionTier } from '@craft/types';
+import type { User, NavItem } from '@/types/navigation';
+
+const mockUser: User = {
+  id: '1',
+  name: 'John Doe',
+  email: 'john@example.com',
+  role: 'user',
+};
+
+const navItems: NavItem[] = [
+  {
+    id: 'home',
+    label: 'Home',
+    icon: (
+      <svg fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
+      </svg>
+    ),
+    path: '/app',
+  },
+  {
+    id: 'templates',
+    label: 'Templates',
+    icon: (
+      <svg fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+      </svg>
+    ),
+    path: '/app/templates',
+  },
+  {
+    id: 'deployments',
+    label: 'Deployments',
+    icon: (
+      <svg fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
+      </svg>
+    ),
+    path: '/app/deployments',
+  },
+  {
+    id: 'settings',
+    label: 'Settings',
+    icon: (
+      <svg fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+      </svg>
+    ),
+    path: '/app/settings/profile',
+  },
+];
+
+export default function SubscriptionPage() {
+  const [currentTier, setCurrentTier] = useState<SubscriptionTier>('free');
+
+  useEffect(() => {
+    fetch('/api/payments/subscription')
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (data?.tier) setCurrentTier(data.tier as SubscriptionTier);
+      })
+      .catch(() => {/* fall back to 'free' */});
+  }, []);
+
+  return (
+    <AppShell
+      user={mockUser}
+      navItems={navItems}
+      breadcrumbs={[
+        { label: 'Settings', path: '/app/settings/profile' },
+        { label: 'Subscription' },
+      ]}
+    >
+      <SubscriptionComparison currentTier={currentTier} />
+    </AppShell>
+  );
+}

--- a/apps/frontend/src/app/app/subscription/upgrade/[tier]/page.tsx
+++ b/apps/frontend/src/app/app/subscription/upgrade/[tier]/page.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+/**
+ * Subscription Upgrade Page
+ *
+ * Confirms the target tier with the user, then initiates a Stripe checkout
+ * session and redirects to the hosted payment page.
+ *
+ * Route: /app/subscription/upgrade/[tier]
+ *
+ * Edge cases:
+ * - Invalid tier param → redirect to /app/subscription
+ * - Same tier as current → redirect to /app/subscription
+ * - Checkout API failure → show inline error, allow retry
+ */
+
+import React, { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { AppShell } from '@/components/app';
+import { UpgradeFlow } from '@/components/app/UpgradeFlow';
+import { TIER_CONFIGS } from '@/lib/stripe/pricing';
+import type { SubscriptionTier } from '@craft/types';
+import type { User, NavItem } from '@/types/navigation';
+
+const VALID_TIERS = new Set<string>(['free', 'pro', 'enterprise']);
+
+const mockUser: User = { id: '1', name: 'John Doe', email: 'john@example.com', role: 'user' };
+
+const navItems: NavItem[] = [
+  {
+    id: 'home', label: 'Home', path: '/app',
+    icon: <svg fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" /></svg>,
+  },
+  {
+    id: 'settings', label: 'Settings', path: '/app/settings/profile',
+    icon: <svg fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" /><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" /></svg>,
+  },
+];
+
+export default function UpgradePage({ params }: { params: { tier: string } }) {
+  const router = useRouter();
+  const [currentTier, setCurrentTier] = useState<SubscriptionTier>('free');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const targetTier = params.tier as SubscriptionTier;
+
+  // Redirect if the tier param is invalid
+  useEffect(() => {
+    if (!VALID_TIERS.has(params.tier)) {
+      router.replace('/app/subscription');
+    }
+  }, [params.tier, router]);
+
+  // Fetch the user's current tier
+  useEffect(() => {
+    fetch('/api/payments/subscription')
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (data?.tier) {
+          const tier = data.tier as SubscriptionTier;
+          // Redirect if already on this tier
+          if (tier === targetTier) {
+            router.replace('/app/subscription');
+            return;
+          }
+          setCurrentTier(tier);
+        }
+      })
+      .catch(() => {/* fall back to 'free' */});
+  }, [targetTier, router]);
+
+  async function handleConfirm() {
+    const priceId = TIER_CONFIGS[targetTier]?.stripePriceId;
+    if (!priceId) {
+      setError('No price configured for this tier.');
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const res = await fetch('/api/payments/checkout', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          priceId,
+          successUrl: `${window.location.origin}/app/subscription?upgraded=1`,
+          cancelUrl: `${window.location.origin}/app/subscription/upgrade/${targetTier}`,
+        }),
+      });
+
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body?.error ?? 'Failed to start checkout. Please try again.');
+      }
+
+      const { url } = await res.json();
+      window.location.href = url;
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'An unexpected error occurred.');
+      setLoading(false);
+    }
+  }
+
+  if (!VALID_TIERS.has(params.tier)) return null;
+
+  return (
+    <AppShell
+      user={mockUser}
+      navItems={navItems}
+      breadcrumbs={[
+        { label: 'Subscription', path: '/app/subscription' },
+        { label: `Upgrade to ${TIER_CONFIGS[targetTier]?.displayName ?? targetTier}` },
+      ]}
+    >
+      <UpgradeFlow
+        currentTier={currentTier}
+        targetTier={targetTier}
+        onConfirm={handleConfirm}
+        loading={loading}
+        error={error}
+      />
+    </AppShell>
+  );
+}

--- a/apps/frontend/src/components/app/SubscriptionComparison.test.tsx
+++ b/apps/frontend/src/components/app/SubscriptionComparison.test.tsx
@@ -1,0 +1,89 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { SubscriptionComparison } from './SubscriptionComparison';
+
+vi.mock('next/link', () => ({
+  default: (props: React.AnchorHTMLAttributes<HTMLAnchorElement> & { 'data-testid'?: string }) => (
+    <a href={props.href} data-testid={props['data-testid']}>
+      {props.children}
+    </a>
+  ),
+}));
+
+vi.mock('@/lib/stripe/pricing', () => ({
+  TIER_CONFIGS: {
+    free:       { displayName: 'Free',       monthlyPriceCents: 0,    entitlements: { maxDeployments: 1,  maxCustomDomains: 0,  analyticsEnabled: false, premiumTemplates: false, prioritySupport: false }, stripePriceId: null },
+    pro:        { displayName: 'Pro',        monthlyPriceCents: 2900, entitlements: { maxDeployments: 10, maxCustomDomains: 1,  analyticsEnabled: true,  premiumTemplates: true,  prioritySupport: false }, stripePriceId: 'price_pro' },
+    enterprise: { displayName: 'Enterprise', monthlyPriceCents: 9900, entitlements: { maxDeployments: -1, maxCustomDomains: -1, analyticsEnabled: true,  premiumTemplates: true,  prioritySupport: true  }, stripePriceId: 'price_ent' },
+  },
+}));
+
+vi.mock('@/components/marketing/FeatureMatrix', () => ({
+  MATRIX_FEATURES: [
+    { label: 'Deployments', free: '1', pro: '10', enterprise: 'Unlimited' },
+    { label: 'Analytics',   free: false, pro: true, enterprise: true },
+  ],
+  MatrixCell: ({ value }: { value: string | boolean }) =>
+    typeof value === 'boolean' ? (
+      <span>{value ? 'yes' : 'no'}</span>
+    ) : (
+      <span>{value}</span>
+    ),
+}));
+
+describe('SubscriptionComparison', () => {
+  it('renders a card for each tier', () => {
+    render(<SubscriptionComparison currentTier="free" />);
+    expect(screen.getByTestId('comparison-card-free')).toBeDefined();
+    expect(screen.getByTestId('comparison-card-pro')).toBeDefined();
+    expect(screen.getByTestId('comparison-card-enterprise')).toBeDefined();
+  });
+
+  it('marks the current tier with a badge', () => {
+    render(<SubscriptionComparison currentTier="pro" />);
+    expect(screen.getByTestId('badge-current')).toBeDefined();
+    // Only one badge should be present
+    expect(screen.getAllByTestId('badge-current')).toHaveLength(1);
+  });
+
+  it('shows "Current Plan" label on the active tier card instead of a link', () => {
+    render(<SubscriptionComparison currentTier="pro" />);
+    // The pro card should NOT have a CTA link
+    expect(screen.queryByTestId('cta-pro')).toBeNull();
+  });
+
+  it('renders upgrade CTA links for non-current paid tiers', () => {
+    render(<SubscriptionComparison currentTier="free" />);
+    const proLink = screen.getByTestId('cta-pro') as HTMLAnchorElement;
+    expect(proLink.getAttribute('href')).toBe('/api/payments/checkout?priceId=price_pro');
+    const entLink = screen.getByTestId('cta-enterprise') as HTMLAnchorElement;
+    expect(entLink.getAttribute('href')).toBe('/api/payments/checkout?priceId=price_ent');
+  });
+
+  it('renders the feature comparison table rows', () => {
+    render(<SubscriptionComparison currentTier="free" />);
+    expect(screen.getByText('Deployments')).toBeDefined();
+    expect(screen.getByText('Analytics')).toBeDefined();
+  });
+
+  it('displays the current plan name in the description', () => {
+    render(<SubscriptionComparison currentTier="enterprise" />);
+    // "Enterprise" appears in the description span, card heading, and table header
+    expect(screen.getAllByText(/Enterprise/).length).toBeGreaterThan(0);
+  });
+
+  it('shows $0 price for free tier', () => {
+    render(<SubscriptionComparison currentTier="free" />);
+    expect(screen.getByTestId('comparison-card-free').textContent).toContain('$0');
+  });
+
+  it('shows monthly price for paid tiers', () => {
+    render(<SubscriptionComparison currentTier="free" />);
+    expect(screen.getByTestId('comparison-card-pro').textContent).toContain('$29');
+    expect(screen.getByTestId('comparison-card-enterprise').textContent).toContain('$99');
+  });
+});

--- a/apps/frontend/src/components/app/SubscriptionComparison.tsx
+++ b/apps/frontend/src/components/app/SubscriptionComparison.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+/**
+ * SubscriptionComparison
+ *
+ * Renders a full-page tier comparison table for authenticated users.
+ * Highlights the current plan and surfaces upgrade CTAs for each paid tier.
+ *
+ * @param currentTier - The user's active subscription tier
+ */
+
+import React from 'react';
+import Link from 'next/link';
+import { TIER_CONFIGS } from '@/lib/stripe/pricing';
+import { MATRIX_FEATURES, MatrixCell } from '@/components/marketing/FeatureMatrix';
+import type { SubscriptionTier } from '@craft/types';
+
+const TIERS: SubscriptionTier[] = ['free', 'pro', 'enterprise'];
+
+function buildCtaHref(tier: SubscriptionTier): string {
+  if (tier === 'free') return '/app';
+  const priceId = TIER_CONFIGS[tier].stripePriceId;
+  return priceId ? `/api/payments/checkout?priceId=${priceId}` : '/app/settings/billing';
+}
+
+function buildCtaLabel(tier: SubscriptionTier, isCurrentTier: boolean): string {
+  if (isCurrentTier) return 'Current Plan';
+  if (tier === 'free') return 'Downgrade';
+  return 'Upgrade';
+}
+
+/**
+ * Subscription tier comparison table for authenticated users.
+ * Shows features, limits, pricing, and CTA buttons per tier.
+ */
+export function SubscriptionComparison({ currentTier }: { currentTier: SubscriptionTier }) {
+  return (
+    <section aria-label="Subscription tier comparison" className="max-w-5xl mx-auto px-6 py-10">
+      <h1 className="text-2xl font-bold font-headline text-on-surface mb-2">Compare Plans</h1>
+      <p className="text-sm text-on-surface-variant mb-8">
+        You are currently on the{' '}
+        <span className="font-semibold text-on-surface">{TIER_CONFIGS[currentTier].displayName}</span> plan.
+      </p>
+
+      {/* Tier header cards */}
+      <div className="grid grid-cols-3 gap-4 mb-6">
+        {TIERS.map((tier) => {
+          const config = TIER_CONFIGS[tier];
+          const isCurrent = tier === currentTier;
+          const ctaHref = buildCtaHref(tier);
+          const ctaLabel = buildCtaLabel(tier, isCurrent);
+          const priceDisplay =
+            config.monthlyPriceCents === 0 ? '$0' : `$${config.monthlyPriceCents / 100}`;
+
+          return (
+            <div
+              key={tier}
+              data-testid={`comparison-card-${tier}`}
+              className={`rounded-xl border p-5 flex flex-col gap-3 ${
+                isCurrent
+                  ? 'border-surface-tint ring-1 ring-surface-tint bg-surface-container-lowest'
+                  : 'border-outline-variant/20 bg-surface-container-lowest'
+              }`}
+            >
+              {isCurrent && (
+                <span
+                  data-testid="badge-current"
+                  className="self-start inline-flex items-center rounded-full bg-secondary-container px-2.5 py-0.5 text-xs font-semibold text-on-secondary-container"
+                >
+                  Current Plan
+                </span>
+              )}
+              <h2 className="text-lg font-bold font-headline text-on-surface">{config.displayName}</h2>
+              <div>
+                <span className="text-3xl font-bold font-headline text-on-surface">{priceDisplay}</span>
+                {config.monthlyPriceCents > 0 && (
+                  <span className="text-xs text-on-surface-variant ml-1">/month</span>
+                )}
+              </div>
+              {isCurrent ? (
+                <span className="w-full rounded-lg border border-outline-variant/40 px-4 py-2 text-sm font-semibold text-on-surface-variant text-center cursor-default select-none">
+                  {ctaLabel}
+                </span>
+              ) : (
+                <Link
+                  href={ctaHref}
+                  data-testid={`cta-${tier}`}
+                  className="w-full rounded-lg bg-surface-tint px-4 py-2 text-sm font-semibold text-on-primary text-center hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-surface-tint focus:ring-offset-2 transition-all duration-200"
+                >
+                  {ctaLabel}
+                </Link>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Feature comparison table */}
+      <div className="overflow-x-auto rounded-xl border border-outline-variant/20 shadow-sm">
+        <table className="w-full min-w-[480px] bg-surface-container-lowest">
+          <thead>
+            <tr className="border-b border-outline-variant/20">
+              <th className="text-left px-6 py-4 text-sm font-semibold text-on-surface w-1/2">Feature</th>
+              {TIERS.map((t) => (
+                <th
+                  key={t}
+                  scope="col"
+                  className={`px-4 py-4 text-center text-sm font-semibold ${
+                    t === currentTier ? 'text-surface-tint' : 'text-on-surface'
+                  }`}
+                >
+                  {TIER_CONFIGS[t].displayName}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {MATRIX_FEATURES.map((row, i) => (
+              <tr
+                key={row.label}
+                className={`border-b border-outline-variant/10 last:border-0 ${
+                  i % 2 !== 0 ? 'bg-surface-container-low/40' : ''
+                }`}
+              >
+                <td className="px-6 py-4 text-sm text-on-surface-variant">{row.label}</td>
+                <td className="px-4 py-4 text-center">
+                  <MatrixCell value={row.free} />
+                </td>
+                <td className="px-4 py-4 text-center">
+                  <MatrixCell value={row.pro} />
+                </td>
+                <td className="px-4 py-4 text-center">
+                  <MatrixCell value={row.enterprise} />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/apps/frontend/src/components/app/UpgradeFlow.test.tsx
+++ b/apps/frontend/src/components/app/UpgradeFlow.test.tsx
@@ -1,0 +1,93 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { UpgradeFlow } from './UpgradeFlow';
+
+vi.mock('next/link', () => ({
+  default: (props: React.AnchorHTMLAttributes<HTMLAnchorElement> & { 'data-testid'?: string }) => (
+    <a href={props.href} data-testid={props['data-testid']}>{props.children}</a>
+  ),
+}));
+
+vi.mock('@/lib/stripe/pricing', () => ({
+  TIER_CONFIGS: {
+    free:       { displayName: 'Free',       monthlyPriceCents: 0,    stripePriceId: null },
+    pro:        { displayName: 'Pro',        monthlyPriceCents: 2900, stripePriceId: 'price_pro' },
+    enterprise: { displayName: 'Enterprise', monthlyPriceCents: 9900, stripePriceId: 'price_ent' },
+  },
+}));
+
+vi.mock('@/components/marketing/FeatureMatrix', () => ({
+  MATRIX_FEATURES: [
+    { label: 'Deployments', free: '1', pro: '10', enterprise: 'Unlimited' },
+    { label: 'Analytics',   free: false, pro: true, enterprise: true },
+  ],
+  MatrixCell: ({ value }: { value: string | boolean }) => (
+    <span>{typeof value === 'boolean' ? (value ? 'yes' : 'no') : value}</span>
+  ),
+}));
+
+const noop = () => {};
+
+describe('UpgradeFlow', () => {
+  it('renders the target tier name in the heading', () => {
+    render(<UpgradeFlow currentTier="free" targetTier="pro" onConfirm={noop} loading={false} error={null} />);
+    expect(screen.getByRole('heading', { level: 1 }).textContent).toContain('Pro');
+  });
+
+  it('shows the target tier monthly price', () => {
+    render(<UpgradeFlow currentTier="free" targetTier="pro" onConfirm={noop} loading={false} error={null} />);
+    expect(screen.getByTestId('pricing-summary').textContent).toContain('$29');
+  });
+
+  it('shows proration note for upgrades', () => {
+    render(<UpgradeFlow currentTier="free" targetTier="pro" onConfirm={noop} loading={false} error={null} />);
+    expect(screen.getByTestId('proration-note')).toBeDefined();
+  });
+
+  it('does not show proration note for downgrades', () => {
+    render(<UpgradeFlow currentTier="enterprise" targetTier="free" onConfirm={noop} loading={false} error={null} />);
+    expect(screen.queryByTestId('proration-note')).toBeNull();
+  });
+
+  it('calls onConfirm when confirm button is clicked', () => {
+    const onConfirm = vi.fn();
+    render(<UpgradeFlow currentTier="free" targetTier="pro" onConfirm={onConfirm} loading={false} error={null} />);
+    fireEvent.click(screen.getByTestId('confirm-button'));
+    expect(onConfirm).toHaveBeenCalledOnce();
+  });
+
+  it('disables confirm button while loading', () => {
+    render(<UpgradeFlow currentTier="free" targetTier="pro" onConfirm={noop} loading={true} error={null} />);
+    expect((screen.getByTestId('confirm-button') as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('shows loading text on confirm button while loading', () => {
+    render(<UpgradeFlow currentTier="free" targetTier="pro" onConfirm={noop} loading={true} error={null} />);
+    expect(screen.getByTestId('confirm-button').textContent).toContain('Redirecting');
+  });
+
+  it('displays an error message when error is set', () => {
+    render(<UpgradeFlow currentTier="free" targetTier="pro" onConfirm={noop} loading={false} error="Something went wrong" />);
+    expect(screen.getByTestId('error-message').textContent).toContain('Something went wrong');
+  });
+
+  it('does not render error message when error is null', () => {
+    render(<UpgradeFlow currentTier="free" targetTier="pro" onConfirm={noop} loading={false} error={null} />);
+    expect(screen.queryByTestId('error-message')).toBeNull();
+  });
+
+  it('cancel link points to /app/subscription', () => {
+    render(<UpgradeFlow currentTier="free" targetTier="pro" onConfirm={noop} loading={false} error={null} />);
+    expect((screen.getByTestId('cancel-link') as HTMLAnchorElement).getAttribute('href')).toBe('/app/subscription');
+  });
+
+  it('renders feature comparison table rows', () => {
+    render(<UpgradeFlow currentTier="free" targetTier="pro" onConfirm={noop} loading={false} error={null} />);
+    expect(screen.getByText('Deployments')).toBeDefined();
+    expect(screen.getByText('Analytics')).toBeDefined();
+  });
+});

--- a/apps/frontend/src/components/app/UpgradeFlow.tsx
+++ b/apps/frontend/src/components/app/UpgradeFlow.tsx
@@ -1,0 +1,154 @@
+'use client';
+
+/**
+ * UpgradeFlow
+ *
+ * Confirmation screen shown before redirecting to Stripe checkout.
+ * Displays the target tier, monthly price, proration note, and a confirm CTA.
+ *
+ * @param currentTier  - The user's active subscription tier
+ * @param targetTier   - The tier the user wants to upgrade to
+ * @param onConfirm    - Called when the user clicks "Confirm upgrade"
+ * @param loading      - Whether the checkout redirect is in progress
+ * @param error        - Error message to display, if any
+ */
+
+import React from 'react';
+import Link from 'next/link';
+import { TIER_CONFIGS } from '@/lib/stripe/pricing';
+import { MATRIX_FEATURES, MatrixCell } from '@/components/marketing/FeatureMatrix';
+import type { SubscriptionTier } from '@craft/types';
+
+const TIER_ORDER: SubscriptionTier[] = ['free', 'pro', 'enterprise'];
+
+function isUpgrade(current: SubscriptionTier, target: SubscriptionTier): boolean {
+  return TIER_ORDER.indexOf(target) > TIER_ORDER.indexOf(current);
+}
+
+interface UpgradeFlowProps {
+  currentTier: SubscriptionTier;
+  targetTier: SubscriptionTier;
+  onConfirm: () => void;
+  loading: boolean;
+  error: string | null;
+}
+
+export function UpgradeFlow({ currentTier, targetTier, onConfirm, loading, error }: UpgradeFlowProps) {
+  const currentConfig = TIER_CONFIGS[currentTier];
+  const targetConfig = TIER_CONFIGS[targetTier];
+  const upgrade = isUpgrade(currentTier, targetTier);
+  const priceDisplay = `$${targetConfig.monthlyPriceCents / 100}/month`;
+
+  return (
+    <section
+      aria-label="Upgrade confirmation"
+      className="max-w-2xl mx-auto px-6 py-10"
+    >
+      {/* Header */}
+      <div className="mb-8">
+        <Link
+          href="/app/subscription"
+          data-testid="back-link"
+          className="text-sm text-on-surface-variant hover:text-on-surface transition-colors"
+        >
+          ← Back to plans
+        </Link>
+        <h1 className="mt-4 text-2xl font-bold font-headline text-on-surface">
+          {upgrade ? 'Upgrade' : 'Change'} to {targetConfig.displayName}
+        </h1>
+        <p className="mt-1 text-sm text-on-surface-variant">
+          Switching from{' '}
+          <span className="font-medium text-on-surface">{currentConfig.displayName}</span> to{' '}
+          <span className="font-medium text-on-surface">{targetConfig.displayName}</span>
+        </p>
+      </div>
+
+      {/* Pricing summary */}
+      <div
+        data-testid="pricing-summary"
+        className="rounded-xl border border-outline-variant/20 bg-surface-container-lowest p-6 mb-6"
+      >
+        <div className="flex items-baseline justify-between mb-4">
+          <span className="text-sm font-medium text-on-surface-variant">New plan</span>
+          <span className="text-2xl font-bold font-headline text-on-surface">{priceDisplay}</span>
+        </div>
+
+        {upgrade && (
+          <p
+            data-testid="proration-note"
+            className="text-xs text-on-surface-variant bg-surface-container-low rounded-lg px-4 py-3"
+          >
+            You will be charged a prorated amount for the remainder of the current billing cycle,
+            then <strong>{priceDisplay}</strong> on each subsequent renewal date.
+          </p>
+        )}
+      </div>
+
+      {/* Feature highlights for target tier */}
+      <div className="rounded-xl border border-outline-variant/20 bg-surface-container-lowest overflow-hidden mb-8">
+        <table className="w-full">
+          <thead>
+            <tr className="border-b border-outline-variant/20 bg-surface-container-low">
+              <th className="text-left px-5 py-3 text-xs font-semibold text-on-surface-variant uppercase tracking-wide">
+                Feature
+              </th>
+              <th className="px-4 py-3 text-center text-xs font-semibold text-on-surface-variant uppercase tracking-wide">
+                {currentConfig.displayName}
+              </th>
+              <th className="px-4 py-3 text-center text-xs font-semibold text-surface-tint uppercase tracking-wide">
+                {targetConfig.displayName}
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {MATRIX_FEATURES.map((row, i) => (
+              <tr
+                key={row.label}
+                className={`border-b border-outline-variant/10 last:border-0 ${i % 2 !== 0 ? 'bg-surface-container-low/30' : ''}`}
+              >
+                <td className="px-5 py-3 text-sm text-on-surface-variant">{row.label}</td>
+                <td className="px-4 py-3 text-center">
+                  <MatrixCell value={row[currentTier]} />
+                </td>
+                <td className="px-4 py-3 text-center">
+                  <MatrixCell value={row[targetTier]} />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Error */}
+      {error && (
+        <p
+          data-testid="error-message"
+          role="alert"
+          className="mb-4 rounded-lg bg-error-container px-4 py-3 text-sm text-on-error-container"
+        >
+          {error}
+        </p>
+      )}
+
+      {/* Actions */}
+      <div className="flex flex-col sm:flex-row gap-3">
+        <button
+          type="button"
+          data-testid="confirm-button"
+          onClick={onConfirm}
+          disabled={loading}
+          className="flex-1 rounded-lg bg-surface-tint px-5 py-3 text-sm font-semibold text-on-primary hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-surface-tint focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-200"
+        >
+          {loading ? 'Redirecting…' : `Confirm ${upgrade ? 'upgrade' : 'change'}`}
+        </button>
+        <Link
+          href="/app/subscription"
+          data-testid="cancel-link"
+          className="flex-1 rounded-lg border border-outline-variant/40 px-5 py-3 text-sm font-semibold text-on-surface text-center hover:bg-surface-container-low focus:outline-none focus:ring-2 focus:ring-surface-tint focus:ring-offset-2 transition-all duration-200"
+        >
+          Cancel
+        </Link>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary

This PR resolves four issues across the CRAFT platform, adding subscription UI pages, an upgrade flow, and two new test suites.

---

## Changes

### feat: add subscription comparison page (Closes #224)

- **New component** `apps/frontend/src/components/app/SubscriptionComparison.tsx`
  - Side-by-side tier cards (Free / Pro / Enterprise) with price, current-plan badge, and upgrade/downgrade CTAs
  - Feature comparison table reusing `MATRIX_FEATURES` / `MatrixCell` from the existing `FeatureMatrix` component
  - Highlights the authenticated user's active tier
- **New page** `apps/frontend/src/app/app/subscription/page.tsx`
  - Route `/app/subscription` — fetches current tier from `GET /api/payments/subscription`, falls back to `free`
  - Wrapped in `AppShell` with breadcrumbs
- **Tests** `SubscriptionComparison.test.tsx` — 8 tests covering tier cards, current-plan badge, CTA links, price display, and feature table rows

### feat: add subscription upgrade flow (Closes #225)

- **New component** `apps/frontend/src/components/app/UpgradeFlow.tsx`
  - Confirmation screen showing target tier price, proration note (upgrades only, not downgrades), feature comparison table (current vs target), confirm/cancel actions
  - Confirm button with loading/disabled state and inline error display
- **New page** `apps/frontend/src/app/app/subscription/upgrade/[tier]/page.tsx`
  - Route `/app/subscription/upgrade/[tier]` — validates tier param, fetches current tier, POSTs to `/api/payments/checkout`, redirects to Stripe URL
  - Edge cases: invalid tier param and same-tier both redirect to `/app/subscription` via `router.replace`
- **Tests** `UpgradeFlow.test.tsx` — 11 tests covering rendering, proration note presence/absence, loading state, error display, CTA hrefs

### test(errors): implement comprehensive error handling tests (Closes #338)

- **New test file** `apps/backend/tests/errors/error-handling.test.ts` — 82 tests
  - Error guidance library: all 18 domain:code combinations verified for title, message, retryable flag, steps, links, and no stack traces in messages
  - Structured logger: correlationId in every entry, ISO timestamp, stack on Error, no correlationId leakage into metadata
  - `withLogging` middleware: 500 on unhandled throw, correlationId in body + header, generic message (no internal details leaked)
  - `withAuth` / `withDeploymentAuth` / `withDomainTierCheck`: 401/403 paths, correlationId header, no data leakage, upgrade prompt includes URL
  - `AuthService`: error result (not throw) on bad credentials/profile failure, user-friendly message, password not echoed
  - `HealthMonitorService`: missing URL, fetch throw, non-2xx, downtime analytics recorded, graceful empty-array on null/empty deployments

### test(websocket): add tests for real-time WebSocket features (Closes #339)

- **New utility** `apps/backend/src/lib/realtime/realtime-status-poller.ts`
  - Wraps Supabase Realtime channels (WebSocket transport) for deployment status updates
  - Connection lifecycle, ownership-based auth, message fan-out with sequence numbers, exponential backoff reconnection
- **New test file** `apps/backend/tests/websocket/realtime.test.ts` — 28 tests
  - Connection lifecycle (6), Authentication (4), Message delivery and ordering (6), Reconnection with exponential backoff (8), Concurrent connections (4)

---

## Test results

| Suite | Tests | Result |
|---|---|---|
| `SubscriptionComparison.test.tsx` | 8 | all pass |
| `UpgradeFlow.test.tsx` | 11 | all pass |
| `error-handling.test.ts` | 82 | all pass |
| `realtime.test.ts` | 28 | all pass |

Closes #224
Closes #225
Closes #338
Closes #339