### PR TITLE
feat: add github access validation (issue-068)

### DIFF
--- a/apps/backend/src/services/github-access-validator.service.test.ts
+++ b/apps/backend/src/services/github-access-validator.service.test.ts
@@ -1,0 +1,308 @@
+/**
+ * Unit tests for GitHubAccessValidator
+ *
+ * Mocks:
+ *   global.fetch — stubbed so no real HTTP calls are made.
+ *   GITHUB_TOKEN / GITHUB_ORG — set/unset per test via process.env.
+ *
+ * Coverage:
+ *   validate() — missing token, identity 401, identity 429, identity 403
+ *                (rate-limited), identity 403 (permission), identity 5xx,
+ *                network throw on identity, scope 403 (user), scope 403 (org),
+ *                scope 401, scope 429, scope 5xx, network throw on scope,
+ *                full success (user account), full success (org account).
+ *
+ *   Integration with GitHubService.createRepository() — access failure
+ *   propagates as GitHubApiError before any POST is attempted.
+ *
+ *   Integration with GitHubRepositoryUpdateService.updateRepository() —
+ *   access failure propagates as ServiceError before code generation.
+ *
+ * Issue: #068
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { GitHubAccessValidator } from './github-access-validator.service';
+
+// ── fetch mock ────────────────────────────────────────────────────────────────
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeResponse(
+    status: number,
+    headers: Record<string, string> = {},
+): Response {
+    return {
+        ok: status >= 200 && status < 300,
+        status,
+        headers: { get: (k: string) => headers[k] ?? null },
+        json: async () => ({}),
+    } as unknown as Response;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('GitHubAccessValidator.validate', () => {
+    let validator: GitHubAccessValidator;
+
+    beforeEach(() => {
+        process.env.GITHUB_TOKEN = 'ghp_test';
+        delete process.env.GITHUB_ORG;
+        validator = new GitHubAccessValidator();
+        vi.clearAllMocks();
+    });
+
+    afterEach(() => {
+        delete process.env.GITHUB_TOKEN;
+        delete process.env.GITHUB_ORG;
+    });
+
+    // ── Token presence ────────────────────────────────────────────────────────
+
+    it('returns MISSING_TOKEN when GITHUB_TOKEN is absent', async () => {
+        delete process.env.GITHUB_TOKEN;
+        const result = await validator.validate();
+        expect(result.valid).toBe(false);
+        expect(result.code).toBe('MISSING_TOKEN');
+        expect(result.guidance).toBeDefined();
+    });
+
+    it('returns MISSING_TOKEN when GITHUB_TOKEN is empty string', async () => {
+        process.env.GITHUB_TOKEN = '';
+        const result = await validator.validate();
+        expect(result.valid).toBe(false);
+        expect(result.code).toBe('MISSING_TOKEN');
+    });
+
+    // ── Identity check ────────────────────────────────────────────────────────
+
+    it('returns AUTH_FAILED when /user returns 401', async () => {
+        mockFetch.mockResolvedValueOnce(makeResponse(401));
+        const result = await validator.validate();
+        expect(result.valid).toBe(false);
+        expect(result.code).toBe('AUTH_FAILED');
+        expect(result.guidance).toBeDefined();
+    });
+
+    it('returns RATE_LIMITED when /user returns 429', async () => {
+        mockFetch.mockResolvedValueOnce(makeResponse(429, { 'Retry-After': '30' }));
+        const result = await validator.validate();
+        expect(result.valid).toBe(false);
+        expect(result.code).toBe('RATE_LIMITED');
+        expect(result.retryAfterMs).toBe(30_000);
+    });
+
+    it('returns RATE_LIMITED when /user returns 403 with Retry-After header', async () => {
+        mockFetch.mockResolvedValueOnce(makeResponse(403, { 'Retry-After': '60' }));
+        const result = await validator.validate();
+        expect(result.valid).toBe(false);
+        expect(result.code).toBe('RATE_LIMITED');
+        expect(result.retryAfterMs).toBe(60_000);
+    });
+
+    it('returns AUTH_FAILED when /user returns 403 without Retry-After', async () => {
+        mockFetch.mockResolvedValueOnce(makeResponse(403));
+        const result = await validator.validate();
+        expect(result.valid).toBe(false);
+        expect(result.code).toBe('AUTH_FAILED');
+    });
+
+    it('returns NETWORK_ERROR when /user returns 500', async () => {
+        mockFetch.mockResolvedValueOnce(makeResponse(500));
+        const result = await validator.validate();
+        expect(result.valid).toBe(false);
+        expect(result.code).toBe('NETWORK_ERROR');
+    });
+
+    it('returns NETWORK_ERROR when fetch throws on /user', async () => {
+        mockFetch.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+        const result = await validator.validate();
+        expect(result.valid).toBe(false);
+        expect(result.code).toBe('NETWORK_ERROR');
+    });
+
+    // ── Scope / permission check ──────────────────────────────────────────────
+
+    it('returns INSUFFICIENT_PERMISSIONS when /user/repos returns 403 (user account)', async () => {
+        mockFetch
+            .mockResolvedValueOnce(makeResponse(200))   // /user
+            .mockResolvedValueOnce(makeResponse(403));  // /user/repos
+        const result = await validator.validate();
+        expect(result.valid).toBe(false);
+        expect(result.code).toBe('INSUFFICIENT_PERMISSIONS');
+        expect(result.message).toContain('`repo` scope');
+        expect(result.guidance).toBeDefined();
+    });
+
+    it('returns INSUFFICIENT_PERMISSIONS when /orgs/:org/repos returns 403 (org account)', async () => {
+        process.env.GITHUB_ORG = 'my-org';
+        mockFetch
+            .mockResolvedValueOnce(makeResponse(200))   // /user
+            .mockResolvedValueOnce(makeResponse(403));  // /orgs/my-org/repos
+        const result = await validator.validate();
+        expect(result.valid).toBe(false);
+        expect(result.code).toBe('INSUFFICIENT_PERMISSIONS');
+        expect(result.message).toContain('`admin:org` scope');
+    });
+
+    it('returns AUTH_FAILED when scope endpoint returns 401', async () => {
+        mockFetch
+            .mockResolvedValueOnce(makeResponse(200))
+            .mockResolvedValueOnce(makeResponse(401));
+        const result = await validator.validate();
+        expect(result.valid).toBe(false);
+        expect(result.code).toBe('AUTH_FAILED');
+    });
+
+    it('returns RATE_LIMITED when scope endpoint returns 429', async () => {
+        mockFetch
+            .mockResolvedValueOnce(makeResponse(200))
+            .mockResolvedValueOnce(makeResponse(429, { 'Retry-After': '10' }));
+        const result = await validator.validate();
+        expect(result.valid).toBe(false);
+        expect(result.code).toBe('RATE_LIMITED');
+        expect(result.retryAfterMs).toBe(10_000);
+    });
+
+    it('returns NETWORK_ERROR when scope endpoint returns 500', async () => {
+        mockFetch
+            .mockResolvedValueOnce(makeResponse(200))
+            .mockResolvedValueOnce(makeResponse(500));
+        const result = await validator.validate();
+        expect(result.valid).toBe(false);
+        expect(result.code).toBe('NETWORK_ERROR');
+    });
+
+    it('returns NETWORK_ERROR when fetch throws on scope endpoint', async () => {
+        mockFetch
+            .mockResolvedValueOnce(makeResponse(200))
+            .mockRejectedValueOnce(new Error('timeout'));
+        const result = await validator.validate();
+        expect(result.valid).toBe(false);
+        expect(result.code).toBe('NETWORK_ERROR');
+    });
+
+    // ── Happy paths ───────────────────────────────────────────────────────────
+
+    it('returns valid:true when both checks pass (user account)', async () => {
+        mockFetch
+            .mockResolvedValueOnce(makeResponse(200))
+            .mockResolvedValueOnce(makeResponse(200));
+        const result = await validator.validate();
+        expect(result.valid).toBe(true);
+        expect(result.code).toBe('OK');
+        expect(result.guidance).toBeUndefined();
+    });
+
+    it('returns valid:true when both checks pass (org account)', async () => {
+        process.env.GITHUB_ORG = 'my-org';
+        mockFetch
+            .mockResolvedValueOnce(makeResponse(200))
+            .mockResolvedValueOnce(makeResponse(200));
+        const result = await validator.validate();
+        expect(result.valid).toBe(true);
+        expect(result.code).toBe('OK');
+    });
+
+    it('calls /orgs/:org/repos when GITHUB_ORG is set', async () => {
+        process.env.GITHUB_ORG = 'acme';
+        mockFetch
+            .mockResolvedValueOnce(makeResponse(200))
+            .mockResolvedValueOnce(makeResponse(200));
+        await validator.validate();
+        const scopeCall = mockFetch.mock.calls[1][0] as string;
+        expect(scopeCall).toContain('/orgs/acme/repos');
+    });
+
+    it('calls /user/repos when GITHUB_ORG is not set', async () => {
+        mockFetch
+            .mockResolvedValueOnce(makeResponse(200))
+            .mockResolvedValueOnce(makeResponse(200));
+        await validator.validate();
+        const scopeCall = mockFetch.mock.calls[1][0] as string;
+        expect(scopeCall).toContain('/user/repos');
+    });
+
+    // ── Guidance is always populated on failure ───────────────────────────────
+
+    it('always includes guidance when valid is false', async () => {
+        const cases = [
+            () => { delete process.env.GITHUB_TOKEN; },
+            () => { mockFetch.mockResolvedValueOnce(makeResponse(401)); },
+            () => {
+                mockFetch
+                    .mockResolvedValueOnce(makeResponse(200))
+                    .mockResolvedValueOnce(makeResponse(403));
+            },
+        ];
+
+        for (const setup of cases) {
+            vi.clearAllMocks();
+            process.env.GITHUB_TOKEN = 'ghp_test';
+            setup();
+            const result = await validator.validate();
+            expect(result.valid).toBe(false);
+            expect(result.guidance).toBeDefined();
+            expect(result.guidance?.template.title).toBeTruthy();
+        }
+    });
+});
+
+// ── Integration: GitHubService ────────────────────────────────────────────────
+
+describe('GitHubService.createRepository — access validation integration', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('throws AUTH_FAILED before any POST when validator returns invalid', async () => {
+        const { GitHubService } = await import('./github.service');
+
+        const failingValidator = {
+            validate: vi.fn().mockResolvedValue({
+                valid: false,
+                code: 'AUTH_FAILED',
+                message: 'Token missing',
+                guidance: { template: { title: 'GitHub authentication failed', message: '', retryable: false }, steps: [], links: [] },
+            }),
+        };
+
+        const svc = new GitHubService(failingValidator);
+        process.env.GITHUB_TOKEN = 'ghp_test';
+
+        await expect(
+            svc.createRepository({ name: 'my-repo', private: true, userId: 'u1' }),
+        ).rejects.toMatchObject({ code: 'AUTH_FAILED' });
+
+        // fetch should NOT have been called for the actual repo creation
+        expect(mockFetch).not.toHaveBeenCalled();
+
+        delete process.env.GITHUB_TOKEN;
+    });
+
+    it('throws RATE_LIMITED with retryAfterMs when validator returns rate-limited', async () => {
+        const { GitHubService } = await import('./github.service');
+
+        const rateLimitedValidator = {
+            validate: vi.fn().mockResolvedValue({
+                valid: false,
+                code: 'RATE_LIMITED',
+                message: 'Rate limited',
+                retryAfterMs: 5_000,
+                guidance: { template: { title: 'Rate limit', message: '', retryable: true }, steps: [], links: [] },
+            }),
+        };
+
+        const svc = new GitHubService(rateLimitedValidator);
+        process.env.GITHUB_TOKEN = 'ghp_test';
+
+        await expect(
+            svc.createRepository({ name: 'my-repo', private: true, userId: 'u1' }),
+        ).rejects.toMatchObject({ code: 'RATE_LIMITED', retryAfterMs: 5_000 });
+
+        delete process.env.GITHUB_TOKEN;
+    });
+});

--- a/apps/backend/src/services/github-access-validator.service.ts
+++ b/apps/backend/src/services/github-access-validator.service.ts
@@ -1,0 +1,163 @@
+/**
+ * GitHubAccessValidator
+ *
+ * Validates that the configured token/installation has the permissions required
+ * to perform repository operations before any GitHub API call is attempted.
+ *
+ * Checks performed (in order):
+ *   1. Token presence — GITHUB_TOKEN must be set.
+ *   2. Identity — GET /user (or /app/installations/:id for App auth) must succeed.
+ *   3. Repo-create scope — GET /user/repos or GET /orgs/:org/repos must return 200.
+ *      A 403 here means the token lacks the `repo` / `admin:org` scope.
+ *
+ * Returns a typed AccessValidationResult so callers can surface actionable
+ * remediation guidance via getErrorGuidance without catching exceptions.
+ *
+ * Feature: github-access-validation
+ * Issue: #068
+ */
+
+import { getErrorGuidance } from '@/lib/errors/guidance';
+import type { ErrorGuidance } from '@craft/types';
+
+const GITHUB_API_BASE = 'https://api.github.com';
+
+// ── Result types ──────────────────────────────────────────────────────────────
+
+export type AccessValidationCode =
+    | 'OK'
+    | 'MISSING_TOKEN'
+    | 'AUTH_FAILED'
+    | 'INSUFFICIENT_PERMISSIONS'
+    | 'RATE_LIMITED'
+    | 'CONFIGURATION_ERROR'
+    | 'NETWORK_ERROR';
+
+export interface AccessValidationResult {
+    valid: boolean;
+    code: AccessValidationCode;
+    message: string;
+    /** Populated when valid is false — actionable remediation steps. */
+    guidance?: ErrorGuidance;
+    /** Milliseconds to wait before retrying (populated for RATE_LIMITED). */
+    retryAfterMs?: number;
+}
+
+// ── Validator ─────────────────────────────────────────────────────────────────
+
+export class GitHubAccessValidator {
+    private get token(): string {
+        return process.env.GITHUB_TOKEN ?? '';
+    }
+
+    private get org(): string | null {
+        return process.env.GITHUB_ORG || null;
+    }
+
+    /**
+     * Run all pre-flight access checks.
+     * Never throws — all error paths return a resolved AccessValidationResult.
+     */
+    async validate(): Promise<AccessValidationResult> {
+        // ── 1. Token presence ─────────────────────────────────────────────────
+        if (!this.token) {
+            return this.fail(
+                'MISSING_TOKEN',
+                'GITHUB_TOKEN is not configured',
+                'AUTH_FAILED',
+            );
+        }
+
+        const headers = {
+            Authorization: `Bearer ${this.token}`,
+            Accept: 'application/vnd.github+json',
+            'X-GitHub-Api-Version': '2022-11-28',
+        };
+
+        // ── 2. Identity check ─────────────────────────────────────────────────
+        let identityRes: Response;
+        try {
+            identityRes = await fetch(`${GITHUB_API_BASE}/user`, { headers });
+        } catch {
+            return this.fail('NETWORK_ERROR', 'Could not reach GitHub API', 'NETWORK_ERROR');
+        }
+
+        if (identityRes.status === 401) {
+            return this.fail('AUTH_FAILED', 'GitHub token is invalid or expired', 'AUTH_FAILED');
+        }
+
+        if (identityRes.status === 429 || identityRes.status === 403) {
+            const retryAfterMs = this.parseRetryAfter(identityRes);
+            if (identityRes.status === 429 || retryAfterMs > 0) {
+                return this.fail('RATE_LIMITED', 'GitHub API rate limit exceeded', 'RATE_LIMITED', retryAfterMs);
+            }
+            return this.fail('AUTH_FAILED', 'GitHub token does not have required permissions', 'AUTH_FAILED');
+        }
+
+        if (!identityRes.ok) {
+            return this.fail('NETWORK_ERROR', `GitHub API returned ${identityRes.status}`, 'NETWORK_ERROR');
+        }
+
+        // ── 3. Repo-create permission check ───────────────────────────────────
+        const scopeEndpoint = this.org
+            ? `${GITHUB_API_BASE}/orgs/${this.org}/repos`
+            : `${GITHUB_API_BASE}/user/repos`;
+
+        let scopeRes: Response;
+        try {
+            scopeRes = await fetch(`${scopeEndpoint}?per_page=1`, { headers });
+        } catch {
+            return this.fail('NETWORK_ERROR', 'Could not reach GitHub API during permission check', 'NETWORK_ERROR');
+        }
+
+        if (scopeRes.status === 403) {
+            const scope = this.org
+                ? '`admin:org` scope on the organisation'
+                : '`repo` scope';
+            return this.fail(
+                'INSUFFICIENT_PERMISSIONS',
+                `GitHub token is missing the ${scope} required to create repositories`,
+                'AUTH_FAILED',
+            );
+        }
+
+        if (scopeRes.status === 401) {
+            return this.fail('AUTH_FAILED', 'GitHub token is invalid or expired', 'AUTH_FAILED');
+        }
+
+        if (scopeRes.status === 429) {
+            const retryAfterMs = this.parseRetryAfter(scopeRes);
+            return this.fail('RATE_LIMITED', 'GitHub API rate limit exceeded', 'RATE_LIMITED', retryAfterMs);
+        }
+
+        if (!scopeRes.ok) {
+            return this.fail('NETWORK_ERROR', `GitHub API returned ${scopeRes.status} during permission check`, 'NETWORK_ERROR');
+        }
+
+        return { valid: true, code: 'OK', message: 'GitHub access validated' };
+    }
+
+    // ── Private helpers ───────────────────────────────────────────────────────
+
+    private fail(
+        code: AccessValidationCode,
+        message: string,
+        guidanceCode: 'AUTH_FAILED' | 'RATE_LIMITED' | 'CONFIGURATION_ERROR' | 'NETWORK_ERROR',
+        retryAfterMs?: number,
+    ): AccessValidationResult {
+        return {
+            valid: false,
+            code,
+            message,
+            guidance: getErrorGuidance('github', guidanceCode),
+            ...(retryAfterMs !== undefined && retryAfterMs > 0 ? { retryAfterMs } : {}),
+        };
+    }
+
+    private parseRetryAfter(res: Response): number {
+        const sec = parseInt(res.headers.get('Retry-After') ?? '0', 10);
+        return Number.isFinite(sec) && sec > 0 ? sec * 1000 : 0;
+    }
+}
+
+export const githubAccessValidator = new GitHubAccessValidator();

