### PR TITLE
feat: add generation syntax validation hook (issue-067)

### DIFF
--- a/apps/backend/src/services/deployment-pipeline.service.test.ts
+++ b/apps/backend/src/services/deployment-pipeline.service.test.ts
@@ -98,6 +98,16 @@ function makeGeneratorMock(success = true) {
     };
 }
 
+function makeSyntaxValidatorMock(valid = true) {
+    return {
+        validate: vi.fn().mockReturnValue(
+            valid
+                ? { valid: true, errors: [] }
+                : { valid: false, errors: [{ file: 'src/index.ts', message: "'}' expected", line: 1 }] },
+        ),
+    };
+}
+
 function makeGithubMock(fail = false) {
     return {
         createRepository: fail
@@ -589,5 +599,178 @@ describe('DeploymentPipelineService — logging integration (#101)', () => {
             expect(log).toHaveProperty('created_at');
             expect(typeof log.created_at).toBe('string');
         }
+    });
+});
+
+// ── Issue #067 — Syntax validation hook ──────────────────────────────────────
+//
+// Verifies that the pipeline runs SyntaxValidator on every generated file
+// between code generation and GitHub repo creation, surfaces errors with
+// file references, and marks the deployment failed at the 'validating' stage.
+
+describe('DeploymentPipelineService — syntax validation hook (#067)', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockInsert.mockResolvedValue({ error: null });
+        mockUpdate.mockReturnValue({ eq: vi.fn().mockResolvedValue({ error: null }) });
+    });
+
+    it('proceeds past validation when all generated files are syntactically valid', async () => {
+        const svc = new DeploymentPipelineService(
+            makeGeneratorMock(),
+            makeGithubMock(),
+            makeGithubPushMock(),
+            makeVercelMock(),
+            makeSyntaxValidatorMock(true),
+        );
+
+        const result = await svc.deploy(request);
+
+        expect(result.success).toBe(true);
+        expect(result.deploymentUrl).toBe('https://craft-my-dex-app.vercel.app');
+    });
+
+    it('fails at validating stage when a generated file has a syntax error', async () => {
+        const svc = new DeploymentPipelineService(
+            makeGeneratorMock(),
+            makeGithubMock(),
+            makeGithubPushMock(),
+            makeVercelMock(),
+            makeSyntaxValidatorMock(false),
+        );
+
+        const result = await svc.deploy(request);
+
+        expect(result.success).toBe(false);
+        expect(result.failedStage).toBe('validating');
+    });
+
+    it('includes the file path in the error message when validation fails', async () => {
+        const svc = new DeploymentPipelineService(
+            makeGeneratorMock(),
+            makeGithubMock(),
+            makeGithubPushMock(),
+            makeVercelMock(),
+            makeSyntaxValidatorMock(false),
+        );
+
+        const result = await svc.deploy(request);
+
+        expect(result.errorMessage).toContain('src/index.ts');
+    });
+
+    it('does not create a GitHub repo when validation fails', async () => {
+        const githubMock = makeGithubMock();
+        const svc = new DeploymentPipelineService(
+            makeGeneratorMock(),
+            githubMock,
+            makeGithubPushMock(),
+            makeVercelMock(),
+            makeSyntaxValidatorMock(false),
+        );
+
+        await svc.deploy(request);
+
+        expect(githubMock.createRepository).not.toHaveBeenCalled();
+    });
+
+    it('calls validate once per generated file', async () => {
+        const validatorMock = makeSyntaxValidatorMock(true);
+        const svc = new DeploymentPipelineService(
+            makeGeneratorMock(),
+            makeGithubMock(),
+            makeGithubPushMock(),
+            makeVercelMock(),
+            validatorMock,
+        );
+
+        await svc.deploy(request);
+
+        // makeGeneratorMock returns 1 file
+        expect(validatorMock.validate).toHaveBeenCalledTimes(1);
+        expect(validatorMock.validate).toHaveBeenCalledWith({ path: 'src/index.ts', content: 'export {}', type: 'code' });
+    });
+
+    it('persists validating status before running validation', async () => {
+        const svc = new DeploymentPipelineService(
+            makeGeneratorMock(),
+            makeGithubMock(),
+            makeGithubPushMock(),
+            makeVercelMock(),
+            makeSyntaxValidatorMock(true),
+        );
+
+        await svc.deploy(request);
+
+        const statusUpdates = mockUpdate.mock.calls
+            .map((call: any[]) => call[0])
+            .filter((p: any) => p.status)
+            .map((p: any) => p.status);
+
+        expect(statusUpdates).toContain('validating');
+    });
+
+    it('writes a validating log entry on success', async () => {
+        const svc = new DeploymentPipelineService(
+            makeGeneratorMock(),
+            makeGithubMock(),
+            makeGithubPushMock(),
+            makeVercelMock(),
+            makeSyntaxValidatorMock(true),
+        );
+
+        await svc.deploy(request);
+
+        const logs = mockInsert.mock.calls
+            .map((call: any[]) => call[0])
+            .filter((p: any) => p.stage === 'validating');
+
+        expect(logs.length).toBeGreaterThan(0);
+    });
+
+    it('writes an error-level log at validating stage when validation fails', async () => {
+        const svc = new DeploymentPipelineService(
+            makeGeneratorMock(),
+            makeGithubMock(),
+            makeGithubPushMock(),
+            makeVercelMock(),
+            makeSyntaxValidatorMock(false),
+        );
+
+        await svc.deploy(request);
+
+        const errorLog = mockInsert.mock.calls
+            .map((call: any[]) => call[0])
+            .find((p: any) => p.stage === 'validating' && p.level === 'error');
+
+        expect(errorLog).toBeDefined();
+        expect(errorLog.message).toContain('Syntax validation failed');
+    });
+
+    it('validating stage appears between generating and creating_repo in the status sequence', async () => {
+        const svc = new DeploymentPipelineService(
+            makeGeneratorMock(),
+            makeGithubMock(),
+            makeGithubPushMock(),
+            makeVercelMock(),
+            makeSyntaxValidatorMock(true),
+        );
+
+        await svc.deploy(request);
+
+        const statusUpdates = mockUpdate.mock.calls
+            .map((call: any[]) => call[0])
+            .filter((p: any) => p.status)
+            .map((p: any) => p.status);
+
+        const genIdx = statusUpdates.indexOf('generating');
+        const valIdx = statusUpdates.indexOf('validating');
+        const repoIdx = statusUpdates.indexOf('creating_repo');
+
+        expect(genIdx).not.toBe(-1);
+        expect(valIdx).not.toBe(-1);
+        expect(repoIdx).not.toBe(-1);
+        expect(genIdx).toBeLessThan(valIdx);
+        expect(valIdx).toBeLessThan(repoIdx);
     });
 });

