### PR TITLE
feat(soroban): harden contract address validation rules

### DIFF
--- a/apps/backend/src/lib/errors/guidance.ts
+++ b/apps/backend/src/lib/errors/guidance.ts
@@ -278,6 +278,97 @@ const GUIDANCE_MAP: Record<GuidanceKey, ErrorGuidance> = {
     ],
   },
 
+  // ── Soroban contract validation ──────────────────────────────────────────
+  'stellar:CONTRACT_ADDRESS_EMPTY': {
+    template: {
+      title: 'Contract address is empty',
+      message: 'A Soroban contract address is required.',
+      retryable: false,
+    },
+    steps: [
+      'Provide a valid 56-character Soroban contract address starting with "C".',
+    ],
+    links: [
+      { label: 'Soroban contract addresses', url: 'https://developers.stellar.org/docs/learn/encyclopedia/contract-development/contract-interactions/stellar-transaction' },
+    ],
+  },
+
+  'stellar:CONTRACT_ADDRESS_WHITESPACE': {
+    template: {
+      title: 'Contract address contains whitespace',
+      message: 'The contract address must not contain leading, trailing, or internal whitespace.',
+      retryable: false,
+    },
+    steps: [
+      'Remove all spaces or newline characters from the contract address.',
+      'Ensure the address is exactly 56 characters of base32 (A-Z, 2-7) starting with "C".',
+    ],
+    links: [
+      { label: 'Soroban contract addresses', url: 'https://developers.stellar.org/docs/learn/encyclopedia/contract-development/contract-interactions/stellar-transaction' },
+    ],
+  },
+
+  'stellar:CONTRACT_ADDRESS_INVALID_LENGTH': {
+    template: {
+      title: 'Contract address has wrong length',
+      message: 'A Soroban contract address must be exactly 56 characters long.',
+      retryable: false,
+    },
+    steps: [
+      'Verify you copied the full contract address.',
+      'Soroban contract addresses are always 56 characters.',
+    ],
+    links: [
+      { label: 'Soroban contract addresses', url: 'https://developers.stellar.org/docs/learn/encyclopedia/contract-development/contract-interactions/stellar-transaction' },
+    ],
+  },
+
+  'stellar:CONTRACT_ADDRESS_INVALID_PREFIX': {
+    template: {
+      title: 'Contract address has wrong prefix',
+      message: 'A Soroban contract address must start with "C". Addresses starting with "G" are Stellar account addresses, not contract addresses.',
+      retryable: false,
+    },
+    steps: [
+      'Confirm you are using a contract address, not a Stellar account (G…) address.',
+      'Retrieve the contract address from the deployment output or Stellar Explorer.',
+    ],
+    links: [
+      { label: 'Stellar Explorer', url: 'https://stellar.expert' },
+    ],
+  },
+
+  'stellar:CONTRACT_ADDRESS_INVALID_CHARSET': {
+    template: {
+      title: 'Contract address contains invalid characters',
+      message: 'Soroban contract addresses use base32 encoding (A-Z and 2-7 only).',
+      retryable: false,
+    },
+    steps: [
+      'Remove any characters outside the base32 alphabet (A-Z, 2-7).',
+      'Copy the address directly from the Stellar Explorer or deployment output.',
+    ],
+    links: [
+      { label: 'Stellar Explorer', url: 'https://stellar.expert' },
+    ],
+  },
+
+  'stellar:CONTRACT_ADDRESS_INVALID_CHECKSUM': {
+    template: {
+      title: 'Contract address checksum mismatch',
+      message: 'The contract address failed the Stellar strkey checksum check. It may be corrupted or mistyped.',
+      retryable: false,
+    },
+    steps: [
+      'Copy the contract address again from a trusted source.',
+      'Verify the address on Stellar Expert to confirm it is correct.',
+    ],
+    links: [
+      { label: 'Stellar Expert', url: 'https://stellar.expert' },
+      { label: 'Stellar strkey spec', url: 'https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0023.md' },
+    ],
+  },
+
   // ── Auth ─────────────────────────────────────────────────────────────────
   'auth:INVALID_CREDENTIALS': {
     template: {

--- a/apps/backend/src/lib/stellar/contract-validation.ts
+++ b/apps/backend/src/lib/stellar/contract-validation.ts
@@ -2,26 +2,90 @@
  * Soroban Contract Address Validation
  *
  * Validates Soroban contract addresses according to Stellar's contract address
- * specifications. Contract addresses are 56-character base32 encoded strings
- * starting with 'C'.
+ * specifications (SEP-0023 / strkey). Contract addresses are 56-character
+ * base32 encoded strings starting with 'C'.
  */
 
 export type ContractValidationResult =
     | { valid: true }
     | { valid: false; reason: string; code: string };
 
+// Base32 alphabet used by Stellar strkey
+const BASE32_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+
+/** Decode a base32 string to a Uint8Array (no padding required). */
+function base32Decode(input: string): Uint8Array {
+    const output: number[] = [];
+    let buffer = 0;
+    let bitsLeft = 0;
+
+    for (const char of input) {
+        const val = BASE32_ALPHABET.indexOf(char);
+        if (val < 0) throw new Error(`Invalid base32 character: ${char}`);
+        buffer = (buffer << 5) | val;
+        bitsLeft += 5;
+        if (bitsLeft >= 8) {
+            bitsLeft -= 8;
+            output.push((buffer >> bitsLeft) & 0xff);
+        }
+    }
+    return new Uint8Array(output);
+}
+
+/** CRC-16/XMODEM as used by Stellar strkey. */
+function crc16(data: Uint8Array): number {
+    let crc = 0x0000;
+    for (const byte of data) {
+        crc ^= byte << 8;
+        for (let i = 0; i < 8; i++) {
+            crc = crc & 0x8000 ? (crc << 1) ^ 0x1021 : crc << 1;
+        }
+    }
+    return crc & 0xffff;
+}
+
+/**
+ * Verify the Stellar strkey checksum embedded in a contract address.
+ * The last 2 bytes of the decoded payload are a little-endian CRC-16 of the
+ * preceding bytes.
+ */
+function verifyStrKeyChecksum(address: string): boolean {
+    try {
+        const decoded = base32Decode(address);
+        if (decoded.length < 3) return false;
+        const payload = decoded.slice(0, -2);
+        const storedCrc = decoded[decoded.length - 2]! | (decoded[decoded.length - 1]! << 8);
+        return crc16(payload) === storedCrc;
+    } catch {
+        return false;
+    }
+}
+
 /**
  * Validate a single Soroban contract address format.
- * 
- * Soroban contract addresses follow SEP-0023 and are:
- * - 56 characters in length
- * - Base32 encoded (characters A-Z and 2-7)
- * - Start with 'C' (indicating contract)
- * 
+ *
+ * Checks (in order):
+ * 1. Whitespace — address must not contain any whitespace
+ * 2. Empty — address must not be empty
+ * 3. Length — must be exactly 56 characters
+ * 4. Prefix — must start with 'C'
+ * 5. Charset — must be valid base32 (A-Z, 2-7)
+ * 6. Checksum — Stellar strkey CRC-16 must match
+ *
  * @param address - The contract address to validate
  * @returns Validation result with validity and reason if invalid
  */
 export function validateContractAddress(address: string): ContractValidationResult {
+    // 1. Whitespace check (before empty check so we catch whitespace-only strings)
+    if (/\s/.test(address)) {
+        return {
+            valid: false,
+            reason: 'Contract address must not contain whitespace',
+            code: 'CONTRACT_ADDRESS_WHITESPACE',
+        };
+    }
+
+    // 2. Empty check
     if (!address) {
         return {
             valid: false,
@@ -30,14 +94,7 @@ export function validateContractAddress(address: string): ContractValidationResu
         };
     }
 
-    if (typeof address !== 'string') {
-        return {
-            valid: false,
-            reason: 'Contract address must be a string',
-            code: 'CONTRACT_ADDRESS_NOT_STRING',
-        };
-    }
-
+    // 3. Length check
     if (address.length !== 56) {
         return {
             valid: false,
@@ -46,6 +103,7 @@ export function validateContractAddress(address: string): ContractValidationResu
         };
     }
 
+    // 4. Prefix check
     if (address[0] !== 'C') {
         return {
             valid: false,
@@ -54,13 +112,21 @@ export function validateContractAddress(address: string): ContractValidationResu
         };
     }
 
-    // Validate base32 encoding (valid characters: A-Z, 2-7)
-    const base32Regex = /^[A-Z2-7]{56}$/;
-    if (!base32Regex.test(address)) {
+    // 5. Charset check — base32: A-Z and 2-7
+    if (!/^[A-Z2-7]{56}$/.test(address)) {
         return {
             valid: false,
             reason: 'Contract address contains invalid characters (must be base32: A-Z, 2-7)',
             code: 'CONTRACT_ADDRESS_INVALID_CHARSET',
+        };
+    }
+
+    // 6. Checksum check
+    if (!verifyStrKeyChecksum(address)) {
+        return {
+            valid: false,
+            reason: 'Contract address checksum is invalid',
+            code: 'CONTRACT_ADDRESS_INVALID_CHECKSUM',
         };
     }
 
@@ -70,7 +136,7 @@ export function validateContractAddress(address: string): ContractValidationResu
 /**
  * Validate all contract addresses in a record.
  * Returns first validation error encountered, or success.
- * 
+ *
  * @param contracts - Object with contract name keys and address values
  * @returns Validation result with field path if invalid
  */

--- a/apps/backend/src/services/soroban-contract-validator.service.ts
+++ b/apps/backend/src/services/soroban-contract-validator.service.ts
@@ -10,15 +10,35 @@
  * this service wraps it and adds RPC-based existence checking.
  *
  * Feature: soroban-contract-address-validation
- * Issue: #248
+ * Issue: #475
  */
 
 import {
     validateContractAddress,
     type ContractValidationResult,
 } from '@/lib/stellar/contract-validation';
+import { getErrorGuidance } from '@/lib/errors/guidance';
+import type { ErrorGuidance } from '@craft/types';
 
 export type { ContractValidationResult };
+
+/**
+ * Structured validation error returned by the service.
+ * Includes the raw code, a human-readable reason, and aligned guidance.
+ */
+export interface ValidationError {
+    /** Error code matching a guidance catalogue entry (e.g. CONTRACT_ADDRESS_EMPTY). */
+    code: string;
+    /** Human-readable explanation of the failure. */
+    reason: string;
+    /** Actionable guidance from the catalogue. */
+    guidance: ErrorGuidance;
+}
+
+export interface ContractFormatResult {
+    valid: boolean;
+    error?: ValidationError;
+}
 
 export interface ContractExistenceResult {
     exists: boolean;
@@ -36,16 +56,34 @@ export class SorobanContractValidator {
 
     /**
      * Validate contract address format only (no network call).
+     * Returns a structured result with guidance on failure.
      */
-    validateFormat(address: unknown): ContractValidationResult {
+    validateFormat(address: unknown): ContractFormatResult {
         if (typeof address !== 'string') {
+            const code = 'CONTRACT_ADDRESS_EMPTY';
             return {
                 valid: false,
-                reason: 'Contract address must be a string',
-                code: 'CONTRACT_ADDRESS_NOT_STRING' as any,
+                error: {
+                    code,
+                    reason: 'Contract address must be a string',
+                    guidance: getErrorGuidance('stellar', code),
+                },
             };
         }
-        return validateContractAddress(address);
+
+        const result = validateContractAddress(address);
+        if (!result.valid) {
+            return {
+                valid: false,
+                error: {
+                    code: result.code,
+                    reason: result.reason,
+                    guidance: getErrorGuidance('stellar', result.code),
+                },
+            };
+        }
+
+        return { valid: true };
     }
 
     /**
@@ -53,13 +91,13 @@ export class SorobanContractValidator {
      * Uses getLedgerEntries to check if the contract's WASM entry exists.
      */
     async checkExistence(contractId: string, sorobanRpcUrl: string): Promise<ContractExistenceResult> {
-        const formatResult = validateContractAddress(contractId);
+        const formatResult = this.validateFormat(contractId);
         if (!formatResult.valid) {
             return {
                 exists: false,
                 contractId,
                 callable: false,
-                error: formatResult.reason,
+                error: formatResult.error?.reason,
             };
         }
 

--- a/apps/backend/tests/soroban/contract-validation.test.ts
+++ b/apps/backend/tests/soroban/contract-validation.test.ts
@@ -1,424 +1,344 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  validateContractAddress,
+  validateContractAddresses,
+} from '../../src/lib/stellar/contract-validation';
+import {
+  SorobanContractValidator,
+} from '../../src/services/soroban-contract-validator.service';
 
 /**
  * Soroban Contract Validation Tests
- * 
- * Verifies Soroban smart contract validation and interaction work correctly.
+ *
+ * Covers:
+ * - validateContractAddress pure function (all rule branches)
+ * - validateContractAddresses batch helper
+ * - SorobanContractValidator.validateFormat (structured errors + guidance)
+ * - SorobanContractValidator.checkExistence (RPC integration)
+ * - Property-based tests for random strings
+ * - Edge cases: empty, whitespace-only, G-prefix, bad checksum
  */
 
-interface ContractAddress {
-  address: string;
-  network: 'testnet' | 'mainnet';
-}
+// ── Fixtures ──────────────────────────────────────────────────────────────────
 
-interface ContractMethod {
-  name: string;
-  params: Array<{ name: string; type: string }>;
-  returns: string;
-}
+/**
+ * A real Soroban contract address with a valid CRC-16/XMODEM checksum.
+ * Version byte 0x10, 32 zero-byte payload, correct checksum appended.
+ */
+const VALID_ADDRESS = 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4';
 
-interface ContractState {
-  address: string;
-  methods: ContractMethod[];
-  isDeployed: boolean;
-  lastUpdated: number;
-}
+// ── validateContractAddress ───────────────────────────────────────────────────
 
-interface InvocationResult {
-  success: boolean;
-  result?: unknown;
-  error?: string;
-  gasUsed?: number;
-}
+describe('validateContractAddress', () => {
+  describe('valid address', () => {
+    it('accepts a well-formed contract address', () => {
+      expect(validateContractAddress(VALID_ADDRESS)).toEqual({ valid: true });
+    });
+  });
 
-class SorobanContractValidator {
-  private contractCache: Map<string, ContractState> = new Map();
-  private testnetHorizonUrl = 'https://horizon-testnet.stellar.org';
-  private mainnetHorizonUrl = 'https://horizon.stellar.org';
+  describe('whitespace checks', () => {
+    it('rejects address with leading whitespace', () => {
+      const result = validateContractAddress(' ' + VALID_ADDRESS);
+      expect(result).toMatchObject({ valid: false, code: 'CONTRACT_ADDRESS_WHITESPACE' });
+    });
 
-  validateContractAddress(address: string, network: 'testnet' | 'mainnet'): boolean {
-    // Stellar contract addresses start with 'C' and are 56 characters
-    if (!address.startsWith('C') || address.length !== 56) {
-      return false;
-    }
+    it('rejects address with trailing whitespace', () => {
+      const result = validateContractAddress(VALID_ADDRESS + ' ');
+      expect(result).toMatchObject({ valid: false, code: 'CONTRACT_ADDRESS_WHITESPACE' });
+    });
 
-    // Basic checksum validation (simplified)
-    const validChars = /^[A-Z2-7]+$/.test(address.slice(1));
-    return validChars;
-  }
+    it('rejects whitespace-only string', () => {
+      const result = validateContractAddress('   ');
+      expect(result).toMatchObject({ valid: false, code: 'CONTRACT_ADDRESS_WHITESPACE' });
+    });
 
-  async getContractState(contractAddress: ContractAddress): Promise<ContractState> {
-    const cacheKey = `${contractAddress.address}-${contractAddress.network}`;
+    it('rejects address with internal tab', () => {
+      const mid = Math.floor(VALID_ADDRESS.length / 2);
+      const withTab = VALID_ADDRESS.slice(0, mid) + '\t' + VALID_ADDRESS.slice(mid);
+      const result = validateContractAddress(withTab);
+      expect(result).toMatchObject({ valid: false, code: 'CONTRACT_ADDRESS_WHITESPACE' });
+    });
 
-    if (this.contractCache.has(cacheKey)) {
-      return this.contractCache.get(cacheKey)!;
-    }
+    it('rejects address with newline', () => {
+      const result = validateContractAddress(VALID_ADDRESS + '\n');
+      expect(result).toMatchObject({ valid: false, code: 'CONTRACT_ADDRESS_WHITESPACE' });
+    });
+  });
 
-    // Simulate fetching contract state
-    const state: ContractState = {
-      address: contractAddress.address,
-      methods: this.getMockContractMethods(),
-      isDeployed: true,
-      lastUpdated: Date.now(),
-    };
+  describe('empty check', () => {
+    it('rejects empty string', () => {
+      const result = validateContractAddress('');
+      expect(result).toMatchObject({ valid: false, code: 'CONTRACT_ADDRESS_EMPTY' });
+    });
+  });
 
-    this.contractCache.set(cacheKey, state);
-    return state;
-  }
+  describe('length check', () => {
+    it('rejects address that is too short', () => {
+      const result = validateContractAddress(VALID_ADDRESS.slice(0, 55));
+      expect(result).toMatchObject({ valid: false, code: 'CONTRACT_ADDRESS_INVALID_LENGTH' });
+    });
 
-  private getMockContractMethods(): ContractMethod[] {
-    return [
-      {
-        name: 'initialize',
-        params: [{ name: 'admin', type: 'Address' }],
-        returns: 'void',
-      },
-      {
-        name: 'transfer',
-        params: [
-          { name: 'from', type: 'Address' },
-          { name: 'to', type: 'Address' },
-          { name: 'amount', type: 'i128' },
-        ],
-        returns: 'bool',
-      },
-      {
-        name: 'balance_of',
-        params: [{ name: 'account', type: 'Address' }],
-        returns: 'i128',
-      },
-    ];
-  }
+    it('rejects address that is too long', () => {
+      const result = validateContractAddress(VALID_ADDRESS + 'A');
+      expect(result).toMatchObject({ valid: false, code: 'CONTRACT_ADDRESS_INVALID_LENGTH' });
+    });
 
-  async invokeContractMethod(
-    contractAddress: ContractAddress,
-    methodName: string,
-    params: Record<string, unknown>
-  ): Promise<InvocationResult> {
-    if (!this.validateContractAddress(contractAddress.address, contractAddress.network)) {
-      return {
-        success: false,
-        error: 'Invalid contract address',
-      };
-    }
+    it('includes actual length in the reason message', () => {
+      const result = validateContractAddress('C'.repeat(10));
+      expect(result).toMatchObject({ valid: false, code: 'CONTRACT_ADDRESS_INVALID_LENGTH' });
+      if (!result.valid) expect(result.reason).toContain('10');
+    });
+  });
 
-    const state = await this.getContractState(contractAddress);
-    const method = state.methods.find((m) => m.name === methodName);
+  describe('prefix check', () => {
+    it('rejects G-prefix (Stellar account address)', () => {
+      const gAddress = 'G' + VALID_ADDRESS.slice(1);
+      const result = validateContractAddress(gAddress);
+      expect(result).toMatchObject({ valid: false, code: 'CONTRACT_ADDRESS_INVALID_PREFIX' });
+    });
 
-    if (!method) {
-      return {
-        success: false,
-        error: `Method ${methodName} not found`,
-      };
-    }
+    it('rejects lowercase c prefix', () => {
+      const lower = 'c' + VALID_ADDRESS.slice(1);
+      const result = validateContractAddress(lower);
+      // lowercase 'c' is not in base32 alphabet, so charset error fires first
+      expect(result.valid).toBe(false);
+    });
 
-    // Simulate method invocation
-    return {
-      success: true,
-      result: this.simulateMethodResult(methodName, params),
-      gasUsed: Math.floor(Math.random() * 100000) + 10000,
-    };
-  }
+    it('rejects S-prefix', () => {
+      const sAddress = 'S' + VALID_ADDRESS.slice(1);
+      const result = validateContractAddress(sAddress);
+      expect(result).toMatchObject({ valid: false, code: 'CONTRACT_ADDRESS_INVALID_PREFIX' });
+    });
+  });
 
-  private simulateMethodResult(methodName: string, params: Record<string, unknown>): unknown {
-    const results: Record<string, unknown> = {
-      initialize: true,
-      transfer: true,
-      balance_of: Math.floor(Math.random() * 1000000),
-    };
-    return results[methodName] || null;
-  }
+  describe('charset check', () => {
+    it('rejects address with digit 0', () => {
+      const bad = 'C' + '0'.repeat(55);
+      const result = validateContractAddress(bad);
+      expect(result).toMatchObject({ valid: false, code: 'CONTRACT_ADDRESS_INVALID_CHARSET' });
+    });
 
-  async queryContractState(
-    contractAddress: ContractAddress,
-    key: string
-  ): Promise<unknown> {
-    if (!this.validateContractAddress(contractAddress.address, contractAddress.network)) {
-      throw new Error('Invalid contract address');
-    }
+    it('rejects address with digit 1', () => {
+      const bad = 'C' + '1'.repeat(55);
+      const result = validateContractAddress(bad);
+      expect(result).toMatchObject({ valid: false, code: 'CONTRACT_ADDRESS_INVALID_CHARSET' });
+    });
 
-    // Simulate state query
-    return {
-      key,
-      value: `state_${key}_value`,
-      ledger: Math.floor(Math.random() * 1000000),
-    };
-  }
+    it('rejects address with digit 8', () => {
+      const bad = 'C' + '8'.repeat(55);
+      const result = validateContractAddress(bad);
+      expect(result).toMatchObject({ valid: false, code: 'CONTRACT_ADDRESS_INVALID_CHARSET' });
+    });
 
-  async verifyContractDeployment(contractAddress: ContractAddress): Promise<boolean> {
-    if (!this.validateContractAddress(contractAddress.address, contractAddress.network)) {
-      return false;
-    }
+    it('rejects address with special character', () => {
+      const bad = 'C' + VALID_ADDRESS.slice(1, 55) + '!';
+      const result = validateContractAddress(bad);
+      expect(result).toMatchObject({ valid: false, code: 'CONTRACT_ADDRESS_INVALID_CHARSET' });
+    });
+  });
 
-    const state = await this.getContractState(contractAddress);
-    return state.isDeployed;
-  }
+  describe('checksum check', () => {
+    it('rejects address with corrupted last character', () => {
+      // Flip the last character to break the checksum
+      const lastChar = VALID_ADDRESS[55]!;
+      const replacement = lastChar === 'A' ? 'B' : 'A';
+      const corrupted = VALID_ADDRESS.slice(0, 55) + replacement;
+      const result = validateContractAddress(corrupted);
+      expect(result).toMatchObject({ valid: false, code: 'CONTRACT_ADDRESS_INVALID_CHECKSUM' });
+    });
 
-  clearCache(): void {
-    this.contractCache.clear();
-  }
-}
+    it('rejects address with corrupted middle character', () => {
+      const chars = VALID_ADDRESS.split('');
+      chars[28] = chars[28] === 'A' ? 'B' : 'A';
+      const corrupted = chars.join('');
+      const result = validateContractAddress(corrupted);
+      expect(result).toMatchObject({ valid: false, code: 'CONTRACT_ADDRESS_INVALID_CHECKSUM' });
+    });
+  });
+});
 
-describe('Soroban Contract Validation', () => {
+// ── validateContractAddresses ─────────────────────────────────────────────────
+
+describe('validateContractAddresses', () => {
+  it('returns valid for empty object', () => {
+    expect(validateContractAddresses({})).toEqual({ valid: true });
+  });
+
+  it('returns valid for undefined', () => {
+    expect(validateContractAddresses(undefined)).toEqual({ valid: true });
+  });
+
+  it('returns valid when all addresses are valid', () => {
+    expect(validateContractAddresses({ token: VALID_ADDRESS })).toEqual({ valid: true });
+  });
+
+  it('returns field path and code on first invalid address', () => {
+    const result = validateContractAddresses({ token: '' });
+    expect(result).toMatchObject({
+      valid: false,
+      field: 'stellar.contractAddresses.token',
+      code: 'CONTRACT_ADDRESS_EMPTY',
+    });
+  });
+});
+
+// ── SorobanContractValidator.validateFormat ───────────────────────────────────
+
+describe('SorobanContractValidator.validateFormat', () => {
   let validator: SorobanContractValidator;
 
   beforeEach(() => {
     validator = new SorobanContractValidator();
   });
 
-  describe('Contract Address Validation', () => {
-    it('should validate correct contract address format', () => {
-      const validAddress = 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4';
-
-      expect(validator.validateContractAddress(validAddress, 'testnet')).toBe(true);
-    });
-
-    it('should reject address with invalid prefix', () => {
-      const invalidAddress = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4';
-
-      expect(validator.validateContractAddress(invalidAddress, 'testnet')).toBe(false);
-    });
-
-    it('should reject address with incorrect length', () => {
-      const shortAddress = 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC';
-
-      expect(validator.validateContractAddress(shortAddress, 'testnet')).toBe(false);
-    });
-
-    it('should reject address with invalid characters', () => {
-      const invalidAddress = 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC!';
-
-      expect(validator.validateContractAddress(invalidAddress, 'testnet')).toBe(false);
-    });
-
-    it('should validate on both testnet and mainnet', () => {
-      const validAddress = 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4';
-
-      expect(validator.validateContractAddress(validAddress, 'testnet')).toBe(true);
-      expect(validator.validateContractAddress(validAddress, 'mainnet')).toBe(true);
-    });
+  it('returns valid: true for a well-formed address', () => {
+    expect(validator.validateFormat(VALID_ADDRESS)).toEqual({ valid: true });
   });
 
-  describe('Contract Method Invocation', () => {
-    it('should invoke contract method successfully', async () => {
-      const contractAddress: ContractAddress = {
-        address: 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4',
-        network: 'testnet',
-      };
-
-      const result = await validator.invokeContractMethod(contractAddress, 'transfer', {
-        from: 'GXXX',
-        to: 'GYYY',
-        amount: 100,
-      });
-
-      expect(result.success).toBe(true);
-      expect(result.result).toBeDefined();
-      expect(result.gasUsed).toBeGreaterThan(0);
-    });
-
-    it('should return error for invalid contract address', async () => {
-      const contractAddress: ContractAddress = {
-        address: 'INVALID',
-        network: 'testnet',
-      };
-
-      const result = await validator.invokeContractMethod(contractAddress, 'transfer', {});
-
-      expect(result.success).toBe(false);
-      expect(result.error).toBeDefined();
-    });
-
-    it('should return error for non-existent method', async () => {
-      const contractAddress: ContractAddress = {
-        address: 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4',
-        network: 'testnet',
-      };
-
-      const result = await validator.invokeContractMethod(contractAddress, 'nonExistent', {});
-
-      expect(result.success).toBe(false);
-      expect(result.error).toContain('not found');
-    });
-
-    it('should include gas usage in result', async () => {
-      const contractAddress: ContractAddress = {
-        address: 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4',
-        network: 'testnet',
-      };
-
-      const result = await validator.invokeContractMethod(contractAddress, 'transfer', {});
-
-      expect(result.gasUsed).toBeGreaterThan(10000);
-      expect(result.gasUsed).toBeLessThan(200000);
-    });
+  it('returns structured error for non-string input', () => {
+    const result = validator.validateFormat(null);
+    expect(result.valid).toBe(false);
+    expect(result.error?.code).toBeDefined();
+    expect(result.error?.guidance).toBeDefined();
+    expect(result.error?.guidance.template.title).toBeTruthy();
   });
 
-  describe('Contract State Queries', () => {
-    it('should query contract state successfully', async () => {
-      const contractAddress: ContractAddress = {
-        address: 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4',
-        network: 'testnet',
-      };
-
-      const state = await validator.queryContractState(contractAddress, 'balance');
-
-      expect(state).toBeDefined();
-      expect((state as Record<string, unknown>).key).toBe('balance');
-    });
-
-    it('should throw error for invalid contract address in query', async () => {
-      const contractAddress: ContractAddress = {
-        address: 'INVALID',
-        network: 'testnet',
-      };
-
-      await expect(
-        validator.queryContractState(contractAddress, 'balance')
-      ).rejects.toThrow('Invalid contract address');
-    });
-
-    it('should return ledger information in state query', async () => {
-      const contractAddress: ContractAddress = {
-        address: 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4',
-        network: 'testnet',
-      };
-
-      const state = await validator.queryContractState(contractAddress, 'data');
-
-      expect((state as Record<string, unknown>).ledger).toBeGreaterThan(0);
-    });
+  it('returns guidance aligned with catalogue for empty string', () => {
+    const result = validator.validateFormat('');
+    expect(result.valid).toBe(false);
+    expect(result.error?.code).toBe('CONTRACT_ADDRESS_EMPTY');
+    expect(result.error?.guidance.template.title).toBeTruthy();
+    expect(result.error?.guidance.steps.length).toBeGreaterThan(0);
   });
 
-  describe('Contract Deployment Verification', () => {
-    it('should verify deployed contract', async () => {
-      const contractAddress: ContractAddress = {
-        address: 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4',
-        network: 'testnet',
-      };
-
-      const isDeployed = await validator.verifyContractDeployment(contractAddress);
-
-      expect(isDeployed).toBe(true);
-    });
-
-    it('should return false for invalid address', async () => {
-      const contractAddress: ContractAddress = {
-        address: 'INVALID',
-        network: 'testnet',
-      };
-
-      const isDeployed = await validator.verifyContractDeployment(contractAddress);
-
-      expect(isDeployed).toBe(false);
-    });
-
-    it('should verify on both networks', async () => {
-      const address = 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4';
-
-      const testnetResult = await validator.verifyContractDeployment({
-        address,
-        network: 'testnet',
-      });
-
-      const mainnetResult = await validator.verifyContractDeployment({
-        address,
-        network: 'mainnet',
-      });
-
-      expect(testnetResult).toBe(true);
-      expect(mainnetResult).toBe(true);
-    });
+  it('returns guidance for whitespace-only input', () => {
+    const result = validator.validateFormat('   ');
+    expect(result.valid).toBe(false);
+    expect(result.error?.code).toBe('CONTRACT_ADDRESS_WHITESPACE');
+    expect(result.error?.guidance).toBeDefined();
   });
 
-  describe('Contract Error Handling', () => {
-    it('should handle contract invocation errors gracefully', async () => {
-      const contractAddress: ContractAddress = {
-        address: 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4',
-        network: 'testnet',
-      };
-
-      const result = await validator.invokeContractMethod(contractAddress, 'unknownMethod', {});
-
-      expect(result.success).toBe(false);
-      expect(result.error).toBeDefined();
-      expect(result.result).toBeUndefined();
-    });
-
-    it('should validate address before any operation', async () => {
-      const invalidAddress: ContractAddress = {
-        address: 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4',
-        network: 'testnet',
-      };
-
-      const result = await validator.invokeContractMethod(invalidAddress, 'transfer', {});
-
-      expect(result.success).toBe(false);
-      expect(result.error).toContain('Invalid');
-    });
+  it('returns guidance for wrong-length address', () => {
+    const result = validator.validateFormat('CAAA');
+    expect(result.valid).toBe(false);
+    expect(result.error?.code).toBe('CONTRACT_ADDRESS_INVALID_LENGTH');
+    expect(result.error?.guidance.steps.length).toBeGreaterThan(0);
   });
 
-  describe('Contract State Caching', () => {
-    it('should cache contract state', async () => {
-      const contractAddress: ContractAddress = {
-        address: 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4',
-        network: 'testnet',
-      };
-
-      const state1 = await validator.getContractState(contractAddress);
-      const state2 = await validator.getContractState(contractAddress);
-
-      expect(state1).toEqual(state2);
-    });
-
-    it('should clear cache without errors', () => {
-      expect(() => validator.clearCache()).not.toThrow();
-    });
-
-    it('should have different cache entries for different networks', async () => {
-      const address = 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4';
-
-      const testnetState = await validator.getContractState({
-        address,
-        network: 'testnet',
-      });
-
-      const mainnetState = await validator.getContractState({
-        address,
-        network: 'mainnet',
-      });
-
-      expect(testnetState.lastUpdated).toBeDefined();
-      expect(mainnetState.lastUpdated).toBeDefined();
-    });
+  it('returns guidance for G-prefix (mainnet vs testnet prefix mismatch)', () => {
+    const result = validator.validateFormat('G' + VALID_ADDRESS.slice(1));
+    expect(result.valid).toBe(false);
+    expect(result.error?.code).toBe('CONTRACT_ADDRESS_INVALID_PREFIX');
+    expect(result.error?.guidance.template.message).toContain('"C"');
   });
 
-  describe('Contract Methods Availability', () => {
-    it('should return available contract methods', async () => {
-      const contractAddress: ContractAddress = {
-        address: 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4',
-        network: 'testnet',
-      };
+  it('returns guidance for invalid charset', () => {
+    const result = validator.validateFormat('C' + '0'.repeat(55));
+    expect(result.valid).toBe(false);
+    expect(result.error?.code).toBe('CONTRACT_ADDRESS_INVALID_CHARSET');
+  });
 
-      const state = await validator.getContractState(contractAddress);
+  it('returns guidance for bad checksum', () => {
+    const corrupted = VALID_ADDRESS.slice(0, 55) + (VALID_ADDRESS[55] === 'A' ? 'B' : 'A');
+    const result = validator.validateFormat(corrupted);
+    expect(result.valid).toBe(false);
+    expect(result.error?.code).toBe('CONTRACT_ADDRESS_INVALID_CHECKSUM');
+    expect(result.error?.guidance.links.length).toBeGreaterThan(0);
+  });
+});
 
-      expect(state.methods.length).toBeGreaterThan(0);
-      expect(state.methods.some((m) => m.name === 'transfer')).toBe(true);
-      expect(state.methods.some((m) => m.name === 'balance_of')).toBe(true);
+// ── SorobanContractValidator.checkExistence ───────────────────────────────────
+
+describe('SorobanContractValidator.checkExistence', () => {
+  it('returns exists: false with error when format is invalid', async () => {
+    const validator = new SorobanContractValidator();
+    const result = await validator.checkExistence('INVALID', 'http://rpc.example.com');
+    expect(result.exists).toBe(false);
+    expect(result.callable).toBe(false);
+    expect(result.error).toBeTruthy();
+  });
+
+  it('returns exists: true when RPC returns entries', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ result: { entries: [{}] } }),
     });
+    const validator = new SorobanContractValidator(mockFetch as any);
+    const result = await validator.checkExistence(VALID_ADDRESS, 'http://rpc.example.com');
+    expect(result.exists).toBe(true);
+    expect(result.callable).toBe(true);
+  });
 
-    it('should include method parameters and return types', async () => {
-      const contractAddress: ContractAddress = {
-        address: 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4',
-        network: 'testnet',
-      };
-
-      const state = await validator.getContractState(contractAddress);
-      const transferMethod = state.methods.find((m) => m.name === 'transfer');
-
-      expect(transferMethod).toBeDefined();
-      expect(transferMethod!.params.length).toBeGreaterThan(0);
-      expect(transferMethod!.returns).toBeDefined();
+  it('returns exists: false when RPC returns empty entries', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ result: { entries: [] } }),
     });
+    const validator = new SorobanContractValidator(mockFetch as any);
+    const result = await validator.checkExistence(VALID_ADDRESS, 'http://rpc.example.com');
+    expect(result.exists).toBe(false);
+    expect(result.callable).toBe(false);
+  });
+
+  it('returns exists: false on HTTP error', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: false, status: 503 });
+    const validator = new SorobanContractValidator(mockFetch as any);
+    const result = await validator.checkExistence(VALID_ADDRESS, 'http://rpc.example.com');
+    expect(result.exists).toBe(false);
+    expect(result.error).toContain('503');
+  });
+
+  it('returns exists: false on network error', async () => {
+    const mockFetch = vi.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+    const validator = new SorobanContractValidator(mockFetch as any);
+    const result = await validator.checkExistence(VALID_ADDRESS, 'http://rpc.example.com');
+    expect(result.exists).toBe(false);
+    expect(result.error).toContain('ECONNREFUSED');
+  });
+
+  it('handles RPC not-found error code', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ error: { code: -32600, message: 'not found' } }),
+    });
+    const validator = new SorobanContractValidator(mockFetch as any);
+    const result = await validator.checkExistence(VALID_ADDRESS, 'http://rpc.example.com');
+    expect(result.exists).toBe(false);
+  });
+});
+
+// ── Property-based tests ──────────────────────────────────────────────────────
+
+describe('property-based: random strings always produce a structured result', () => {
+  const randomStrings = [
+    '',
+    ' ',
+    '\t\n',
+    'abc',
+    'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4',
+    'C'.repeat(56),
+    'C' + 'A'.repeat(54) + '!',
+    'C' + '0'.repeat(55),
+    Array.from({ length: 56 }, () => String.fromCharCode(33 + Math.floor(Math.random() * 94))).join(''),
+    Array.from({ length: 100 }, () => 'A').join(''),
+  ];
+
+  for (const input of randomStrings) {
+    it(`validateContractAddress("${input.slice(0, 20)}…") returns a typed result`, () => {
+      const result = validateContractAddress(input);
+      expect(typeof result.valid).toBe('boolean');
+      if (!result.valid) {
+        expect(typeof result.code).toBe('string');
+        expect(typeof result.reason).toBe('string');
+      }
+    });
+  }
+
+  it('validateFormat never throws for arbitrary inputs', () => {
+    const validator = new SorobanContractValidator();
+    const inputs: unknown[] = [null, undefined, 42, {}, [], true, '', ' ', VALID_ADDRESS];
+    for (const input of inputs) {
+      expect(() => validator.validateFormat(input)).not.toThrow();
+    }
   });
 });


### PR DESCRIPTION
## Summary

Closes #475

Strengthens `SorobanContractValidator` and the underlying `validateContractAddress` pure function with stricter format rules, checksum verification, and structured error objects aligned to the guidance catalogue.

## Changes

- **`contract-validation.ts`** — Added whitespace check (before empty check) and CRC-16/XMODEM strkey checksum verification
- **`guidance.ts`** — Added 6 `stellar:CONTRACT_ADDRESS_*` guidance entries covering all new error codes
- **`soroban-contract-validator.service.ts`** — `validateFormat` now returns structured `ValidationError` with `code`, `reason`, and `guidance`; `checkExistence` delegates to `validateFormat`
- **`contract-validation.test.ts`** — Full rewrite: all rule branches, batch helper, service structured-error + guidance alignment, RPC mock scenarios, property-based tests

## Testing

48 tests passing — all rule branches, edge cases (empty, whitespace-only, G-prefix, bad checksum), RPC mock scenarios, and property-based tests for arbitrary inputs.