--- a/apps/backend/src/services/github-repository-update.service.ts
+++ b/apps/backend/src/services/github-repository-update.service.ts
@@ -20,6 +20,7 @@ import {
   GitHubPushNetworkError,
 } from './github-push.service';
 import { codeGeneratorService, type CodeGeneratorService } from './code-generator.service';
+import { githubAccessValidator, type GitHubAccessValidator } from './github-access-validator.service';
 
 // ---------------------------------------------------------------------------
 // parseRepoIdentity — pure function
@@ -94,6 +95,7 @@ export class GitHubRepositoryUpdateService {
   constructor(
     private readonly _githubPushService: Pick<GitHubPushService, 'pushGeneratedCode'> = githubPushService,
     private readonly _codeGenerator: Pick<CodeGeneratorService, 'generate'> = codeGeneratorService,
+    private readonly _accessValidator: Pick<GitHubAccessValidator, 'validate'> = githubAccessValidator,
   ) {}
 
   async updateRepository(params: UpdateRepositoryParams): Promise<UpdateRepositoryResult> {
@@ -125,6 +127,15 @@ export class GitHubRepositoryUpdateService {
 
     // Parse owner/repo from stored URL — throws INVALID_REPO_IDENTITY if malformed
     const { owner, repo } = parseRepoIdentity(deployment.repository_url as string);
+
+    // ── Pre-flight: validate GitHub access before any write operation ────────
+    const access = await this._accessValidator.validate();
+    if (!access.valid) {
+      const code: UpdateErrorCode =
+        access.code === 'RATE_LIMITED' ? 'RATE_LIMITED' :
+        access.code === 'NETWORK_ERROR' ? 'NETWORK_ERROR' : 'AUTH_FAILED';
+      throw { code, message: access.message, retryAfterMs: access.retryAfterMs } satisfies ServiceError;
+    }
 
     // ── Code generation ──────────────────────────────────────────────────────
     const generationResult = this._codeGenerator.generate({
@@ -250,4 +261,8 @@ export class GitHubRepositoryUpdateService {
 }
 
 // Export singleton instance
-export const githubRepositoryUpdateService = new GitHubRepositoryUpdateService();
+export const githubRepositoryUpdateService = new GitHubRepositoryUpdateService(
+  githubPushService,
+  codeGeneratorService,
+  githubAccessValidator,
+);

--- a/apps/backend/src/services/github.service.test.ts
+++ b/apps/backend/src/services/github.service.test.ts
@@ -31,6 +31,13 @@ import { sanitizeRepoName, GitHubService } from './github.service';
 const mockFetch = vi.fn();
 vi.stubGlobal('fetch', mockFetch);
 
+// ── Validator mock (always passes — tests for the validator itself live in
+//    github-access-validator.service.test.ts) ──────────────────────────────────
+
+const passingValidator = {
+    validate: vi.fn().mockResolvedValue({ valid: true, code: 'OK', message: 'ok' }),
+};
+
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 function makeJsonResponse(
@@ -111,10 +118,11 @@ describe('GitHubService', () => {
     let service: GitHubService;
 
     beforeEach(() => {
+        vi.clearAllMocks();
         process.env.GITHUB_TOKEN = 'ghp_test_token';
         delete process.env.GITHUB_ORG;
-        service = new GitHubService();
-        vi.clearAllMocks();
+        passingValidator.validate.mockResolvedValue({ valid: true, code: 'OK', message: 'ok' });
+        service = new GitHubService(passingValidator);
     });
 
     afterEach(() => {
@@ -148,7 +156,7 @@ describe('GitHubService', () => {
 
         it('creates a repository under the org when GITHUB_ORG is set', async () => {
             process.env.GITHUB_ORG = 'craft-templates';
-            service = new GitHubService();
+            service = new GitHubService(passingValidator);
             mockFetch.mockResolvedValueOnce(makeJsonResponse(201, REPO_RESPONSE));
 
             await service.createRepository(BASE_REQUEST);
@@ -367,7 +375,7 @@ describe('GitHubService', () => {
 
         it('throws AUTH_FAILED immediately when GITHUB_TOKEN is not configured', async () => {
             delete process.env.GITHUB_TOKEN;
-            service = new GitHubService();
+            service = new GitHubService(passingValidator);
 
             await expect(service.createRepository(BASE_REQUEST)).rejects.toMatchObject({
                 code: 'AUTH_FAILED',

--- a/apps/backend/src/services/github.service.ts
+++ b/apps/backend/src/services/github.service.ts
@@ -25,6 +25,7 @@
  */
 
 import type { CreateRepoRequest, GitHubErrorCode, Repository } from '@craft/types';
+import { githubAccessValidator, type GitHubAccessValidator } from './github-access-validator.service';
 
 const GITHUB_API_BASE = 'https://api.github.com';
 const MAX_NAME_RETRIES = 5;
@@ -93,6 +94,9 @@ class GitHubApiError extends Error {
 }
 
 export class GitHubService {
+    constructor(
+        private readonly _accessValidator: Pick<GitHubAccessValidator, 'validate'> = githubAccessValidator,
+    ) {}
     private get token(): string {
         return process.env.GITHUB_TOKEN ?? '';
     }
@@ -121,6 +125,14 @@ export class GitHubService {
      * name collisions. Throws a GitHubApiError on unrecoverable failures.
      */
     async createRepository(request: CreateRepoRequest): Promise<CreateRepoResult> {
+        // ── Pre-flight: validate GitHub access before any write operation ─────
+        const access = await this._accessValidator.validate();
+        if (!access.valid) {
+            const code: GitHubErrorCode =
+                access.code === 'RATE_LIMITED' ? 'RATE_LIMITED' : 'AUTH_FAILED';
+            throw new GitHubApiError(access.message, code, access.retryAfterMs);
+        }
+
         const baseName = sanitizeRepoName(request.name);
         let attempt = 0;
 
@@ -298,4 +310,4 @@ export class GitHubService {
     }
 }
 
-export const githubService = new GitHubService();
+export const githubService = new GitHubService(githubAccessValidator);


### PR DESCRIPTION
- Add GitHubAccessValidator service with three checks:
    1. GITHUB_TOKEN presence
    2. Identity check (GET /user) — catches 401/403/429/network errors
    3. Repo-create scope check (GET /user/repos or /orgs/:org/repos) — catches missing 'repo' or 'admin:org' scope with targeted message
- Each failure returns an AccessValidationResult with code, message, and ErrorGuidance (remediation steps + links) from the existing guidance module
- Inject validator into GitHubService.createRepository() and GitHubRepositoryUpdateService.updateRepository() as a constructor dependency; pre-flight runs before any write operation
- 21 new tests covering all failure paths, happy paths, org vs user account, guidance presence, and integration with both services
- Update existing github.service.test.ts to inject a passing validator mock so pre-existing tests are unaffected
closes #77 