--- a/apps/backend/src/services/deployment-pipeline.service.ts
+++ b/apps/backend/src/services/deployment-pipeline.service.ts
@@ -48,6 +48,7 @@ import { vercelService, type VercelService } from './vercel.service';
 import { buildVercelEnvVars } from '@/lib/env/env-template-generator';
 import { mapCategoryToFamily } from './template-generator.service';
 import type { TemplateFamilyId } from './code-generator.service';
+import { syntaxValidator, type SyntaxValidator } from './syntax-validator';
 
 // ── Request / result types ────────────────────────────────────────────────────
 
@@ -86,6 +87,7 @@ export class DeploymentPipelineService {
         private readonly _githubService: Pick<GitHubService, 'createRepository'> = githubService,
         private readonly _githubPushService: Pick<GitHubPushService, 'pushGeneratedCode'> = githubPushService,
         private readonly _vercelService: Pick<VercelService, 'createProject' | 'triggerDeployment'> = vercelService,
+        private readonly _syntaxValidator: Pick<SyntaxValidator, 'validate'> = syntaxValidator,
     ) {}
 
     /**
@@ -144,6 +146,35 @@ export class DeploymentPipelineService {
             deploymentId,
             'generating',
             `Generated ${generationResult.generatedFiles.length} files`,
+            'info',
+            { correlationId, fileCount: generationResult.generatedFiles.length },
+        );
+
+        // ── Step 2b: Validate syntax of generated files ───────────────────────
+        await this.setStatus(deploymentId, 'validating');
+        await this.log(deploymentId, 'validating', 'Validating generated file syntax', 'info', { correlationId });
+
+        const syntaxErrors: Array<{ file: string; message: string; line?: number }> = [];
+        for (const file of generationResult.generatedFiles) {
+            const validation = this._syntaxValidator.validate(file);
+            if (!validation.valid) {
+                for (const err of validation.errors) {
+                    syntaxErrors.push(err);
+                }
+            }
+        }
+
+        if (syntaxErrors.length > 0) {
+            const summary = syntaxErrors
+                .map((e) => `${e.file}: ${e.message}`)
+                .join('; ');
+            return this.fail(deploymentId, 'validating', `Syntax validation failed: ${summary}`, { correlationId, errorCount: syntaxErrors.length });
+        }
+
+        await this.log(
+            deploymentId,
+            'validating',
+            `Syntax validation passed for ${generationResult.generatedFiles.length} files`,
             'info',
             { correlationId, fileCount: generationResult.generatedFiles.length },
         );
@@ -389,4 +420,10 @@ export class DeploymentPipelineService {
     }
 }
 
-export const deploymentPipelineService = new DeploymentPipelineService();
+export const deploymentPipelineService = new DeploymentPipelineService(
+    templateGeneratorService,
+    githubService,
+    githubPushService,
+    vercelService,
+    syntaxValidator,
+);

--- a/packages/types/src/deployment.ts
+++ b/packages/types/src/deployment.ts
@@ -3,6 +3,7 @@ import { CustomizationConfig } from './customization';
 export type DeploymentStatusType =
     | 'pending'
     | 'generating'
+    | 'validating'
     | 'creating_repo'
     | 'pushing_code'
     | 'deploying'


### PR DESCRIPTION
- Add 'validating' to DeploymentStatusType between generating and creating_repo
- Inject SyntaxValidator into DeploymentPipelineService constructor
- Add Step 2b: validate each generated file before GitHub/Vercel handoff; surface errors with file references and fail at 'validating' stage
- Add 9 tests covering: pass-through, failure, file-reference in error message, GitHub not called on failure, validate-per-file count, status persistence, log entries, error-level log, and stage ordering

SyntaxValidator (TypeScript compiler API + JSON.parse) was already implemented and integrated into TemplateGeneratorService; this PR adds the explicit pipeline hook so the deployment status machine reflects the validation stage.

closes #67 