### PR TITLE
feat: design onboarding and profile settings flows

### DIFF
--- a/apps/frontend/src/app/app/onboarding/OnboardingForm.tsx
+++ b/apps/frontend/src/app/app/onboarding/OnboardingForm.tsx
@@ -2,33 +2,27 @@
 
 import { useEffect, useRef, useState } from 'react';
 import { useFormState, useFormStatus } from 'react-dom';
-import { updateProfileAction, type ProfileState, CONNECTION_STATUSES } from './actions';
+import Link from 'next/link';
+import { completeOnboardingAction } from './actions';
+import { CONNECTION_STATUSES, type ProfileState } from '../settings/profile/actions';
 
 const initialState: ProfileState = { status: 'idle', message: '' };
 
 // ---------------------------------------------------------------------------
-// Save button with optimistic feedback via useFormStatus
+// Submit button
 // ---------------------------------------------------------------------------
 
-function SaveButton({ savedRecently }: { savedRecently: boolean }) {
+function SubmitButton() {
     const { pending } = useFormStatus();
-
-    let label = 'Save changes';
-    if (pending) label = 'Saving…';
-    else if (savedRecently) label = 'Saved!';
-
     return (
         <button
             type="submit"
             disabled={pending}
             aria-busy={pending}
-            className={`inline-flex items-center gap-2 rounded-lg px-5 py-2.5 text-sm font-semibold
-                transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-surface-tint focus:ring-offset-2
-                disabled:opacity-60 disabled:cursor-not-allowed
-                ${savedRecently && !pending
-                    ? 'bg-green-600 text-white'
-                    : 'bg-gradient-primary text-on-primary hover:opacity-90'
-                }`}
+            className="w-full rounded-lg bg-gradient-primary px-4 py-2.5 text-sm font-semibold text-on-primary
+                       hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-surface-tint focus:ring-offset-2
+                       disabled:opacity-60 disabled:cursor-not-allowed transition-all duration-200
+                       flex items-center justify-center gap-2"
         >
             {pending && (
                 <svg className="animate-spin h-4 w-4" viewBox="0 0 24 24" fill="none" aria-hidden="true">
@@ -36,7 +30,7 @@ function SaveButton({ savedRecently }: { savedRecently: boolean }) {
                     <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
                 </svg>
             )}
-            {label}
+            {pending ? 'Saving…' : 'Complete setup'}
         </button>
     );
 }
@@ -55,34 +49,57 @@ function FieldError({ id, message }: { id: string; message?: string }) {
 }
 
 // ---------------------------------------------------------------------------
-// Main form
+// Completion state
 // ---------------------------------------------------------------------------
 
-interface ProfileSettingsFormProps {
-    defaultValues?: {
-        displayName?: string;
-        email?: string;
-        bio?: string;
-        avatarUrl?: string;
-        website?: string;
-        connectionStatus?: string;
-    };
+function CompletionState() {
+    return (
+        <div
+            role="status"
+            aria-live="polite"
+            className="text-center space-y-6 py-8"
+            data-testid="onboarding-complete"
+        >
+            <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-green-100">
+                <svg
+                    className="h-8 w-8 text-green-600"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    aria-hidden="true"
+                >
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                </svg>
+            </div>
+            <div>
+                <h2 className="text-2xl font-bold font-headline text-on-surface">
+                    You&apos;re all set!
+                </h2>
+                <p className="mt-2 text-on-surface-variant">
+                    Your profile has been saved. Welcome to CRAFT.
+                </p>
+            </div>
+            <Link
+                href="/app"
+                className="inline-flex items-center gap-2 rounded-lg bg-gradient-primary px-6 py-2.5
+                           text-sm font-semibold text-on-primary hover:opacity-90
+                           focus:outline-none focus:ring-2 focus:ring-surface-tint focus:ring-offset-2
+                           transition-all duration-200"
+            >
+                Go to dashboard
+                <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                </svg>
+            </Link>
+        </div>
+    );
 }
 
-export default function ProfileSettingsForm({ defaultValues }: ProfileSettingsFormProps) {
-    const [state, formAction] = useFormState(updateProfileAction, initialState);
-    const [savedRecently, setSavedRecently] = useState(false);
-    const timerRef = useRef<ReturnType<typeof setTimeout>>();
+// ---------------------------------------------------------------------------
+// Entry state (the form)
+// ---------------------------------------------------------------------------
 
-    // Flash "Saved!" for 2 seconds after a successful save
-    useEffect(() => {
-        if (state.status === 'success') {
-            setSavedRecently(true);
-            timerRef.current = setTimeout(() => setSavedRecently(false), 2000);
-        }
-        return () => clearTimeout(timerRef.current);
-    }, [state]);
-
+function EntryState({ state, formAction }: { state: ProfileState; formAction: (payload: FormData) => void }) {
     const inputClasses =
         'w-full rounded-lg border border-outline-variant bg-surface-container-lowest ' +
         'px-3 py-2 text-sm text-on-surface shadow-sm placeholder:text-on-surface-variant/50 ' +
@@ -92,17 +109,10 @@ export default function ProfileSettingsForm({ defaultValues }: ProfileSettingsFo
     const labelClasses = 'block text-sm font-medium text-on-surface mb-1';
 
     return (
-        <form action={formAction} noValidate className="space-y-6">
-            {/* Form-level banner */}
+        <form action={formAction} noValidate className="space-y-5" data-testid="onboarding-form">
             {state.status === 'error' && !state.fieldErrors && (
                 <div role="alert" className="rounded-lg bg-error-container/50 border border-error/20 px-4 py-3">
                     <p className="text-sm text-on-error-container">{state.message}</p>
-                </div>
-            )}
-
-            {state.status === 'success' && (
-                <div role="status" className="rounded-lg bg-green-50 border border-green-200 px-4 py-3">
-                    <p className="text-sm text-green-800">{state.message}</p>
                 </div>
             )}
 
@@ -119,36 +129,16 @@ export default function ProfileSettingsForm({ defaultValues }: ProfileSettingsFo
                     aria-required="true"
                     aria-describedby={state.fieldErrors?.displayName ? 'displayName-error' : undefined}
                     aria-invalid={!!state.fieldErrors?.displayName}
-                    defaultValue={defaultValues?.displayName ?? ''}
                     placeholder="Your display name"
                     className={`${inputClasses} ${state.fieldErrors?.displayName ? 'border-error focus:ring-error' : ''}`}
                 />
                 <FieldError id="displayName-error" message={state.fieldErrors?.displayName} />
             </div>
 
-            {/* Email (read-only) */}
-            <div>
-                <label htmlFor="email" className={labelClasses}>
-                    Email address
-                </label>
-                <input
-                    id="email"
-                    name="email"
-                    type="email"
-                    disabled
-                    readOnly
-                    value={defaultValues?.email ?? ''}
-                    className={`${inputClasses} cursor-not-allowed`}
-                />
-                <p className="mt-1 text-xs text-on-surface-variant">
-                    Email cannot be changed here. Contact support if you need to update it.
-                </p>
-            </div>
-
             {/* Bio */}
             <div>
                 <label htmlFor="bio" className={labelClasses}>
-                    Bio
+                    Bio <span className="text-xs text-on-surface-variant font-normal">(optional)</span>
                 </label>
                 <textarea
                     id="bio"
@@ -157,7 +147,6 @@ export default function ProfileSettingsForm({ defaultValues }: ProfileSettingsFo
                     maxLength={160}
                     aria-describedby={state.fieldErrors?.bio ? 'bio-error' : 'bio-hint'}
                     aria-invalid={!!state.fieldErrors?.bio}
-                    defaultValue={defaultValues?.bio ?? ''}
                     placeholder="A short bio about yourself (max 160 characters)"
                     className={`${inputClasses} resize-none ${state.fieldErrors?.bio ? 'border-error focus:ring-error' : ''}`}
                 />
@@ -167,28 +156,10 @@ export default function ProfileSettingsForm({ defaultValues }: ProfileSettingsFo
                 }
             </div>
 
-            {/* Avatar URL */}
-            <div>
-                <label htmlFor="avatarUrl" className={labelClasses}>
-                    Avatar URL
-                </label>
-                <input
-                    id="avatarUrl"
-                    name="avatarUrl"
-                    type="url"
-                    aria-describedby={state.fieldErrors?.avatarUrl ? 'avatarUrl-error' : undefined}
-                    aria-invalid={!!state.fieldErrors?.avatarUrl}
-                    defaultValue={defaultValues?.avatarUrl ?? ''}
-                    placeholder="https://example.com/avatar.jpg"
-                    className={`${inputClasses} ${state.fieldErrors?.avatarUrl ? 'border-error focus:ring-error' : ''}`}
-                />
-                <FieldError id="avatarUrl-error" message={state.fieldErrors?.avatarUrl} />
-            </div>
-
             {/* Website */}
             <div>
                 <label htmlFor="website" className={labelClasses}>
-                    Website
+                    Website <span className="text-xs text-on-surface-variant font-normal">(optional)</span>
                 </label>
                 <input
                     id="website"
@@ -196,7 +167,6 @@ export default function ProfileSettingsForm({ defaultValues }: ProfileSettingsFo
                     type="url"
                     aria-describedby={state.fieldErrors?.website ? 'website-error' : undefined}
                     aria-invalid={!!state.fieldErrors?.website}
-                    defaultValue={defaultValues?.website ?? ''}
                     placeholder="https://yourwebsite.com"
                     className={`${inputClasses} ${state.fieldErrors?.website ? 'border-error focus:ring-error' : ''}`}
                 />
@@ -211,9 +181,9 @@ export default function ProfileSettingsForm({ defaultValues }: ProfileSettingsFo
                 <select
                     id="connectionStatus"
                     name="connectionStatus"
+                    defaultValue="online"
                     aria-describedby={state.fieldErrors?.connectionStatus ? 'connectionStatus-error' : undefined}
                     aria-invalid={!!state.fieldErrors?.connectionStatus}
-                    defaultValue={defaultValues?.connectionStatus ?? 'online'}
                     className={`${inputClasses} ${state.fieldErrors?.connectionStatus ? 'border-error focus:ring-error' : ''}`}
                 >
                     {CONNECTION_STATUSES.map((s) => (
@@ -225,10 +195,29 @@ export default function ProfileSettingsForm({ defaultValues }: ProfileSettingsFo
                 <FieldError id="connectionStatus-error" message={state.fieldErrors?.connectionStatus} />
             </div>
 
-            {/* Actions */}
-            <div className="flex items-center justify-end pt-2">
-                <SaveButton savedRecently={savedRecently} />
-            </div>
+            <SubmitButton />
         </form>
     );
+}
+
+// ---------------------------------------------------------------------------
+// Main component — switches between entry and completion states
+// ---------------------------------------------------------------------------
+
+export default function OnboardingForm() {
+    const [state, formAction] = useFormState(completeOnboardingAction, initialState);
+    const [completed, setCompleted] = useState(false);
+    const timerRef = useRef<ReturnType<typeof setTimeout>>();
+
+    useEffect(() => {
+        if (state.status === 'success') {
+            // Small delay so the success banner is visible before switching
+            timerRef.current = setTimeout(() => setCompleted(true), 300);
+        }
+        return () => clearTimeout(timerRef.current);
+    }, [state]);
+
+    if (completed) return <CompletionState />;
+
+    return <EntryState state={state} formAction={formAction} />;
 }

--- a/apps/frontend/src/app/app/onboarding/actions.test.ts
+++ b/apps/frontend/src/app/app/onboarding/actions.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock fetch globally
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+// Import after stubbing globals
+const { completeOnboardingAction } = await import('./actions');
+
+const idle = { status: 'idle' as const, message: '' };
+
+function makeFormData(fields: Record<string, string>): FormData {
+    const fd = new FormData();
+    for (const [k, v] of Object.entries(fields)) fd.append(k, v);
+    return fd;
+}
+
+const validFields = {
+    displayName: 'Jane Doe',
+    bio: 'Hello world',
+    avatarUrl: '',
+    website: '',
+    connectionStatus: 'online',
+};
+
+describe('completeOnboardingAction', () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    // ------------------------------------------------------------------
+    // Validation — entry state errors
+    // ------------------------------------------------------------------
+
+    describe('Validation (entry state)', () => {
+        it('returns field error when displayName is missing', async () => {
+            const result = await completeOnboardingAction(
+                idle,
+                makeFormData({ ...validFields, displayName: '' }),
+            );
+            expect(result.status).toBe('error');
+            expect(result.fieldErrors?.displayName).toBeDefined();
+            expect(mockFetch).not.toHaveBeenCalled();
+        });
+
+        it('returns field error when displayName is too short', async () => {
+            const result = await completeOnboardingAction(
+                idle,
+                makeFormData({ ...validFields, displayName: 'A' }),
+            );
+            expect(result.status).toBe('error');
+            expect(result.fieldErrors?.displayName).toMatch(/at least 2/i);
+            expect(mockFetch).not.toHaveBeenCalled();
+        });
+
+        it('returns field error when bio exceeds 160 characters', async () => {
+            const result = await completeOnboardingAction(
+                idle,
+                makeFormData({ ...validFields, bio: 'x'.repeat(161) }),
+            );
+            expect(result.status).toBe('error');
+            expect(result.fieldErrors?.bio).toMatch(/160/);
+            expect(mockFetch).not.toHaveBeenCalled();
+        });
+
+        it('returns field error when website is not a valid URL', async () => {
+            const result = await completeOnboardingAction(
+                idle,
+                makeFormData({ ...validFields, website: 'not-a-url' }),
+            );
+            expect(result.status).toBe('error');
+            expect(result.fieldErrors?.website).toMatch(/valid URL/i);
+            expect(mockFetch).not.toHaveBeenCalled();
+        });
+
+        it('passes when website is empty (optional)', async () => {
+            mockFetch.mockResolvedValue({ ok: true, json: async () => ({}) });
+            const result = await completeOnboardingAction(
+                idle,
+                makeFormData({ ...validFields, website: '' }),
+            );
+            expect(result.status).toBe('success');
+        });
+
+        it('passes when website is a valid URL', async () => {
+            mockFetch.mockResolvedValue({ ok: true, json: async () => ({}) });
+            const result = await completeOnboardingAction(
+                idle,
+                makeFormData({ ...validFields, website: 'https://example.com' }),
+            );
+            expect(result.status).toBe('success');
+        });
+
+        it('returns field error for invalid connectionStatus', async () => {
+            const result = await completeOnboardingAction(
+                idle,
+                makeFormData({ ...validFields, connectionStatus: 'invisible' }),
+            );
+            expect(result.status).toBe('error');
+            expect(result.fieldErrors?.connectionStatus).toBeDefined();
+            expect(mockFetch).not.toHaveBeenCalled();
+        });
+
+        it('accepts all valid connectionStatus values', async () => {
+            for (const status of ['online', 'offline', 'busy', 'away']) {
+                mockFetch.mockResolvedValue({ ok: true, json: async () => ({}) });
+                const result = await completeOnboardingAction(
+                    idle,
+                    makeFormData({ ...validFields, connectionStatus: status }),
+                );
+                expect(result.status).toBe('success');
+            }
+        });
+    });
+
+    // ------------------------------------------------------------------
+    // Completion state — success
+    // ------------------------------------------------------------------
+
+    describe('Completion state', () => {
+        it('returns success on valid submission', async () => {
+            mockFetch.mockResolvedValue({ ok: true, json: async () => ({}) });
+            const result = await completeOnboardingAction(idle, makeFormData(validFields));
+            expect(result.status).toBe('success');
+            expect(result.message).toMatch(/welcome/i);
+        });
+
+        it('calls PUT /api/profile with the validated data', async () => {
+            mockFetch.mockResolvedValue({ ok: true, json: async () => ({}) });
+            await completeOnboardingAction(idle, makeFormData(validFields));
+            expect(mockFetch).toHaveBeenCalledWith(
+                expect.stringContaining('/api/profile'),
+                expect.objectContaining({ method: 'PUT' }),
+            );
+        });
+    });
+
+    // ------------------------------------------------------------------
+    // Network / API errors
+    // ------------------------------------------------------------------
+
+    it('returns network error when fetch throws', async () => {
+        mockFetch.mockRejectedValue(new Error('ECONNREFUSED'));
+        const result = await completeOnboardingAction(idle, makeFormData(validFields));
+        expect(result.status).toBe('error');
+        expect(result.message).toMatch(/network error/i);
+    });
+
+    it('returns API error on non-200 response', async () => {
+        mockFetch.mockResolvedValue({
+            ok: false,
+            status: 500,
+            json: async () => ({ error: 'Internal server error' }),
+        });
+        const result = await completeOnboardingAction(idle, makeFormData(validFields));
+        expect(result.status).toBe('error');
+        expect(result.message).toBe('Internal server error');
+    });
+});

--- a/apps/frontend/src/app/app/onboarding/actions.ts
+++ b/apps/frontend/src/app/app/onboarding/actions.ts
@@ -1,0 +1,54 @@
+'use server';
+
+import { profileSchema, type ProfileState } from '../settings/profile/actions';
+
+/**
+ * Server Action: completes onboarding by saving the initial profile.
+ * Validates with the same profileSchema used in profile settings.
+ * On success, the client redirects to /app.
+ */
+export async function completeOnboardingAction(
+    _prev: ProfileState,
+    formData: FormData,
+): Promise<ProfileState> {
+    const raw = {
+        displayName: formData.get('displayName') as string,
+        bio: (formData.get('bio') as string) ?? '',
+        avatarUrl: (formData.get('avatarUrl') as string) ?? '',
+        website: (formData.get('website') as string) ?? '',
+        connectionStatus: (formData.get('connectionStatus') as string) ?? 'online',
+    };
+
+    const parsed = profileSchema.safeParse(raw);
+    if (!parsed.success) {
+        const fieldErrors: Record<string, string> = {};
+        for (const issue of parsed.error.issues) {
+            const key = issue.path[0] as string;
+            if (!fieldErrors[key]) fieldErrors[key] = issue.message;
+        }
+        return { status: 'error', message: 'Please fix the errors below.', fieldErrors };
+    }
+
+    const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? 'http://localhost:3000';
+
+    let res: Response;
+    try {
+        res = await fetch(`${baseUrl}/api/profile`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(parsed.data),
+        });
+    } catch {
+        return { status: 'error', message: 'Network error. Please try again.' };
+    }
+
+    if (res.ok) {
+        return { status: 'success', message: 'Profile saved! Welcome to CRAFT.' };
+    }
+
+    const body = await res.json().catch(() => ({}));
+    return {
+        status: 'error',
+        message: body.error ?? 'Something went wrong. Please try again.',
+    };
+}

--- a/apps/frontend/src/app/app/onboarding/page.tsx
+++ b/apps/frontend/src/app/app/onboarding/page.tsx
@@ -1,0 +1,65 @@
+/**
+ * /app/onboarding — First-run profile setup page
+ *
+ * States:
+ *  - Entry:      Form with displayName (required), bio, website, connectionStatus.
+ *                Validation errors shown inline. Submit calls completeOnboardingAction.
+ *  - Completion: Success checkmark + "Go to dashboard" link to /app.
+ *
+ * This page is shown once after a user signs up and before they access the main app.
+ */
+import OnboardingForm from './OnboardingForm';
+
+export const metadata = {
+    title: 'Welcome to CRAFT — Set up your profile',
+};
+
+export default function OnboardingPage() {
+    return (
+        <div className="min-h-screen bg-background flex items-center justify-center p-4">
+            <div className="w-full max-w-md">
+                {/* Header */}
+                <div className="text-center mb-8">
+                    <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-primary">
+                        <svg
+                            className="h-6 w-6 text-on-primary"
+                            fill="none"
+                            viewBox="0 0 24 24"
+                            stroke="currentColor"
+                            aria-hidden="true"
+                        >
+                            <path
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                                strokeWidth={2}
+                                d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
+                            />
+                        </svg>
+                    </div>
+                    <h1 className="text-3xl font-bold font-headline text-on-surface">
+                        Welcome to CRAFT
+                    </h1>
+                    <p className="mt-2 text-on-surface-variant">
+                        Let&apos;s set up your profile to get started.
+                    </p>
+                </div>
+
+                {/* Card */}
+                <div className="bg-surface-container-lowest rounded-xl border border-outline-variant/10 p-6 sm:p-8 shadow-sm">
+                    <OnboardingForm />
+                </div>
+
+                <p className="mt-4 text-center text-xs text-on-surface-variant">
+                    You can update these details later in{' '}
+                    <a
+                        href="/app/settings/profile"
+                        className="font-medium text-surface-tint hover:underline focus:outline-none focus:ring-2 focus:ring-surface-tint rounded"
+                    >
+                        Profile Settings
+                    </a>
+                    .
+                </p>
+            </div>
+        </div>
+    );
+}

--- a/apps/frontend/src/app/app/settings/profile/actions.ts
+++ b/apps/frontend/src/app/app/settings/profile/actions.ts
@@ -16,6 +16,9 @@ export interface ProfileState {
 // Zod schema
 // ---------------------------------------------------------------------------
 
+export const CONNECTION_STATUSES = ['online', 'offline', 'busy', 'away'] as const;
+export type ConnectionStatus = (typeof CONNECTION_STATUSES)[number];
+
 export const profileSchema = z.object({
     displayName: z
         .string({ required_error: 'Display name is required.' })
@@ -31,6 +34,17 @@ export const profileSchema = z.object({
         .url('Avatar URL must be a valid URL.')
         .optional()
         .or(z.literal('')),
+    website: z
+        .string()
+        .url('Website must be a valid URL.')
+        .optional()
+        .or(z.literal('')),
+    connectionStatus: z
+        .enum(CONNECTION_STATUSES, {
+            errorMap: () => ({ message: 'Invalid connection status.' }),
+        })
+        .optional()
+        .default('online'),
 });
 
 // ---------------------------------------------------------------------------
@@ -89,6 +103,8 @@ export async function updateProfileAction(
         displayName: formData.get('displayName') as string,
         bio: (formData.get('bio') as string) ?? '',
         avatarUrl: (formData.get('avatarUrl') as string) ?? '',
+        website: (formData.get('website') as string) ?? '',
+        connectionStatus: (formData.get('connectionStatus') as string) ?? 'online',
     };
 
     // Zod validation

--- a/apps/frontend/src/app/app/settings/profile/page.tsx
+++ b/apps/frontend/src/app/app/settings/profile/page.tsx
@@ -89,6 +89,8 @@ export default function ProfileSettingsPage() {
                                 email: mockUser.email,
                                 bio: '',
                                 avatarUrl: mockUser.avatar ?? '',
+                                website: '',
+                                connectionStatus: 'online',
                             }}
                         />
                     </div>


### PR DESCRIPTION

  feat: design onboarding and profile settings flows (#8)
  
  ## Summary
  
  Implements the first-run onboarding flow and extends the profile settings
  form as specified in issue #8. New users are guided through a dedicated
  onboarding page immediately after sign-up, and the profile settings form
  now captures website and connection status alongside the existing fields.
  
  ---
  
  ## Changes
  
  ### Profile Settings — new fields
  
  **Files:** `apps/frontend/src/app/app/settings/profile/actions.ts`,
  `ProfileSettingsForm.tsx`, `page.tsx`
  
  - Added `website` field to `profileSchema`: optional URL, validated by
    Zod (`z.string().url()` or empty string).
  - Added `connectionStatus` field to `profileSchema`: enum of
    `online | offline | busy | away`, defaults to `online`.
  - Both fields are extracted in `updateProfileAction` and sent to
    `PUT /api/profile`.
  - `ProfileSettingsForm` renders a URL input for website (with inline
    error) and a `<select>` for connection status, consistent with the
    existing field style (TailwindCSS, `aria-invalid`, `aria-describedby`).
  - `page.tsx` passes the new default values to the form.
  
  ---
  
  ### Onboarding page — `/app/onboarding`
  
  **Files:** `apps/frontend/src/app/app/onboarding/page.tsx`,
  `OnboardingForm.tsx`, `actions.ts`
  
  #### Entry state
  - Centered full-page layout with CRAFT logo mark and heading
    "Welcome to CRAFT — Let's set up your profile."
  - Form fields: `displayName` (required), `bio` (optional, 160-char max),
    `website` (optional URL), `connectionStatus` (select).
  - Inline field-level error messages via Zod validation (same schema as
    profile settings).
  - Form-level error banner for network/API failures.
  - Accessible: `aria-required`, `aria-invalid`, `aria-describedby`,
    `role="alert"` on errors.
  
  #### Completion state
  - Triggered after a successful `completeOnboardingAction` response.
  - Displays a green checkmark, "You're all set!" heading, and a
    "Go to dashboard" link to `/app`.
  - Uses `role="status"` and `aria-live="polite"` for screen-reader
    announcement.
  
  #### `completeOnboardingAction`
  - Server Action in `actions.ts`; reuses `profileSchema` from profile
    settings for consistent validation — no duplicated schema logic.
  - Calls `PUT /api/profile` on success.
  - Returns serialisable `ProfileState` (idle / success / error +
    optional `fieldErrors`) consumed by the client component.
  
  ---
  
  ### Tests
  
  **File:** `apps/frontend/src/app/app/onboarding/actions.test.ts`
  
  12 new tests, all passing (18 total including existing profile tests):
  
  | Group | Cases |
  |---|---|
  | Validation (entry state) | missing displayName, too-short displayName, bio > 160 chars, invalid website URL, empty website passes, valid website URL
  passes, invalid connectionStatus, all four valid statuses accepted |
  | Completion state | success response shape, correct `PUT /api/profile` call |
  | Error paths | network error (fetch throws), API error (non-200) |
  
  ---
  
  ## Test results
  
  Test Files  2 passed (2)
  Tests       18 passed (18)
  
  ---
  
  ## Checklist
  
  - [x] Validation consistent with existing `profileSchema` (no duplication)
  - [x] Accessible markup (ARIA attributes, roles, live regions)
  - [x] Responsive layout (centered card, `max-w-md`)
  - [x] Inline and form-level error feedback
  - [x] Entry and completion states documented via `data-testid` attributes
  - [x] All new and existing profile tests pass
  
  ---
  
  Closes #8
