### PR TITLE
feat(drafts): add draft-to-deployment promotion endpoint

### DIFF
--- a/apps/backend/src/app/api/drafts/[templateId]/promote/route.test.ts
+++ b/apps/backend/src/app/api/drafts/[templateId]/promote/route.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+// ── Supabase mock ─────────────────────────────────────────────────────────────
+const mockGetUser = vi.fn();
+const mockFrom = vi.fn();
+
+vi.mock('@/lib/supabase/server', () => ({
+    createClient: () => ({
+        auth: { getUser: mockGetUser },
+        from: mockFrom,
+    }),
+}));
+
+// ── Service mocks ─────────────────────────────────────────────────────────────
+const mockPromoteDraft = vi.fn();
+
+vi.mock('@/services/customization-draft.service', () => ({
+    customizationDraftService: {
+        promoteDraft: mockPromoteDraft,
+    },
+}));
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+const fakeUser = { id: 'user-1', email: 'a@b.com' };
+const templateId = 'tmpl-1';
+const deploymentId = 'dep-1';
+const params = { templateId };
+
+const successResult = {
+    success: true,
+    deploymentId,
+    rolledBack: false,
+    deploymentUrl: 'https://my-dex.vercel.app',
+};
+
+const makeRequest = (body?: unknown) =>
+    new NextRequest(`http://localhost/api/drafts/${templateId}/promote`, {
+        method: 'POST',
+        ...(body !== undefined
+            ? { body: JSON.stringify(body), headers: { 'Content-Type': 'application/json' } }
+            : {}),
+    });
+
+// ── POST /api/drafts/[templateId]/promote ─────────────────────────────────────
+describe('POST /api/drafts/[templateId]/promote', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockGetUser.mockResolvedValue({ data: { user: fakeUser }, error: null });
+    });
+
+    it('returns 401 when unauthenticated', async () => {
+        mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+        const { POST } = await import('./route');
+        const res = await POST(makeRequest({ deploymentId }), { params });
+        expect(res.status).toBe(401);
+    });
+
+    it('returns 400 for invalid JSON', async () => {
+        const { POST } = await import('./route');
+        const req = new NextRequest(`http://localhost/api/drafts/${templateId}/promote`, {
+            method: 'POST',
+            body: 'not-json',
+            headers: { 'Content-Type': 'application/json' },
+        });
+        const res = await POST(req, { params });
+        expect(res.status).toBe(400);
+    });
+
+    it('returns 400 when deploymentId is missing', async () => {
+        const { POST } = await import('./route');
+        const res = await POST(makeRequest({}), { params });
+        expect(res.status).toBe(400);
+        const body = await res.json();
+        expect(body.error).toMatch(/deploymentId/);
+    });
+
+    it('returns 404 when draft is not found', async () => {
+        mockPromoteDraft.mockRejectedValue(new Error('Draft not found'));
+        const { POST } = await import('./route');
+        const res = await POST(makeRequest({ deploymentId }), { params });
+        expect(res.status).toBe(404);
+        const body = await res.json();
+        expect(body.error).toBe('Draft not found');
+    });
+
+    it('returns 400 with details when draft config is invalid', async () => {
+        const validationErrors = [{ field: 'branding.appName', message: 'App name is required', code: 'TOO_SMALL' }];
+        const err = Object.assign(new Error('Invalid draft configuration'), { validationErrors });
+        mockPromoteDraft.mockRejectedValue(err);
+        const { POST } = await import('./route');
+        const res = await POST(makeRequest({ deploymentId }), { params });
+        expect(res.status).toBe(400);
+        const body = await res.json();
+        expect(body.details).toEqual(validationErrors);
+    });
+
+    it('returns 404 when deployment is not found or access denied', async () => {
+        mockPromoteDraft.mockResolvedValue({
+            success: false,
+            deploymentId,
+            rolledBack: false,
+            errorMessage: 'Deployment not found or access denied',
+        });
+        const { POST } = await import('./route');
+        const res = await POST(makeRequest({ deploymentId }), { params });
+        expect(res.status).toBe(404);
+    });
+
+    it('returns 200 with result on successful promotion', async () => {
+        mockPromoteDraft.mockResolvedValue(successResult);
+        const { POST } = await import('./route');
+        const res = await POST(makeRequest({ deploymentId }), { params });
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.success).toBe(true);
+        expect(body.deploymentId).toBe(deploymentId);
+        expect(body.deploymentUrl).toBe('https://my-dex.vercel.app');
+    });
+
+    it('calls promoteDraft with correct userId, templateId, and deploymentId', async () => {
+        mockPromoteDraft.mockResolvedValue(successResult);
+        const { POST } = await import('./route');
+        await POST(makeRequest({ deploymentId }), { params });
+        expect(mockPromoteDraft).toHaveBeenCalledWith(fakeUser.id, templateId, deploymentId);
+    });
+
+    it('returns 500 on unexpected service error', async () => {
+        mockPromoteDraft.mockRejectedValue(new Error('Unexpected DB failure'));
+        const { POST } = await import('./route');
+        const res = await POST(makeRequest({ deploymentId }), { params });
+        expect(res.status).toBe(500);
+    });
+});

