### PR TITLE
feat: add github rate limit

### DIFF
--- a/apps/backend/src/services/github.auth-errors.property.test.ts
+++ b/apps/backend/src/services/github.auth-errors.property.test.ts
@@ -32,6 +32,9 @@ import {
 const RETRYABLE_CODES = new Set(['RATE_LIMITED']);
 const TERMINAL_CODES = new Set(['AUTH_FAILED', 'NETWORK_ERROR', 'COLLISION', 'UNKNOWN']);
 
+/** No-op sleep — prevents real delays in tests that exercise the retry path. */
+const noSleep = () => Promise.resolve();
+
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 function makeJsonResponse(
@@ -224,14 +227,15 @@ describe('Property 18 — GitHub auth and installation error classification', ()
             fc.asyncProperty(arbRetryAfterSec, async (retryAfterSec) => {
                 const headers =
                     retryAfterSec > 0 ? { 'Retry-After': String(retryAfterSec) } : {};
-                mockFetch.mockResolvedValueOnce(
+                // Use persistent mock so all retry attempts get the same response.
+                mockFetch.mockResolvedValue(
                     makeJsonResponse(429, { message: 'rate limited' }, headers),
                 );
 
                 let thrownCode: string | undefined;
                 let retryAfterMs: number | undefined;
                 try {
-                    await service.createRepository(BASE_REPO_REQUEST);
+                    await service.createRepository(BASE_REPO_REQUEST, noSleep);
                 } catch (err: unknown) {
                     const e = err as { code?: string; retryAfterMs?: number };
                     thrownCode = e.code;
@@ -246,6 +250,8 @@ describe('Property 18 — GitHub auth and installation error classification', ()
                 if (retryAfterSec > 0) {
                     expect(retryAfterMs).toBe(retryAfterSec * 1000);
                 }
+
+                vi.clearAllMocks();
             }),
             { numRuns: 100 },
         );
@@ -258,11 +264,11 @@ describe('Property 18 — GitHub auth and installation error classification', ()
                 async ([body, retryAfterSec]) => {
                     const headers =
                         retryAfterSec > 0 ? { 'Retry-After': String(retryAfterSec) } : {};
-                    mockFetch.mockResolvedValueOnce(makeJsonResponse(403, body, headers));
+                    mockFetch.mockResolvedValue(makeJsonResponse(403, body, headers));
 
                     let thrownCode: string | undefined;
                     try {
-                        await service.createRepository(BASE_REPO_REQUEST);
+                        await service.createRepository(BASE_REPO_REQUEST, noSleep);
                     } catch (err: unknown) {
                         thrownCode = (err as { code?: string }).code;
                     }
@@ -270,6 +276,8 @@ describe('Property 18 — GitHub auth and installation error classification', ()
                     // Invariant: rate-limit 403 is always retryable
                     expect(thrownCode).toBe('RATE_LIMITED');
                     expect(RETRYABLE_CODES).toContain(thrownCode);
+
+                    vi.clearAllMocks();
                 },
             ),
             { numRuns: 100 },
@@ -290,11 +298,11 @@ describe('Property 18 — GitHub auth and installation error classification', ()
                     ),
                 ),
                 async ([status, body]) => {
-                    mockFetch.mockResolvedValueOnce(makeJsonResponse(status, body));
+                    mockFetch.mockResolvedValue(makeJsonResponse(status, body));
 
                     let thrownCode: string | undefined;
                     try {
-                        await service.createRepository(BASE_REPO_REQUEST);
+                        await service.createRepository(BASE_REPO_REQUEST, noSleep);
                     } catch (err: unknown) {
                         thrownCode = (err as { code?: string }).code;
                     }
@@ -302,6 +310,8 @@ describe('Property 18 — GitHub auth and installation error classification', ()
                     // Invariant: 5xx is always terminal NETWORK_ERROR
                     expect(thrownCode).toBe('NETWORK_ERROR');
                     expect(TERMINAL_CODES).toContain(thrownCode);
+
+                    vi.clearAllMocks();
                 },
             ),
             { numRuns: 100 },
@@ -318,11 +328,11 @@ describe('Property 18 — GitHub auth and installation error classification', ()
                     fc.stringMatching(/^[A-Za-z ]{5,30}$/),
                 ),
                 async (errorMessage) => {
-                    mockFetch.mockRejectedValueOnce(new Error(errorMessage));
+                    mockFetch.mockRejectedValue(new Error(errorMessage));
 
                     let thrownCode: string | undefined;
                     try {
-                        await service.createRepository(BASE_REPO_REQUEST);
+                        await service.createRepository(BASE_REPO_REQUEST, noSleep);
                     } catch (err: unknown) {
                         thrownCode = (err as { code?: string }).code;
                     }
@@ -330,6 +340,8 @@ describe('Property 18 — GitHub auth and installation error classification', ()
                     // Invariant: fetch throw is always terminal NETWORK_ERROR
                     expect(thrownCode).toBe('NETWORK_ERROR');
                     expect(TERMINAL_CODES).toContain(thrownCode);
+
+                    vi.clearAllMocks();
                 },
             ),
             { numRuns: 100 },
@@ -354,13 +366,14 @@ describe('Property 18 — GitHub auth and installation error classification', ()
 
         await fc.assert(
             fc.asyncProperty(scenarios, async ([status, body, headers]) => {
-                mockFetch.mockResolvedValueOnce(
+                // Use persistent mock so retry attempts all get the same response.
+                mockFetch.mockResolvedValue(
                     makeJsonResponse(status, body, headers as Record<string, string>),
                 );
 
                 let thrownCode: string | undefined;
                 try {
-                    await service.createRepository(BASE_REPO_REQUEST);
+                    await service.createRepository(BASE_REPO_REQUEST, noSleep);
                 } catch (err: unknown) {
                     thrownCode = (err as { code?: string }).code;
                 }
@@ -368,6 +381,8 @@ describe('Property 18 — GitHub auth and installation error classification', ()
                 // Invariant: every thrown code is in the known classification set
                 expect(thrownCode).toBeDefined();
                 expect(ALL_CODES).toContain(thrownCode);
+
+                vi.clearAllMocks();
             }),
             { numRuns: 100 },
         );

--- a/apps/backend/src/services/github.backoff.test.ts
+++ b/apps/backend/src/services/github.backoff.test.ts
@@ -1,0 +1,265 @@
+/**
+ * Tests for withGitHubRetry — bounded exponential backoff for GitHub API calls.
+ *
+ * Covers:
+ *   - Succeeds on first attempt (no retries)
+ *   - Retries RATE_LIMITED and recovers
+ *   - Retries NETWORK_ERROR and recovers
+ *   - Honours Retry-After header as the delay floor
+ *   - Falls back to exponential backoff when Retry-After is absent
+ *   - Exhausts retries and re-throws the last error
+ *   - Does NOT retry terminal errors (AUTH_FAILED, COLLISION, UNKNOWN)
+ *   - Logs a warning on each retry
+ *   - createRepository retries transparently and returns on recovery
+ *   - createRepository still surfaces COLLISION after name retries
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { withGitHubRetry, GitHubService } from './github.service';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const noSleep = vi.fn().mockResolvedValue(undefined);
+
+function makeError(code: string, retryAfterMs?: number) {
+    const err = new Error(`GitHub error: ${code}`) as Error & {
+        code: string;
+        retryAfterMs?: number;
+    };
+    err.code = code;
+    if (retryAfterMs !== undefined) err.retryAfterMs = retryAfterMs;
+    return err;
+}
+
+function makeJsonResponse(
+    status: number,
+    body: unknown,
+    headers: Record<string, string> = {},
+) {
+    return {
+        ok: status >= 200 && status < 300,
+        status,
+        headers: { get: (k: string) => headers[k] ?? null },
+        json: async () => body,
+    };
+}
+
+const REPO_RESPONSE = {
+    id: 1,
+    html_url: 'https://github.com/org/repo',
+    clone_url: 'https://github.com/org/repo.git',
+    ssh_url: 'git@github.com:org/repo.git',
+    full_name: 'org/repo',
+    default_branch: 'main',
+    private: true,
+};
+
+// ── withGitHubRetry ───────────────────────────────────────────────────────────
+
+describe('withGitHubRetry', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns immediately when fn succeeds on the first attempt', async () => {
+        const fn = vi.fn().mockResolvedValue('ok');
+        const result = await withGitHubRetry(fn, noSleep);
+        expect(result).toBe('ok');
+        expect(fn).toHaveBeenCalledTimes(1);
+        expect(noSleep).not.toHaveBeenCalled();
+    });
+
+    it('retries on RATE_LIMITED and returns on recovery', async () => {
+        const fn = vi
+            .fn()
+            .mockRejectedValueOnce(makeError('RATE_LIMITED'))
+            .mockResolvedValue('recovered');
+
+        const result = await withGitHubRetry(fn, noSleep);
+        expect(result).toBe('recovered');
+        expect(fn).toHaveBeenCalledTimes(2);
+        expect(noSleep).toHaveBeenCalledTimes(1);
+    });
+
+    it('retries on NETWORK_ERROR and returns on recovery', async () => {
+        const fn = vi
+            .fn()
+            .mockRejectedValueOnce(makeError('NETWORK_ERROR'))
+            .mockResolvedValue('recovered');
+
+        const result = await withGitHubRetry(fn, noSleep);
+        expect(result).toBe('recovered');
+        expect(fn).toHaveBeenCalledTimes(2);
+    });
+
+    it('honours Retry-After as the sleep delay', async () => {
+        const delays: number[] = [];
+        const sleep = (ms: number) => { delays.push(ms); return Promise.resolve(); };
+
+        const fn = vi
+            .fn()
+            .mockRejectedValueOnce(makeError('RATE_LIMITED', 5_000))
+            .mockResolvedValue('ok');
+
+        await withGitHubRetry(fn, sleep);
+        expect(delays).toHaveLength(1);
+        expect(delays[0]).toBe(5_000);
+    });
+
+    it('uses exponential backoff when Retry-After is absent', async () => {
+        const delays: number[] = [];
+        const sleep = (ms: number) => { delays.push(ms); return Promise.resolve(); };
+
+        const fn = vi
+            .fn()
+            .mockRejectedValueOnce(makeError('RATE_LIMITED'))
+            .mockRejectedValueOnce(makeError('RATE_LIMITED'))
+            .mockResolvedValue('ok');
+
+        await withGitHubRetry(fn, sleep);
+        expect(delays).toHaveLength(2);
+        // Both delays must be non-negative and within the 32 s cap
+        for (const d of delays) {
+            expect(d).toBeGreaterThanOrEqual(0);
+            expect(d).toBeLessThanOrEqual(32_000);
+        }
+    });
+
+    it('exhausts retries and re-throws the last error', async () => {
+        const lastErr = makeError('RATE_LIMITED', 1_000);
+        const fn = vi.fn().mockRejectedValue(lastErr);
+
+        await expect(withGitHubRetry(fn, noSleep)).rejects.toBe(lastErr);
+        // 1 initial + 3 retries = 4 total calls
+        expect(fn).toHaveBeenCalledTimes(4);
+    });
+
+    it('does NOT retry AUTH_FAILED — throws immediately', async () => {
+        const fn = vi.fn().mockRejectedValue(makeError('AUTH_FAILED'));
+
+        await expect(withGitHubRetry(fn, noSleep)).rejects.toMatchObject({ code: 'AUTH_FAILED' });
+        expect(fn).toHaveBeenCalledTimes(1);
+        expect(noSleep).not.toHaveBeenCalled();
+    });
+
+    it('does NOT retry COLLISION — throws immediately', async () => {
+        const fn = vi.fn().mockRejectedValue(makeError('COLLISION'));
+
+        await expect(withGitHubRetry(fn, noSleep)).rejects.toMatchObject({ code: 'COLLISION' });
+        expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT retry UNKNOWN — throws immediately', async () => {
+        const fn = vi.fn().mockRejectedValue(makeError('UNKNOWN'));
+
+        await expect(withGitHubRetry(fn, noSleep)).rejects.toMatchObject({ code: 'UNKNOWN' });
+        expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    it('logs a console.warn on each retry with attempt context', async () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+        const fn = vi
+            .fn()
+            .mockRejectedValueOnce(makeError('RATE_LIMITED'))
+            .mockRejectedValueOnce(makeError('NETWORK_ERROR'))
+            .mockResolvedValue('ok');
+
+        await withGitHubRetry(fn, noSleep);
+
+        expect(warnSpy).toHaveBeenCalledTimes(2);
+        expect(warnSpy.mock.calls[0][0]).toMatch(/RATE_LIMITED/);
+        expect(warnSpy.mock.calls[0][0]).toMatch(/attempt 1\/3/);
+        expect(warnSpy.mock.calls[1][0]).toMatch(/NETWORK_ERROR/);
+        expect(warnSpy.mock.calls[1][0]).toMatch(/attempt 2\/3/);
+
+        warnSpy.mockRestore();
+    });
+});
+
+// ── GitHubService.createRepository — backoff integration ─────────────────────
+
+describe('GitHubService.createRepository — backoff integration', () => {
+    const mockFetch = vi.fn();
+
+    beforeEach(() => {
+        vi.stubGlobal('fetch', mockFetch);
+        process.env.GITHUB_TOKEN = 'ghp_test_token';
+        vi.clearAllMocks();
+    });
+
+    afterEach(() => {
+        delete process.env.GITHUB_TOKEN;
+        vi.unstubAllGlobals();
+    });
+
+    it('retries a 429 transparently and returns the repository on recovery', async () => {
+        mockFetch
+            .mockResolvedValueOnce(
+                makeJsonResponse(429, { message: 'rate limited' }, { 'Retry-After': '1' }),
+            )
+            .mockResolvedValueOnce(makeJsonResponse(201, REPO_RESPONSE));
+
+        const service = new GitHubService();
+        const result = await service.createRepository(
+            { name: 'repo', private: true, userId: 'u1' },
+            noSleep,
+        );
+
+        expect(result.resolvedName).toBe('repo');
+        expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('retries a transient 500 and returns the repository on recovery', async () => {
+        mockFetch
+            .mockResolvedValueOnce(makeJsonResponse(500, { message: 'Internal Server Error' }))
+            .mockResolvedValueOnce(makeJsonResponse(201, REPO_RESPONSE));
+
+        const service = new GitHubService();
+        const result = await service.createRepository(
+            { name: 'repo', private: true, userId: 'u1' },
+            noSleep,
+        );
+
+        expect(result.resolvedName).toBe('repo');
+        expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('surfaces the last RATE_LIMITED error after all retries are exhausted', async () => {
+        // 1 initial + 3 retries = 4 calls, all rate-limited
+        mockFetch.mockResolvedValue(
+            makeJsonResponse(429, { message: 'rate limited' }, { 'Retry-After': '0' }),
+        );
+
+        const service = new GitHubService();
+        await expect(
+            service.createRepository({ name: 'repo', private: true, userId: 'u1' }, noSleep),
+        ).rejects.toMatchObject({ code: 'RATE_LIMITED' });
+
+        expect(mockFetch).toHaveBeenCalledTimes(4);
+    });
+
+    it('still surfaces COLLISION after name retries are exhausted', async () => {
+        const collisionBody = { errors: [{ message: 'name already exists on this account' }] };
+        // 6 collision responses (base + 5 suffixes), each wrapped in withGitHubRetry
+        for (let i = 0; i < 6; i++) {
+            mockFetch.mockResolvedValueOnce(makeJsonResponse(422, collisionBody));
+        }
+
+        const service = new GitHubService();
+        await expect(
+            service.createRepository({ name: 'repo', private: true, userId: 'u1' }, noSleep),
+        ).rejects.toMatchObject({ code: 'COLLISION' });
+    });
+
+    it('does not retry AUTH_FAILED — surfaces it immediately', async () => {
+        mockFetch.mockResolvedValueOnce(makeJsonResponse(401, { message: 'Bad credentials' }));
+
+        const service = new GitHubService();
+        await expect(
+            service.createRepository({ name: 'repo', private: true, userId: 'u1' }, noSleep),
+        ).rejects.toMatchObject({ code: 'AUTH_FAILED' });
+
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+});

--- a/apps/backend/src/services/github.service.test.ts
+++ b/apps/backend/src/services/github.service.test.ts
@@ -31,6 +31,8 @@ import { sanitizeRepoName, GitHubService } from './github.service';
 const mockFetch = vi.fn();
 vi.stubGlobal('fetch', mockFetch);
 
+const noSleep = vi.fn().mockResolvedValue(undefined);
+
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 function makeJsonResponse(
@@ -293,22 +295,21 @@ describe('GitHubService', () => {
         });
 
         it('throws a RATE_LIMITED error with retryAfterMs on HTTP 429', async () => {
-            mockFetch.mockResolvedValueOnce(
-                makeJsonResponse(429, { message: 'rate limited' }, { 'Retry-After': '60' }),
-            );
+            const response = makeJsonResponse(429, { message: 'rate limited' }, { 'Retry-After': '60' });
+            // 1 initial + 3 retries, all rate-limited
+            mockFetch.mockResolvedValue(response);
 
-            await expect(service.createRepository(BASE_REQUEST)).rejects.toMatchObject({
+            await expect(service.createRepository(BASE_REQUEST, noSleep)).rejects.toMatchObject({
                 code: 'RATE_LIMITED',
                 retryAfterMs: 60_000,
             });
         });
 
         it('throws a RATE_LIMITED error with retryAfterMs on HTTP 403', async () => {
-            mockFetch.mockResolvedValueOnce(
-                makeJsonResponse(403, { message: 'rate limited' }, { 'Retry-After': '30' }),
-            );
+            const response = makeJsonResponse(403, { message: 'rate limited' }, { 'Retry-After': '30' });
+            mockFetch.mockResolvedValue(response);
 
-            await expect(service.createRepository(BASE_REQUEST)).rejects.toMatchObject({
+            await expect(service.createRepository(BASE_REQUEST, noSleep)).rejects.toMatchObject({
                 code: 'RATE_LIMITED',
                 retryAfterMs: 30_000,
             });
@@ -336,20 +337,22 @@ describe('GitHubService', () => {
         });
 
         it('throws a NETWORK_ERROR for unexpected server errors', async () => {
-            mockFetch.mockResolvedValueOnce(
+            // 1 initial + 3 retries, all 500
+            mockFetch.mockResolvedValue(
                 makeJsonResponse(500, { message: 'Internal Server Error' }),
             );
 
-            await expect(service.createRepository(BASE_REQUEST)).rejects.toMatchObject({
+            await expect(service.createRepository(BASE_REQUEST, noSleep)).rejects.toMatchObject({
                 code: 'NETWORK_ERROR',
                 message: 'Internal Server Error',
             });
         });
 
         it('throws NETWORK_ERROR when fetch itself fails', async () => {
-            mockFetch.mockRejectedValueOnce(new Error('socket hang up'));
+            // 1 initial + 3 retries, all throw
+            mockFetch.mockRejectedValue(new Error('socket hang up'));
 
-            await expect(service.createRepository(BASE_REQUEST)).rejects.toMatchObject({
+            await expect(service.createRepository(BASE_REQUEST, noSleep)).rejects.toMatchObject({
                 code: 'NETWORK_ERROR',
                 message: 'socket hang up',
             });

--- a/apps/backend/src/services/github.service.ts
+++ b/apps/backend/src/services/github.service.ts
@@ -15,8 +15,11 @@
  *
  * Rate limiting:
  *   GitHub returns 403/429 with a `Retry-After` (seconds) header when rate-
- *   limited. The service surfaces `retryAfterMs` in the thrown error so callers
- *   can implement their own back-off strategy without polling.
+ *   limited. The service retries up to 3 times with bounded exponential
+ *   backoff, honouring the `Retry-After` value when present. If all retries
+ *   are exhausted the last error is re-thrown so the caller can surface a
+ *   meaningful message. Transient network errors (NETWORK_ERROR) are retried
+ *   with the same strategy.
  *
  * Returns:
  *   { repository, resolvedName } — all identifiers needed for subsequent git
@@ -25,11 +28,75 @@
  */
 
 import type { CreateRepoRequest, GitHubErrorCode, Repository } from '@craft/types';
+import { computeDelay } from '../lib/api/retry';
 
 const GITHUB_API_BASE = 'https://api.github.com';
 const MAX_NAME_RETRIES = 5;
 const MAX_REPOSITORY_NAME_LENGTH = 100;
 const DEFAULT_REPOSITORY_TOPICS = ['craft', 'stellar', 'defi'];
+
+/** Maximum number of rate-limit / transient-error retries per API call. */
+const MAX_RATE_LIMIT_RETRIES = 3;
+/** Base delay (ms) for exponential backoff when no Retry-After header is present. */
+const BACKOFF_BASE_MS = 1_000;
+/** Hard cap on any single backoff delay (ms). */
+const BACKOFF_MAX_MS = 32_000;
+
+/**
+ * Executes `fn`, retrying up to MAX_RATE_LIMIT_RETRIES times on RATE_LIMITED
+ * or NETWORK_ERROR responses with bounded exponential backoff.
+ *
+ * When GitHub supplies a `Retry-After` value it is used as the delay floor;
+ * otherwise full-jitter exponential backoff is applied.
+ *
+ * Non-retryable errors (AUTH_FAILED, COLLISION, UNKNOWN) are re-thrown
+ * immediately without consuming a retry slot.
+ *
+ * @param fn    - Async operation to attempt.
+ * @param sleep - Injected sleep function (override in tests to avoid real delays).
+ */
+export async function withGitHubRetry<T>(
+    fn: () => Promise<T>,
+    sleep: (ms: number) => Promise<void> = (ms) => new Promise((r) => setTimeout(r, ms)),
+): Promise<T> {
+    let lastError: unknown;
+
+    for (let attempt = 0; attempt <= MAX_RATE_LIMIT_RETRIES; attempt++) {
+        try {
+            return await fn();
+        } catch (err: unknown) {
+            lastError = err;
+
+            const isGitHubError =
+                err instanceof Error && (err as { code?: string }).code !== undefined;
+            const code = isGitHubError ? (err as { code: string }).code : null;
+
+            // Only retry on transient errors; surface terminal errors immediately.
+            if (code !== 'RATE_LIMITED' && code !== 'NETWORK_ERROR') {
+                throw err;
+            }
+
+            if (attempt === MAX_RATE_LIMIT_RETRIES) {
+                break;
+            }
+
+            // Honour Retry-After when GitHub tells us how long to wait.
+            const retryAfterMs = (err as { retryAfterMs?: number }).retryAfterMs ?? 0;
+            const backoff = retryAfterMs > 0
+                ? retryAfterMs
+                : computeDelay(attempt, BACKOFF_BASE_MS, BACKOFF_MAX_MS);
+
+            console.warn(
+                `[GitHubService] ${code} — retrying in ${Math.round(backoff)}ms ` +
+                `(attempt ${attempt + 1}/${MAX_RATE_LIMIT_RETRIES})`,
+            );
+
+            await sleep(backoff);
+        }
+    }
+
+    throw lastError;
+}
 
 /**
  * Sanitizes an arbitrary string into a valid GitHub repository name.
@@ -118,9 +185,16 @@ export class GitHubService {
 
     /**
      * Create a GitHub repository, retrying with `-1`, `-2`, … suffixes on
-     * name collisions. Throws a GitHubApiError on unrecoverable failures.
+     * name collisions. Each attempt is wrapped in `withGitHubRetry` so
+     * transient rate-limit and network errors are retried with bounded
+     * exponential backoff before a collision suffix is tried.
+     *
+     * Throws a GitHubApiError on unrecoverable failures.
      */
-    async createRepository(request: CreateRepoRequest): Promise<CreateRepoResult> {
+    async createRepository(
+        request: CreateRepoRequest,
+        sleep?: (ms: number) => Promise<void>,
+    ): Promise<CreateRepoResult> {
         const baseName = sanitizeRepoName(request.name);
         let attempt = 0;
 
@@ -128,7 +202,10 @@ export class GitHubService {
             const candidateName = buildCandidateName(baseName, attempt);
 
             try {
-                const repository = await this.tryCreate(candidateName, request);
+                const repository = await withGitHubRetry(
+                    () => this.tryCreate(candidateName, request),
+                    sleep,
+                );
                 return { repository, resolvedName: candidateName };
             } catch (err: unknown) {
                 if (err instanceof GitHubApiError && err.code === 'COLLISION') {


### PR DESCRIPTION
Here's a summary of what was done:
  
  apps/backend/src/services/github.service.ts — two changes:
  
  1. Added withGitHubRetry<T>(fn, sleep?) — an exported async helper that wraps any operation with up to 3 retries on RATE_LIMITED or NETWORK_ERROR. It honours the
  Retry-After header as the sleep floor when present, falls back to full-jitter exponential backoff (base 1 s, cap 32 s) otherwise, and logs each retry with
  console.warn. Terminal errors (AUTH_FAILED, COLLISION, UNKNOWN) are re-thrown immediately without consuming a retry slot.
  2. Wired withGitHubRetry into createRepository — each tryCreate call is now wrapped, so rate-limit and transient network failures are retried transparently before
  the collision-suffix loop advances. An optional sleep parameter threads through for test injection.
  
  apps/backend/src/services/github.backoff.test.ts — 15 new tests covering: success on first attempt, retry on RATE_LIMITED/NETWORK_ERROR with recovery, Retry-After
   honoured as delay floor, exponential backoff when header absent, retry exhaustion re-throws last error, no retry for terminal codes, warn logging per retry, and
  createRepository integration (429 recovery, 500 recovery, exhaustion, collision still surfaces, AUTH_FAILED not retried).
  
  Existing tests updated — 4 tests in github.service.test.ts and 5 property tests in github.auth-errors.property.test.ts updated to pass noSleep and use persistent
  mocks so retries don't block or consume undefined responses.

closes #78 