--- a/apps/backend/src/app/api/drafts/[templateId]/promote/route.ts
+++ b/apps/backend/src/app/api/drafts/[templateId]/promote/route.ts
@@ -1,0 +1,68 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { withAuth } from '@/lib/api/with-auth';
+import { customizationDraftService } from '@/services/customization-draft.service';
+
+type Params = { templateId: string };
+
+/**
+ * POST /api/drafts/[templateId]/promote
+ *
+ * Promotes the authenticated user's saved draft for the given template into a
+ * live deployment update.
+ *
+ * Request body:
+ *   { "deploymentId": "<uuid>" }
+ *
+ * Responses:
+ *   200 – { success, deploymentId, rolledBack, deploymentUrl? }
+ *   400 – Invalid JSON or missing deploymentId
+ *   400 – Draft config failed validation  { error, details }
+ *   404 – Draft not found
+ *   404 – Deployment not found or access denied (returned by updateDeployment)
+ *   500 – Unexpected error
+ */
+export const POST = withAuth<Params>(async (req: NextRequest, { user, params }) => {
+    let body: unknown;
+    try {
+        body = await req.json();
+    } catch {
+        return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+    }
+
+    const { deploymentId } = (body as Record<string, unknown>) ?? {};
+    if (!deploymentId || typeof deploymentId !== 'string') {
+        return NextResponse.json({ error: 'deploymentId is required' }, { status: 400 });
+    }
+
+    try {
+        const result = await customizationDraftService.promoteDraft(
+            user.id,
+            params.templateId,
+            deploymentId,
+        );
+
+        if (!result.success) {
+            // updateDeployment returns success:false when the deployment is not found
+            // or is in a non-promotable state.
+            const isNotFound = result.errorMessage?.includes('not found') ||
+                result.errorMessage?.includes('access denied');
+            return NextResponse.json(
+                { error: result.errorMessage ?? 'Promotion failed' },
+                { status: isNotFound ? 404 : 500 },
+            );
+        }
+
+        return NextResponse.json(result);
+    } catch (error: any) {
+        if (error.message === 'Draft not found') {
+            return NextResponse.json({ error: 'Draft not found' }, { status: 404 });
+        }
+        if (error.validationErrors) {
+            return NextResponse.json(
+                { error: 'Invalid draft configuration', details: error.validationErrors },
+                { status: 400 },
+            );
+        }
+        return NextResponse.json({ error: error.message || 'Promotion failed' }, { status: 500 });
+    }
+});

--- a/apps/backend/src/services/customization-draft.service.test.ts
+++ b/apps/backend/src/services/customization-draft.service.test.ts
@@ -2,6 +2,12 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { CustomizationDraftService, normalizeDraftConfig } from './customization-draft.service';
 import type { CustomizationConfig } from '@craft/types';
 
+// ── DeploymentUpdateService mock ──────────────────────────────────────────────
+const mockUpdateDeployment = vi.fn();
+vi.mock('./deployment-update.service', () => ({
+    deploymentUpdateService: { updateDeployment: (...args: any[]) => mockUpdateDeployment(...args) },
+}));
+
 // ── Supabase mock ─────────────────────────────────────────────────────────────
 //
 // All Supabase query-builder calls (eq, select, upsert) are chained on a single
@@ -372,6 +378,74 @@ describe('CustomizationDraftService', () => {
 
             expect(caughtError).not.toBeNull();
             expect(caughtError!.message).toBe('Forbidden');
+        });
+    });
+
+    // ── promoteDraft ──────────────────────────────────────────────────────────
+
+    describe('promoteDraft', () => {
+        const deploymentId = 'dep-001';
+
+        it('throws "Draft not found" when no draft exists for the user+template', async () => {
+            mockSingle.mockResolvedValueOnce({ data: null, error: { code: 'PGRST116', message: 'no rows' } });
+
+            await expect(service.promoteDraft(userId, templateId, deploymentId)).rejects.toThrow('Draft not found');
+        });
+
+        it('throws with validationErrors when the draft config is invalid', async () => {
+            const invalidConfig = {
+                ...validConfig,
+                branding: { ...validConfig.branding, appName: '' }, // fails min(1)
+            };
+            const invalidRow = { ...dbRow, customization_config: invalidConfig };
+            mockSingle.mockResolvedValueOnce({ data: invalidRow, error: null });
+
+            let caught: any;
+            try {
+                await service.promoteDraft(userId, templateId, deploymentId);
+            } catch (e) {
+                caught = e;
+            }
+
+            expect(caught).toBeDefined();
+            expect(caught.validationErrors).toBeDefined();
+            expect(Array.isArray(caught.validationErrors)).toBe(true);
+        });
+
+        it('calls updateDeployment with correct deploymentId, userId, and config on valid draft', async () => {
+            mockSingle.mockResolvedValueOnce({ data: dbRow, error: null });
+            mockUpdateDeployment.mockResolvedValueOnce({
+                success: true,
+                deploymentId,
+                rolledBack: false,
+            });
+
+            await service.promoteDraft(userId, templateId, deploymentId);
+
+            expect(mockUpdateDeployment).toHaveBeenCalledWith({
+                deploymentId,
+                userId,
+                customizationConfig: expect.objectContaining({
+                    branding: expect.objectContaining({ appName: 'My DEX' }),
+                }),
+            });
+        });
+
+        it('returns the UpdateDeploymentResult from updateDeployment', async () => {
+            mockSingle.mockResolvedValueOnce({ data: dbRow, error: null });
+            const expected = { success: true, deploymentId, rolledBack: false, deploymentUrl: 'https://x.vercel.app' };
+            mockUpdateDeployment.mockResolvedValueOnce(expected);
+
+            const result = await service.promoteDraft(userId, templateId, deploymentId);
+
+            expect(result).toEqual(expected);
+        });
+
+        it('propagates errors thrown by updateDeployment', async () => {
+            mockSingle.mockResolvedValueOnce({ data: dbRow, error: null });
+            mockUpdateDeployment.mockRejectedValueOnce(new Error('DB connection lost'));
+
+            await expect(service.promoteDraft(userId, templateId, deploymentId)).rejects.toThrow('DB connection lost');
         });
     });
 });

--- a/apps/backend/src/services/customization-draft.service.ts
+++ b/apps/backend/src/services/customization-draft.service.ts
@@ -1,5 +1,7 @@
 import { createClient } from '@/lib/supabase/server';
 import type { CustomizationConfig } from '@craft/types';
+import { validateCustomizationConfig } from '@/lib/customization/validate';
+import { deploymentUpdateService, type UpdateDeploymentResult } from './deployment-update.service';
 
 const DEFAULT_CONFIG: CustomizationConfig = {
     branding: {
@@ -131,6 +133,35 @@ export class CustomizationDraftService {
         if (deployment.user_id !== userId) throw new Error('Forbidden');
 
         return this.getDraft(userId, deployment.template_id);
+    }
+
+    /**
+     * Promote a draft to a live deployment.
+     * Validates the draft config, then delegates to DeploymentUpdateService.
+     * The caller must supply the target deploymentId.
+     *
+     * @throws Error if the draft is not found, belongs to another user, or config is invalid.
+     */
+    async promoteDraft(
+        userId: string,
+        templateId: string,
+        deploymentId: string
+    ): Promise<UpdateDeploymentResult> {
+        const draft = await this.getDraft(userId, templateId);
+        if (!draft) {
+            throw new Error('Draft not found');
+        }
+
+        const validation = validateCustomizationConfig(draft.customizationConfig);
+        if (!validation.valid) {
+            throw Object.assign(new Error('Invalid draft configuration'), { validationErrors: validation.errors });
+        }
+
+        return deploymentUpdateService.updateDeployment({
+            deploymentId,
+            userId,
+            customizationConfig: draft.customizationConfig,
+        });
     }
 
     private mapRow(row: any): CustomizationDraft {


### PR DESCRIPTION
## Summary

Implements draft-to-deployment promotion as requested in #484.

Users can now promote a saved customization draft into a live deployment update via a new API endpoint.

## Changes

### `CustomizationDraftService` — new `promoteDraft` method
- Loads the draft for the given `userId` + `templateId`; returns `404` if absent
- Validates the config via `validateCustomizationConfig`; surfaces field-level errors on failure
- Delegates to `DeploymentUpdateService.updateDeployment` and returns its result

### `POST /api/drafts/[templateId]/promote` (new route)
- Auth-gated via `withAuth`
- Request body: `{ "deploymentId": "<uuid>" }`
- Response codes: `200` success · `400` bad input / invalid config · `401` unauthed · `404` draft or deployment not found · `500` unexpected error

**Example request:**
```http
POST /api/drafts/tmpl-abc/promote
Authorization: Bearer <token>
Content-Type: application/json

{ "deploymentId": "dep-xyz" }
```

**Example response (200):**
```json
{
  "success": true,
  "deploymentId": "dep-xyz",
  "rolledBack": false,
  "deploymentUrl": "https://my-dex.vercel.app"
}
```

**Example response (400 — invalid config):**
```json
{
  "error": "Invalid draft configuration",
  "details": [
    { "field": "branding.appName", "message": "App name is required", "code": "TOO_SMALL" }
  ]
}
```

**Example response (404 — draft not found):**
```json
{ "error": "Draft not found" }
```

**Example response (404 — deleted/inaccessible deployment):**
```json
{ "error": "Deployment not found or access denied" }
```

## Tests

42 tests pass (all new + existing):

- **Route tests (9):** 401, 400 bad JSON, 400 missing deploymentId, 400 invalid config with field details, 404 draft not found, 404 deployment not found, 200 success, correct args forwarded, 500 unexpected error
- **Service tests (5):** draft not found, validation failure with `.validationErrors`, correct args to `updateDeployment`, result passthrough, error propagation

## Edge cases covered
- Draft references a deleted/inaccessible deployment → `404` with clear message
- Invalid draft config → `400` with field-level validation details
- Unauthorized access → `401`

Closes #484