### PR TITLE
feat: stellar configuration panel

### DIFF
--- a/apps/frontend/src/components/app/stellar/AssetPairEditor.tsx
+++ b/apps/frontend/src/components/app/stellar/AssetPairEditor.tsx
@@ -1,0 +1,189 @@
+'use client';
+
+import React, { useState } from 'react';
+import type { AssetPair, StellarAsset, StellarAssetType } from '@craft/types';
+
+interface AssetPairEditorProps {
+    pairs: AssetPair[];
+    onAdd: (pair: AssetPair) => void;
+    onRemove: (index: number) => void;
+    error?: string;
+}
+
+const EMPTY_ASSET: StellarAsset = { code: '', issuer: '', type: 'credit_alphanum4' };
+const EMPTY_PAIR: AssetPair = { base: { ...EMPTY_ASSET }, counter: { ...EMPTY_ASSET } };
+
+function assetLabel(asset: StellarAsset): string {
+    if (asset.type === 'native') return 'XLM (native)';
+    return asset.issuer ? `${asset.code}:${asset.issuer.slice(0, 8)}…` : asset.code;
+}
+
+function AssetFields({
+    prefix,
+    asset,
+    onChange,
+}: {
+    prefix: string;
+    asset: StellarAsset;
+    onChange: (a: StellarAsset) => void;
+}) {
+    const isNative = asset.type === 'native';
+    return (
+        <div className="flex flex-col gap-2">
+            <div className="flex gap-2 items-center">
+                <label htmlFor={`${prefix}-type`} className="text-xs text-on-surface-variant w-12 shrink-0">
+                    Type
+                </label>
+                <select
+                    id={`${prefix}-type`}
+                    value={asset.type}
+                    onChange={(e) =>
+                        onChange({
+                            ...asset,
+                            type: e.target.value as StellarAssetType,
+                            code: e.target.value === 'native' ? 'XLM' : asset.code,
+                            issuer: e.target.value === 'native' ? '' : asset.issuer,
+                        })
+                    }
+                    className="flex-1 rounded border border-outline-variant/30 px-2 py-1 text-xs bg-surface-container-lowest text-on-surface"
+                >
+                    <option value="native">Native (XLM)</option>
+                    <option value="credit_alphanum4">Alphanum-4</option>
+                    <option value="credit_alphanum12">Alphanum-12</option>
+                </select>
+            </div>
+            {!isNative && (
+                <>
+                    <div className="flex gap-2 items-center">
+                        <label htmlFor={`${prefix}-code`} className="text-xs text-on-surface-variant w-12 shrink-0">
+                            Code
+                        </label>
+                        <input
+                            id={`${prefix}-code`}
+                            type="text"
+                            value={asset.code}
+                            onChange={(e) => onChange({ ...asset, code: e.target.value.toUpperCase() })}
+                            placeholder="USDC"
+                            maxLength={12}
+                            className="flex-1 rounded border border-outline-variant/30 px-2 py-1 text-xs bg-surface-container-lowest text-on-surface placeholder:text-on-surface-variant/50"
+                        />
+                    </div>
+                    <div className="flex gap-2 items-center">
+                        <label htmlFor={`${prefix}-issuer`} className="text-xs text-on-surface-variant w-12 shrink-0">
+                            Issuer
+                        </label>
+                        <input
+                            id={`${prefix}-issuer`}
+                            type="text"
+                            value={asset.issuer}
+                            onChange={(e) => onChange({ ...asset, issuer: e.target.value })}
+                            placeholder="G…"
+                            className="flex-1 rounded border border-outline-variant/30 px-2 py-1 text-xs bg-surface-container-lowest text-on-surface placeholder:text-on-surface-variant/50 font-mono"
+                        />
+                    </div>
+                </>
+            )}
+        </div>
+    );
+}
+
+export function AssetPairEditor({ pairs, onAdd, onRemove, error }: AssetPairEditorProps) {
+    const [draft, setDraft] = useState<AssetPair>(EMPTY_PAIR);
+    const [open, setOpen] = useState(false);
+
+    function handleAdd() {
+        onAdd(draft);
+        setDraft(EMPTY_PAIR);
+        setOpen(false);
+    }
+
+    const canAdd =
+        (draft.base.type === 'native' || (draft.base.code && draft.base.issuer)) &&
+        (draft.counter.type === 'native' || (draft.counter.code && draft.counter.issuer));
+
+    return (
+        <div className="flex flex-col gap-2">
+            <div className="flex items-center justify-between">
+                <span className="text-sm font-medium text-on-surface">Asset Pairs</span>
+                <button
+                    type="button"
+                    onClick={() => setOpen((v) => !v)}
+                    aria-expanded={open}
+                    className="text-xs px-2.5 py-1 rounded border border-outline-variant/30 text-on-surface-variant hover:bg-surface-container-low transition-colors"
+                >
+                    {open ? 'Cancel' : '+ Add pair'}
+                </button>
+            </div>
+
+            {error && (
+                <p role="alert" className="text-xs text-error">
+                    {error}
+                </p>
+            )}
+
+            {pairs.length > 0 && (
+                <ul className="flex flex-col gap-1.5" aria-label="Asset pairs">
+                    {pairs.map((pair, i) => (
+                        <li
+                            key={i}
+                            className="flex items-center justify-between rounded-lg border border-outline-variant/20 px-3 py-2 bg-surface-container-lowest text-sm"
+                        >
+                            <span className="text-on-surface font-mono text-xs">
+                                {assetLabel(pair.base)} / {assetLabel(pair.counter)}
+                            </span>
+                            <button
+                                type="button"
+                                onClick={() => onRemove(i)}
+                                aria-label={`Remove pair ${assetLabel(pair.base)} / ${assetLabel(pair.counter)}`}
+                                className="text-on-surface-variant hover:text-error transition-colors text-xs ml-2"
+                            >
+                                ✕
+                            </button>
+                        </li>
+                    ))}
+                </ul>
+            )}
+
+            {pairs.length === 0 && !open && (
+                <p className="text-xs text-on-surface-variant">No asset pairs configured.</p>
+            )}
+
+            {open && (
+                <div className="rounded-lg border border-outline-variant/30 p-4 bg-surface-container-low flex flex-col gap-4">
+                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                        <div className="flex flex-col gap-1.5">
+                            <span className="text-xs font-semibold text-on-surface-variant uppercase tracking-wide">
+                                Base asset
+                            </span>
+                            <AssetFields
+                                prefix="base"
+                                asset={draft.base}
+                                onChange={(a) => setDraft((d) => ({ ...d, base: a }))}
+                            />
+                        </div>
+                        <div className="flex flex-col gap-1.5">
+                            <span className="text-xs font-semibold text-on-surface-variant uppercase tracking-wide">
+                                Counter asset
+                            </span>
+                            <AssetFields
+                                prefix="counter"
+                                asset={draft.counter}
+                                onChange={(a) => setDraft((d) => ({ ...d, counter: a }))}
+                            />
+                        </div>
+                    </div>
+                    <div className="flex justify-end">
+                        <button
+                            type="button"
+                            onClick={handleAdd}
+                            disabled={!canAdd}
+                            className="px-3 py-1.5 rounded-lg text-sm font-semibold text-on-primary primary-gradient shadow-sm disabled:opacity-40 disabled:cursor-not-allowed transition-all"
+                        >
+                            Add pair
+                        </button>
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/apps/frontend/src/components/app/stellar/ContractAddressInputs.tsx
+++ b/apps/frontend/src/components/app/stellar/ContractAddressInputs.tsx
@@ -1,0 +1,159 @@
+'use client';
+
+import React, { useState } from 'react';
+import { validateContractAddress } from '@/lib/stellar/contract-validation';
+
+interface ContractAddressInputsProps {
+    contracts: Record<string, string>;
+    onSet: (name: string, address: string) => void;
+    onRemove: (name: string) => void;
+    /** Field-level errors keyed by `stellar.contractAddresses.<name>` */
+    errors?: Map<string, string>;
+}
+
+export function ContractAddressInputs({
+    contracts,
+    onSet,
+    onRemove,
+    errors,
+}: ContractAddressInputsProps) {
+    const [newName, setNewName] = useState('');
+    const [newAddress, setNewAddress] = useState('');
+    const [addError, setAddError] = useState<string | null>(null);
+    const [open, setOpen] = useState(false);
+
+    function handleAdd() {
+        const trimmedName = newName.trim();
+        const trimmedAddress = newAddress.trim();
+
+        if (!trimmedName) {
+            setAddError('Contract name is required');
+            return;
+        }
+        if (trimmedName in contracts) {
+            setAddError(`A contract named "${trimmedName}" already exists`);
+            return;
+        }
+        const result = validateContractAddress(trimmedAddress);
+        if (!result.valid) {
+            setAddError(result.reason);
+            return;
+        }
+
+        onSet(trimmedName, trimmedAddress);
+        setNewName('');
+        setNewAddress('');
+        setAddError(null);
+        setOpen(false);
+    }
+
+    const entries = Object.entries(contracts);
+
+    return (
+        <div className="flex flex-col gap-2">
+            <div className="flex items-center justify-between">
+                <span className="text-sm font-medium text-on-surface">Contract Addresses</span>
+                <button
+                    type="button"
+                    onClick={() => {
+                        setOpen((v) => !v);
+                        setAddError(null);
+                    }}
+                    aria-expanded={open}
+                    className="text-xs px-2.5 py-1 rounded border border-outline-variant/30 text-on-surface-variant hover:bg-surface-container-low transition-colors"
+                >
+                    {open ? 'Cancel' : '+ Add contract'}
+                </button>
+            </div>
+
+            {entries.length > 0 && (
+                <ul className="flex flex-col gap-2" aria-label="Contract addresses">
+                    {entries.map(([name, address]) => {
+                        const fieldError = errors?.get(`stellar.contractAddresses.${name}`);
+                        return (
+                            <li key={name} className="flex flex-col gap-0.5">
+                                <div className="flex items-center justify-between rounded-lg border border-outline-variant/20 px-3 py-2 bg-surface-container-lowest">
+                                    <div className="flex flex-col gap-0.5 min-w-0">
+                                        <span className="text-xs font-semibold text-on-surface">{name}</span>
+                                        <span className="text-xs font-mono text-on-surface-variant truncate">
+                                            {address}
+                                        </span>
+                                    </div>
+                                    <button
+                                        type="button"
+                                        onClick={() => onRemove(name)}
+                                        aria-label={`Remove contract ${name}`}
+                                        className="text-on-surface-variant hover:text-error transition-colors text-xs ml-2 shrink-0"
+                                    >
+                                        ✕
+                                    </button>
+                                </div>
+                                {fieldError && (
+                                    <p role="alert" className="text-xs text-error pl-1">
+                                        {fieldError}
+                                    </p>
+                                )}
+                            </li>
+                        );
+                    })}
+                </ul>
+            )}
+
+            {entries.length === 0 && !open && (
+                <p className="text-xs text-on-surface-variant">No contract addresses configured.</p>
+            )}
+
+            {open && (
+                <div className="rounded-lg border border-outline-variant/30 p-4 bg-surface-container-low flex flex-col gap-3">
+                    <div className="flex flex-col gap-1.5">
+                        <label htmlFor="contract-name" className="text-xs font-medium text-on-surface">
+                            Contract name
+                        </label>
+                        <input
+                            id="contract-name"
+                            type="text"
+                            value={newName}
+                            onChange={(e) => {
+                                setNewName(e.target.value);
+                                setAddError(null);
+                            }}
+                            placeholder="e.g. amm_pool"
+                            className="rounded border border-outline-variant/30 px-3 py-1.5 text-sm bg-surface-container-lowest text-on-surface placeholder:text-on-surface-variant/50"
+                        />
+                    </div>
+                    <div className="flex flex-col gap-1.5">
+                        <label htmlFor="contract-address" className="text-xs font-medium text-on-surface">
+                            Contract address
+                        </label>
+                        <input
+                            id="contract-address"
+                            type="text"
+                            value={newAddress}
+                            onChange={(e) => {
+                                setNewAddress(e.target.value);
+                                setAddError(null);
+                            }}
+                            placeholder="C…"
+                            className="rounded border border-outline-variant/30 px-3 py-1.5 text-sm font-mono bg-surface-container-lowest text-on-surface placeholder:text-on-surface-variant/50"
+                        />
+                    </div>
+                    {addError && (
+                        <p role="alert" className="text-xs text-error">
+                            {addError}
+                        </p>
+                    )}
+                    <div className="flex justify-end">
+                        <button
+                            type="button"
+                            onClick={handleAdd}
+                            disabled={!newName || !newAddress}
+                            className="px-3 py-1.5 rounded-lg text-sm font-semibold text-on-primary primary-gradient shadow-sm disabled:opacity-40 disabled:cursor-not-allowed transition-all"
+                        >
+                            Add contract
+                        </button>
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/apps/frontend/src/components/app/stellar/HorizonUrlInput.tsx
+++ b/apps/frontend/src/components/app/stellar/HorizonUrlInput.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import React from 'react';
+import type { ConnectivityStatus } from './useStellarConfigForm';
+import type { ConnectivityCheckResult } from '@/lib/stellar/endpoint-connectivity';
+
+interface HorizonUrlInputProps {
+    value: string;
+    onChange: (value: string) => void;
+    onCheckConnectivity: () => void;
+    connectivityStatus: ConnectivityStatus;
+    connectivityResult: ConnectivityCheckResult | null;
+    error?: string;
+    label?: string;
+    id?: string;
+}
+
+const STATUS_ICONS: Record<ConnectivityStatus, string> = {
+    idle: '',
+    checking: '⏳',
+    ok: '✓',
+    error: '✗',
+};
+
+const STATUS_CLASSES: Record<ConnectivityStatus, string> = {
+    idle: 'text-on-surface-variant',
+    checking: 'text-on-surface-variant',
+    ok: 'text-success',
+    error: 'text-error',
+};
+
+export function HorizonUrlInput({
+    value,
+    onChange,
+    onCheckConnectivity,
+    connectivityStatus,
+    connectivityResult,
+    error,
+    label = 'Horizon URL',
+    id = 'horizon-url',
+}: HorizonUrlInputProps) {
+    const hasError = !!error;
+    const statusDescId = `${id}-status`;
+    const errorId = `${id}-error`;
+
+    const statusMessage = (() => {
+        if (connectivityStatus === 'checking') return 'Checking connectivity…';
+        if (connectivityStatus === 'ok') {
+            const ms = connectivityResult?.responseTime;
+            return ms !== undefined ? `Reachable (${Math.round(ms)}ms)` : 'Reachable';
+        }
+        if (connectivityStatus === 'error') {
+            return connectivityResult?.error ?? 'Endpoint unreachable';
+        }
+        return null;
+    })();
+
+    return (
+        <div className="flex flex-col gap-1.5">
+            <label htmlFor={id} className="text-sm font-medium text-on-surface">
+                {label}
+            </label>
+            <div className="flex gap-2">
+                <input
+                    id={id}
+                    type="url"
+                    value={value}
+                    onChange={(e) => onChange(e.target.value)}
+                    placeholder="https://horizon-testnet.stellar.org"
+                    aria-invalid={hasError}
+                    aria-describedby={[hasError ? errorId : '', statusMessage ? statusDescId : '']
+                        .filter(Boolean)
+                        .join(' ') || undefined}
+                    className={`flex-1 rounded-lg border px-3 py-2 text-sm text-on-surface bg-surface-container-lowest placeholder:text-on-surface-variant/50 focus:outline-none focus:ring-2 transition-colors ${
+                        hasError
+                            ? 'border-error focus:ring-error/40'
+                            : 'border-outline-variant/30 focus:ring-primary/40'
+                    }`}
+                />
+                <button
+                    type="button"
+                    onClick={onCheckConnectivity}
+                    disabled={connectivityStatus === 'checking' || !value}
+                    aria-label="Check connectivity"
+                    className="shrink-0 px-3 py-2 rounded-lg border border-outline-variant/30 text-sm text-on-surface-variant hover:bg-surface-container-low transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+                >
+                    {connectivityStatus === 'checking' ? 'Checking…' : 'Check'}
+                </button>
+            </div>
+            {hasError && (
+                <p id={errorId} role="alert" className="text-xs text-error">
+                    {error}
+                </p>
+            )}
+            {statusMessage && (
+                <p
+                    id={statusDescId}
+                    className={`text-xs flex items-center gap-1 ${STATUS_CLASSES[connectivityStatus]}`}
+                >
+                    <span aria-hidden="true">{STATUS_ICONS[connectivityStatus]}</span>
+                    {statusMessage}
+                </p>
+            )}
+        </div>
+    );
+}

--- a/apps/frontend/src/components/app/stellar/NetworkSelector.tsx
+++ b/apps/frontend/src/components/app/stellar/NetworkSelector.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import React from 'react';
+
+type Network = 'mainnet' | 'testnet';
+
+interface NetworkSelectorProps {
+    value: Network;
+    onChange: (value: Network) => void;
+    error?: string;
+}
+
+const NETWORKS: { value: Network; label: string; description: string }[] = [
+    {
+        value: 'testnet',
+        label: 'Testnet',
+        description: 'Stellar test network — safe for development',
+    },
+    {
+        value: 'mainnet',
+        label: 'Mainnet',
+        description: 'Stellar public network — real assets',
+    },
+];
+
+export function NetworkSelector({ value, onChange, error }: NetworkSelectorProps) {
+    const hasError = !!error;
+
+    return (
+        <div className="flex flex-col gap-1.5">
+            <fieldset>
+                <legend className="text-sm font-medium text-on-surface mb-2">
+                    Network
+                </legend>
+                <div
+                    className="flex gap-3"
+                    role="radiogroup"
+                    aria-label="Stellar network"
+                    aria-invalid={hasError}
+                    aria-describedby={hasError ? 'network-error' : undefined}
+                >
+                    {NETWORKS.map((net) => {
+                        const checked = value === net.value;
+                        return (
+                            <label
+                                key={net.value}
+                                className={`flex-1 flex items-start gap-3 rounded-lg border p-3 cursor-pointer transition-colors ${
+                                    checked
+                                        ? 'border-primary bg-primary/5'
+                                        : 'border-outline-variant/30 hover:bg-surface-container-low'
+                                } ${hasError ? 'border-error' : ''}`}
+                            >
+                                <input
+                                    type="radio"
+                                    name="stellar-network"
+                                    value={net.value}
+                                    checked={checked}
+                                    onChange={() => onChange(net.value)}
+                                    className="mt-0.5 accent-primary"
+                                    aria-label={net.label}
+                                />
+                                <div className="flex flex-col gap-0.5">
+                                    <span className="text-sm font-semibold text-on-surface">
+                                        {net.label}
+                                    </span>
+                                    <span className="text-xs text-on-surface-variant">
+                                        {net.description}
+                                    </span>
+                                </div>
+                            </label>
+                        );
+                    })}
+                </div>
+            </fieldset>
+            {hasError && (
+                <p id="network-error" role="alert" className="text-xs text-error">
+                    {error}
+                </p>
+            )}
+        </div>
+    );
+}

--- a/apps/frontend/src/components/app/stellar/SorobanRpcInput.tsx
+++ b/apps/frontend/src/components/app/stellar/SorobanRpcInput.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import React from 'react';
+import type { ConnectivityStatus } from './useStellarConfigForm';
+import type { ConnectivityCheckResult } from '@/lib/stellar/endpoint-connectivity';
+
+interface SorobanRpcInputProps {
+    value: string;
+    onChange: (value: string) => void;
+    onCheckConnectivity: () => void;
+    connectivityStatus: ConnectivityStatus;
+    connectivityResult: ConnectivityCheckResult | null;
+    error?: string;
+}
+
+const STATUS_ICONS: Record<ConnectivityStatus, string> = {
+    idle: '',
+    checking: '⏳',
+    ok: '✓',
+    error: '✗',
+};
+
+const STATUS_CLASSES: Record<ConnectivityStatus, string> = {
+    idle: 'text-on-surface-variant',
+    checking: 'text-on-surface-variant',
+    ok: 'text-success',
+    error: 'text-error',
+};
+
+export function SorobanRpcInput({
+    value,
+    onChange,
+    onCheckConnectivity,
+    connectivityStatus,
+    connectivityResult,
+    error,
+}: SorobanRpcInputProps) {
+    const hasError = !!error;
+    const statusDescId = 'soroban-rpc-status';
+    const errorId = 'soroban-rpc-error';
+
+    const statusMessage = (() => {
+        if (connectivityStatus === 'checking') return 'Checking connectivity…';
+        if (connectivityStatus === 'ok') {
+            const ms = connectivityResult?.responseTime;
+            return ms !== undefined ? `Reachable (${Math.round(ms)}ms)` : 'Reachable';
+        }
+        if (connectivityStatus === 'error') {
+            return connectivityResult?.error ?? 'Endpoint unreachable';
+        }
+        return null;
+    })();
+
+    return (
+        <div className="flex flex-col gap-1.5">
+            <label htmlFor="soroban-rpc-url" className="text-sm font-medium text-on-surface">
+                Soroban RPC URL
+                <span className="ml-1.5 text-xs font-normal text-on-surface-variant">(optional)</span>
+            </label>
+            <div className="flex gap-2">
+                <input
+                    id="soroban-rpc-url"
+                    type="url"
+                    value={value}
+                    onChange={(e) => onChange(e.target.value)}
+                    placeholder="https://soroban-testnet.stellar.org"
+                    aria-invalid={hasError}
+                    aria-describedby={
+                        [hasError ? errorId : '', statusMessage ? statusDescId : '']
+                            .filter(Boolean)
+                            .join(' ') || undefined
+                    }
+                    className={`flex-1 rounded-lg border px-3 py-2 text-sm text-on-surface bg-surface-container-lowest placeholder:text-on-surface-variant/50 focus:outline-none focus:ring-2 transition-colors ${
+                        hasError
+                            ? 'border-error focus:ring-error/40'
+                            : 'border-outline-variant/30 focus:ring-primary/40'
+                    }`}
+                />
+                <button
+                    type="button"
+                    onClick={onCheckConnectivity}
+                    disabled={connectivityStatus === 'checking' || !value}
+                    aria-label="Check Soroban RPC connectivity"
+                    className="shrink-0 px-3 py-2 rounded-lg border border-outline-variant/30 text-sm text-on-surface-variant hover:bg-surface-container-low transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+                >
+                    {connectivityStatus === 'checking' ? 'Checking…' : 'Check'}
+                </button>
+            </div>
+            {hasError && (
+                <p id={errorId} role="alert" className="text-xs text-error">
+                    {error}
+                </p>
+            )}
+            {statusMessage && (
+                <p
+                    id={statusDescId}
+                    className={`text-xs flex items-center gap-1 ${STATUS_CLASSES[connectivityStatus]}`}
+                >
+                    <span aria-hidden="true">{STATUS_ICONS[connectivityStatus]}</span>
+                    {statusMessage}
+                </p>
+            )}
+        </div>
+    );
+}

--- a/apps/frontend/src/components/app/stellar/StellarConfigPanel.tsx
+++ b/apps/frontend/src/components/app/stellar/StellarConfigPanel.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import React from 'react';
+import { NetworkSelector } from './NetworkSelector';
+import { HorizonUrlInput } from './HorizonUrlInput';
+import { SorobanRpcInput } from './SorobanRpcInput';
+import { AssetPairEditor } from './AssetPairEditor';
+import { ContractAddressInputs } from './ContractAddressInputs';
+import type { StellarConfigFormReturn } from './useStellarConfigForm';
+
+interface StellarConfigPanelProps {
+    form: StellarConfigFormReturn;
+    onSubmit: () => void;
+    submitLabel?: string;
+    isSubmitting?: boolean;
+}
+
+export function StellarConfigPanel({
+    form,
+    onSubmit,
+    submitLabel = 'Save changes',
+    isSubmitting = false,
+}: StellarConfigPanelProps) {
+    const {
+        state,
+        errors,
+        isDirty,
+        connectivityStatus,
+        connectivityResult,
+        sorobanConnectivityStatus,
+        sorobanConnectivityResult,
+        setStellar,
+        addAssetPair,
+        removeAssetPair,
+        setContractAddress,
+        removeContractAddress,
+        validate,
+        checkConnectivity,
+        checkSorobanConnectivity,
+        reset,
+    } = form;
+
+    function handleSubmit(e: React.FormEvent) {
+        e.preventDefault();
+        const validationErrors = validate();
+        if (validationErrors.length === 0) {
+            onSubmit();
+        }
+    }
+
+    return (
+        <form onSubmit={handleSubmit} className="flex flex-col gap-8" noValidate>
+            <ConfigSection title="Network">
+                <NetworkSelector
+                    value={state.stellar.network}
+                    onChange={(v) => setStellar('network', v)}
+                    error={errors.get('stellar.network')}
+                />
+            </ConfigSection>
+
+            <ConfigSection title="Endpoints">
+                <HorizonUrlInput
+                    value={state.stellar.horizonUrl}
+                    onChange={(v) => setStellar('horizonUrl', v)}
+                    onCheckConnectivity={checkConnectivity}
+                    connectivityStatus={connectivityStatus}
+                    connectivityResult={connectivityResult}
+                    error={errors.get('stellar.horizonUrl')}
+                />
+                <SorobanRpcInput
+                    value={state.stellar.sorobanRpcUrl ?? ''}
+                    onChange={(v) => setStellar('sorobanRpcUrl', v || undefined)}
+                    onCheckConnectivity={checkSorobanConnectivity}
+                    connectivityStatus={sorobanConnectivityStatus}
+                    connectivityResult={sorobanConnectivityResult}
+                    error={errors.get('stellar.sorobanRpcUrl')}
+                />
+            </ConfigSection>
+
+            <ConfigSection title="Asset Pairs">
+                <AssetPairEditor
+                    pairs={state.stellar.assetPairs ?? []}
+                    onAdd={addAssetPair}
+                    onRemove={removeAssetPair}
+                />
+            </ConfigSection>
+
+            <ConfigSection title="Smart Contracts">
+                <ContractAddressInputs
+                    contracts={state.stellar.contractAddresses ?? {}}
+                    onSet={setContractAddress}
+                    onRemove={removeContractAddress}
+                    errors={errors}
+                />
+            </ConfigSection>
+
+            <div className="flex gap-3 justify-end border-t border-outline-variant/20 pt-6">
+                <button
+                    type="button"
+                    onClick={reset}
+                    disabled={!isDirty || isSubmitting}
+                    className="px-4 py-2.5 rounded-lg text-sm font-semibold text-on-surface-variant border border-outline-variant/20 hover:bg-surface-container-low transition-all disabled:opacity-40 disabled:cursor-not-allowed"
+                >
+                    Reset
+                </button>
+                <button
+                    type="submit"
+                    disabled={!isDirty || isSubmitting}
+                    className="primary-gradient text-on-primary px-5 py-2.5 rounded-lg text-sm font-semibold shadow-md hover:shadow-lg transition-all active:scale-95 disabled:opacity-60 disabled:cursor-not-allowed disabled:active:scale-100"
+                >
+                    {isSubmitting ? 'Saving…' : submitLabel}
+                </button>
+            </div>
+        </form>
+    );
+}
+
+function ConfigSection({
+    title,
+    children,
+}: {
+    title: string;
+    children: React.ReactNode;
+}) {
+    return (
+        <section className="flex flex-col gap-5">
+            <h3 className="text-lg font-bold font-headline text-on-surface">{title}</h3>
+            <div className="flex flex-col gap-4">{children}</div>
+        </section>
+    );
+}

--- a/apps/frontend/src/components/app/stellar/index.ts
+++ b/apps/frontend/src/components/app/stellar/index.ts
@@ -1,0 +1,12 @@
+export { NetworkSelector } from './NetworkSelector';
+export { HorizonUrlInput } from './HorizonUrlInput';
+export { SorobanRpcInput } from './SorobanRpcInput';
+export { AssetPairEditor } from './AssetPairEditor';
+export { ContractAddressInputs } from './ContractAddressInputs';
+export { StellarConfigPanel } from './StellarConfigPanel';
+export { useStellarConfigForm } from './useStellarConfigForm';
+export type {
+    ConnectivityStatus,
+    StellarConfigFormState,
+    StellarConfigFormReturn,
+} from './useStellarConfigForm';

--- a/apps/frontend/src/components/app/stellar/stellar.test.tsx
+++ b/apps/frontend/src/components/app/stellar/stellar.test.tsx
@@ -1,0 +1,495 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { renderHook, act } from '@testing-library/react';
+import { AssetPairEditor } from './AssetPairEditor';
+import { ContractAddressInputs } from './ContractAddressInputs';
+import { SorobanRpcInput } from './SorobanRpcInput';
+import { StellarConfigPanel } from './StellarConfigPanel';
+import { useStellarConfigForm, type StellarConfigFormState, type StellarConfigFormReturn } from './useStellarConfigForm';
+import type { AssetPair } from '@craft/types';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const XLM_PAIR: AssetPair = {
+    base: { code: 'XLM', issuer: '', type: 'native' },
+    counter: { code: 'USDC', issuer: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN', type: 'credit_alphanum4' },
+};
+
+const VALID_CONTRACT = 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM';
+
+const INITIAL_STATE: StellarConfigFormState = {
+    stellar: {
+        network: 'testnet',
+        horizonUrl: 'https://horizon-testnet.stellar.org',
+        sorobanRpcUrl: '',
+        assetPairs: [],
+        contractAddresses: {},
+    },
+};
+
+function createMockForm(overrides: Partial<StellarConfigFormReturn> = {}): StellarConfigFormReturn {
+    return {
+        state: INITIAL_STATE,
+        errors: new Map(),
+        isDirty: false,
+        connectivityStatus: 'idle',
+        connectivityResult: null,
+        sorobanConnectivityStatus: 'idle',
+        sorobanConnectivityResult: null,
+        setStellar: vi.fn(),
+        addAssetPair: vi.fn(),
+        removeAssetPair: vi.fn(),
+        setContractAddress: vi.fn(),
+        removeContractAddress: vi.fn(),
+        validate: vi.fn(() => []),
+        checkConnectivity: vi.fn(),
+        checkSorobanConnectivity: vi.fn(),
+        reset: vi.fn(),
+        ...overrides,
+    };
+}
+
+// ── AssetPairEditor ───────────────────────────────────────────────────────────
+
+describe('AssetPairEditor', () => {
+    it('renders empty state message when no pairs', () => {
+        render(<AssetPairEditor pairs={[]} onAdd={vi.fn()} onRemove={vi.fn()} />);
+        expect(screen.getByText('No asset pairs configured.')).toBeDefined();
+    });
+
+    it('renders existing pairs', () => {
+        render(<AssetPairEditor pairs={[XLM_PAIR]} onAdd={vi.fn()} onRemove={vi.fn()} />);
+        expect(screen.getByText(/XLM.*USDC/)).toBeDefined();
+    });
+
+    it('calls onRemove when remove button clicked', () => {
+        const onRemove = vi.fn();
+        render(<AssetPairEditor pairs={[XLM_PAIR]} onAdd={vi.fn()} onRemove={onRemove} />);
+        fireEvent.click(screen.getByRole('button', { name: /Remove pair/i }));
+        expect(onRemove).toHaveBeenCalledWith(0);
+    });
+
+    it('opens add form when Add pair button clicked', () => {
+        render(<AssetPairEditor pairs={[]} onAdd={vi.fn()} onRemove={vi.fn()} />);
+        fireEvent.click(screen.getByRole('button', { name: '+ Add pair' }));
+        expect(screen.getByText('Base asset')).toBeDefined();
+        expect(screen.getByText('Counter asset')).toBeDefined();
+    });
+
+    it('closes add form when Cancel clicked', () => {
+        render(<AssetPairEditor pairs={[]} onAdd={vi.fn()} onRemove={vi.fn()} />);
+        fireEvent.click(screen.getByRole('button', { name: '+ Add pair' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+        expect(screen.queryByText('Base asset')).toBeNull();
+    });
+
+    it('Add pair button is disabled when fields are incomplete', () => {
+        render(<AssetPairEditor pairs={[]} onAdd={vi.fn()} onRemove={vi.fn()} />);
+        fireEvent.click(screen.getByRole('button', { name: '+ Add pair' }));
+        const addBtn = screen.getByRole('button', { name: 'Add pair' }) as HTMLButtonElement;
+        expect(addBtn.disabled).toBe(true);
+    });
+
+    it('shows error message when error prop provided', () => {
+        render(<AssetPairEditor pairs={[]} onAdd={vi.fn()} onRemove={vi.fn()} error="At least one pair required" />);
+        expect(screen.getByRole('alert')).toBeDefined();
+        expect(screen.getByText('At least one pair required')).toBeDefined();
+    });
+});
+
+// ── ContractAddressInputs ─────────────────────────────────────────────────────
+
+describe('ContractAddressInputs', () => {
+    it('renders empty state message when no contracts', () => {
+        render(<ContractAddressInputs contracts={{}} onSet={vi.fn()} onRemove={vi.fn()} />);
+        expect(screen.getByText('No contract addresses configured.')).toBeDefined();
+    });
+
+    it('renders existing contracts', () => {
+        render(
+            <ContractAddressInputs
+                contracts={{ amm_pool: VALID_CONTRACT }}
+                onSet={vi.fn()}
+                onRemove={vi.fn()}
+            />,
+        );
+        expect(screen.getByText('amm_pool')).toBeDefined();
+        expect(screen.getByText(VALID_CONTRACT)).toBeDefined();
+    });
+
+    it('calls onRemove when remove button clicked', () => {
+        const onRemove = vi.fn();
+        render(
+            <ContractAddressInputs
+                contracts={{ amm_pool: VALID_CONTRACT }}
+                onSet={vi.fn()}
+                onRemove={onRemove}
+            />,
+        );
+        fireEvent.click(screen.getByRole('button', { name: /Remove contract amm_pool/i }));
+        expect(onRemove).toHaveBeenCalledWith('amm_pool');
+    });
+
+    it('opens add form when Add contract button clicked', () => {
+        render(<ContractAddressInputs contracts={{}} onSet={vi.fn()} onRemove={vi.fn()} />);
+        fireEvent.click(screen.getByRole('button', { name: '+ Add contract' }));
+        expect(screen.getByLabelText('Contract name')).toBeDefined();
+        expect(screen.getByLabelText('Contract address')).toBeDefined();
+    });
+
+    it('shows validation error for invalid contract address', () => {
+        render(<ContractAddressInputs contracts={{}} onSet={vi.fn()} onRemove={vi.fn()} />);
+        fireEvent.click(screen.getByRole('button', { name: '+ Add contract' }));
+        fireEvent.change(screen.getByLabelText('Contract name'), { target: { value: 'pool' } });
+        fireEvent.change(screen.getByLabelText('Contract address'), { target: { value: 'INVALID' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Add contract' }));
+        expect(screen.getByRole('alert')).toBeDefined();
+    });
+
+    it('calls onSet with valid name and address', () => {
+        const onSet = vi.fn();
+        render(<ContractAddressInputs contracts={{}} onSet={onSet} onRemove={vi.fn()} />);
+        fireEvent.click(screen.getByRole('button', { name: '+ Add contract' }));
+        fireEvent.change(screen.getByLabelText('Contract name'), { target: { value: 'pool' } });
+        fireEvent.change(screen.getByLabelText('Contract address'), { target: { value: VALID_CONTRACT } });
+        fireEvent.click(screen.getByRole('button', { name: 'Add contract' }));
+        expect(onSet).toHaveBeenCalledWith('pool', VALID_CONTRACT);
+    });
+
+    it('shows field-level error from errors map', () => {
+        const errors = new Map([['stellar.contractAddresses.amm_pool', 'Invalid address']]);
+        render(
+            <ContractAddressInputs
+                contracts={{ amm_pool: 'BADADDR' }}
+                onSet={vi.fn()}
+                onRemove={vi.fn()}
+                errors={errors}
+            />,
+        );
+        expect(screen.getByText('Invalid address')).toBeDefined();
+    });
+
+    it('shows error when duplicate contract name added', () => {
+        render(
+            <ContractAddressInputs
+                contracts={{ pool: VALID_CONTRACT }}
+                onSet={vi.fn()}
+                onRemove={vi.fn()}
+            />,
+        );
+        fireEvent.click(screen.getByRole('button', { name: '+ Add contract' }));
+        fireEvent.change(screen.getByLabelText('Contract name'), { target: { value: 'pool' } });
+        fireEvent.change(screen.getByLabelText('Contract address'), { target: { value: VALID_CONTRACT } });
+        fireEvent.click(screen.getByRole('button', { name: 'Add contract' }));
+        expect(screen.getByRole('alert')).toBeDefined();
+        expect(screen.getByText(/already exists/i)).toBeDefined();
+    });
+});
+
+// ── SorobanRpcInput ───────────────────────────────────────────────────────────
+
+describe('SorobanRpcInput', () => {
+    it('renders label and input', () => {
+        render(
+            <SorobanRpcInput
+                value=""
+                onChange={vi.fn()}
+                onCheckConnectivity={vi.fn()}
+                connectivityStatus="idle"
+                connectivityResult={null}
+            />,
+        );
+        expect(screen.getByLabelText(/Soroban RPC URL/i)).toBeDefined();
+    });
+
+    it('calls onChange when input changes', () => {
+        const onChange = vi.fn();
+        render(
+            <SorobanRpcInput
+                value=""
+                onChange={onChange}
+                onCheckConnectivity={vi.fn()}
+                connectivityStatus="idle"
+                connectivityResult={null}
+            />,
+        );
+        fireEvent.change(screen.getByLabelText(/Soroban RPC URL/i), {
+            target: { value: 'https://soroban-testnet.stellar.org' },
+        });
+        expect(onChange).toHaveBeenCalledWith('https://soroban-testnet.stellar.org');
+    });
+
+    it('disables Check button when value is empty', () => {
+        render(
+            <SorobanRpcInput
+                value=""
+                onChange={vi.fn()}
+                onCheckConnectivity={vi.fn()}
+                connectivityStatus="idle"
+                connectivityResult={null}
+            />,
+        );
+        const btn = screen.getByRole('button', { name: /Check Soroban RPC connectivity/i }) as HTMLButtonElement;
+        expect(btn.disabled).toBe(true);
+    });
+
+    it('calls onCheckConnectivity when Check button clicked', () => {
+        const onCheck = vi.fn();
+        render(
+            <SorobanRpcInput
+                value="https://soroban-testnet.stellar.org"
+                onChange={vi.fn()}
+                onCheckConnectivity={onCheck}
+                connectivityStatus="idle"
+                connectivityResult={null}
+            />,
+        );
+        fireEvent.click(screen.getByRole('button', { name: /Check Soroban RPC connectivity/i }));
+        expect(onCheck).toHaveBeenCalledOnce();
+    });
+
+    it('shows reachable status with response time', () => {
+        render(
+            <SorobanRpcInput
+                value="https://soroban-testnet.stellar.org"
+                onChange={vi.fn()}
+                onCheckConnectivity={vi.fn()}
+                connectivityStatus="ok"
+                connectivityResult={{ reachable: true, endpoint: 'https://soroban-testnet.stellar.org', responseTime: 123 }}
+            />,
+        );
+        expect(screen.getByText(/Reachable.*123ms/)).toBeDefined();
+    });
+
+    it('shows error status message', () => {
+        render(
+            <SorobanRpcInput
+                value="https://bad-url.example.com"
+                onChange={vi.fn()}
+                onCheckConnectivity={vi.fn()}
+                connectivityStatus="error"
+                connectivityResult={{ reachable: false, endpoint: 'https://bad-url.example.com', error: 'Timeout after 5000ms' }}
+            />,
+        );
+        expect(screen.getByText('Timeout after 5000ms')).toBeDefined();
+    });
+
+    it('shows validation error', () => {
+        render(
+            <SorobanRpcInput
+                value="not-a-url"
+                onChange={vi.fn()}
+                onCheckConnectivity={vi.fn()}
+                connectivityStatus="idle"
+                connectivityResult={null}
+                error="Soroban RPC URL must be a valid http/https URL"
+            />,
+        );
+        expect(screen.getByRole('alert')).toBeDefined();
+        expect(screen.getByText('Soroban RPC URL must be a valid http/https URL')).toBeDefined();
+    });
+});
+
+// ── StellarConfigPanel ────────────────────────────────────────────────────────
+
+describe('StellarConfigPanel', () => {
+    it('renders all sections', () => {
+        render(<StellarConfigPanel form={createMockForm()} onSubmit={vi.fn()} />);
+        // Section headings may share text with child component labels
+        expect(screen.getAllByText('Network').length).toBeGreaterThanOrEqual(1);
+        expect(screen.getByText('Endpoints')).toBeDefined();
+        expect(screen.getAllByText('Asset Pairs').length).toBeGreaterThanOrEqual(1);
+        expect(screen.getByText('Smart Contracts')).toBeDefined();
+    });
+
+    it('disables submit and reset when not dirty', () => {
+        render(<StellarConfigPanel form={createMockForm()} onSubmit={vi.fn()} />);
+        const submit = screen.getByRole('button', { name: 'Save changes' }) as HTMLButtonElement;
+        const reset = screen.getByRole('button', { name: 'Reset' }) as HTMLButtonElement;
+        expect(submit.disabled).toBe(true);
+        expect(reset.disabled).toBe(true);
+    });
+
+    it('enables submit and reset when dirty', () => {
+        render(<StellarConfigPanel form={createMockForm({ isDirty: true })} onSubmit={vi.fn()} />);
+        const submit = screen.getByRole('button', { name: 'Save changes' }) as HTMLButtonElement;
+        expect(submit.disabled).toBe(false);
+    });
+
+    it('calls validate then onSubmit when form submitted with no errors', () => {
+        const onSubmit = vi.fn();
+        const validate = vi.fn(() => []);
+        render(
+            <StellarConfigPanel
+                form={createMockForm({ isDirty: true, validate })}
+                onSubmit={onSubmit}
+            />,
+        );
+        fireEvent.click(screen.getByRole('button', { name: 'Save changes' }));
+        expect(validate).toHaveBeenCalledOnce();
+        expect(onSubmit).toHaveBeenCalledOnce();
+    });
+
+    it('does not call onSubmit when validation fails', () => {
+        const onSubmit = vi.fn();
+        const validate = vi.fn(() => [
+            { field: 'stellar.horizonUrl', message: 'Invalid URL', code: 'INVALID_URL' },
+        ]);
+        render(
+            <StellarConfigPanel
+                form={createMockForm({ isDirty: true, validate })}
+                onSubmit={onSubmit}
+            />,
+        );
+        fireEvent.click(screen.getByRole('button', { name: 'Save changes' }));
+        expect(onSubmit).not.toHaveBeenCalled();
+    });
+
+    it('calls reset when Reset button clicked', () => {
+        const reset = vi.fn();
+        render(
+            <StellarConfigPanel
+                form={createMockForm({ isDirty: true, reset })}
+                onSubmit={vi.fn()}
+            />,
+        );
+        fireEvent.click(screen.getByRole('button', { name: 'Reset' }));
+        expect(reset).toHaveBeenCalledOnce();
+    });
+
+    it('shows custom submit label', () => {
+        render(
+            <StellarConfigPanel
+                form={createMockForm({ isDirty: true })}
+                onSubmit={vi.fn()}
+                submitLabel="Deploy"
+            />,
+        );
+        expect(screen.getByRole('button', { name: 'Deploy' })).toBeDefined();
+    });
+
+    it('shows submitting state', () => {
+        render(
+            <StellarConfigPanel
+                form={createMockForm({ isDirty: true })}
+                onSubmit={vi.fn()}
+                isSubmitting
+            />,
+        );
+        expect(screen.getByRole('button', { name: 'Saving…' })).toBeDefined();
+    });
+});
+
+// ── useStellarConfigForm ──────────────────────────────────────────────────────
+
+describe('useStellarConfigForm', () => {
+    it('initializes with given state', () => {
+        const { result } = renderHook(() => useStellarConfigForm(INITIAL_STATE));
+        expect(result.current.state).toEqual(INITIAL_STATE);
+        expect(result.current.isDirty).toBe(false);
+        expect(result.current.errors.size).toBe(0);
+    });
+
+    it('tracks dirty state when network changes', () => {
+        const { result } = renderHook(() => useStellarConfigForm(INITIAL_STATE));
+        act(() => result.current.setStellar('network', 'mainnet'));
+        expect(result.current.isDirty).toBe(true);
+    });
+
+    it('auto-updates horizonUrl when network changes from default', () => {
+        const { result } = renderHook(() => useStellarConfigForm(INITIAL_STATE));
+        act(() => result.current.setStellar('network', 'mainnet'));
+        expect(result.current.state.stellar.horizonUrl).toBe('https://horizon.stellar.org');
+    });
+
+    it('does not auto-update horizonUrl when it was customized', () => {
+        const custom: StellarConfigFormState = {
+            stellar: { ...INITIAL_STATE.stellar, horizonUrl: 'https://custom.horizon.example.com' },
+        };
+        const { result } = renderHook(() => useStellarConfigForm(custom));
+        act(() => result.current.setStellar('network', 'mainnet'));
+        expect(result.current.state.stellar.horizonUrl).toBe('https://custom.horizon.example.com');
+    });
+
+    it('resets connectivity status when horizonUrl changes', () => {
+        const { result } = renderHook(() => useStellarConfigForm(INITIAL_STATE));
+        act(() => result.current.setStellar('horizonUrl', 'https://new.horizon.example.com'));
+        expect(result.current.connectivityStatus).toBe('idle');
+        expect(result.current.connectivityResult).toBeNull();
+    });
+
+    it('resets soroban connectivity status when sorobanRpcUrl changes', () => {
+        const { result } = renderHook(() => useStellarConfigForm(INITIAL_STATE));
+        act(() => result.current.setStellar('sorobanRpcUrl', 'https://new.soroban.example.com'));
+        expect(result.current.sorobanConnectivityStatus).toBe('idle');
+        expect(result.current.sorobanConnectivityResult).toBeNull();
+    });
+
+    it('adds and removes asset pairs', () => {
+        const { result } = renderHook(() => useStellarConfigForm(INITIAL_STATE));
+        act(() => result.current.addAssetPair(XLM_PAIR));
+        expect(result.current.state.stellar.assetPairs).toHaveLength(1);
+        act(() => result.current.removeAssetPair(0));
+        expect(result.current.state.stellar.assetPairs).toHaveLength(0);
+    });
+
+    it('sets and removes contract addresses', () => {
+        const { result } = renderHook(() => useStellarConfigForm(INITIAL_STATE));
+        act(() => result.current.setContractAddress('pool', VALID_CONTRACT));
+        expect(result.current.state.stellar.contractAddresses?.pool).toBe(VALID_CONTRACT);
+        act(() => result.current.removeContractAddress('pool'));
+        expect(result.current.state.stellar.contractAddresses?.pool).toBeUndefined();
+    });
+
+    it('validates invalid horizonUrl', () => {
+        const { result } = renderHook(() => useStellarConfigForm(INITIAL_STATE));
+        act(() => result.current.setStellar('horizonUrl', 'not-a-url'));
+        let errors: any[];
+        act(() => { errors = result.current.validate(); });
+        expect(errors!.some((e) => e.field === 'stellar.horizonUrl')).toBe(true);
+    });
+
+    it('validates network/horizon mismatch', () => {
+        const { result } = renderHook(() => useStellarConfigForm(INITIAL_STATE));
+        act(() => {
+            result.current.setStellar('network', 'mainnet');
+            result.current.setStellar('horizonUrl', 'https://horizon-testnet.stellar.org');
+        });
+        let errors: any[];
+        act(() => { errors = result.current.validate(); });
+        expect(errors!.some((e) => e.code === 'HORIZON_NETWORK_MISMATCH')).toBe(true);
+    });
+
+    it('validates invalid sorobanRpcUrl', () => {
+        const { result } = renderHook(() => useStellarConfigForm(INITIAL_STATE));
+        act(() => result.current.setStellar('sorobanRpcUrl', 'not-a-url'));
+        let errors: any[];
+        act(() => { errors = result.current.validate(); });
+        expect(errors!.some((e) => e.field === 'stellar.sorobanRpcUrl')).toBe(true);
+    });
+
+    it('returns no errors for valid state', () => {
+        const { result } = renderHook(() => useStellarConfigForm(INITIAL_STATE));
+        let errors: any[];
+        act(() => { errors = result.current.validate(); });
+        expect(errors!).toEqual([]);
+    });
+
+    it('resets to initial state', () => {
+        const { result } = renderHook(() => useStellarConfigForm(INITIAL_STATE));
+        act(() => result.current.setStellar('network', 'mainnet'));
+        act(() => result.current.reset());
+        expect(result.current.state).toEqual(INITIAL_STATE);
+        expect(result.current.isDirty).toBe(false);
+        expect(result.current.errors.size).toBe(0);
+    });
+
+    it('clears field error when that field changes', () => {
+        const { result } = renderHook(() => useStellarConfigForm(INITIAL_STATE));
+        act(() => result.current.setStellar('horizonUrl', 'bad'));
+        act(() => { result.current.validate(); });
+        expect(result.current.errors.has('stellar.horizonUrl')).toBe(true);
+        act(() => result.current.setStellar('horizonUrl', 'https://horizon-testnet.stellar.org'));
+        expect(result.current.errors.has('stellar.horizonUrl')).toBe(false);
+    });
+});

--- a/apps/frontend/src/components/app/stellar/useStellarConfigForm.ts
+++ b/apps/frontend/src/components/app/stellar/useStellarConfigForm.ts
@@ -1,0 +1,271 @@
+'use client';
+
+import { useState, useCallback, useMemo, useRef } from 'react';
+import type { StellarConfig, AssetPair, ValidationError } from '@craft/types';
+import { HORIZON_URLS } from '@craft/stellar';
+import { validateContractAddresses } from '@/lib/stellar/contract-validation';
+import {
+    checkHorizonEndpoint,
+    checkSorobanRpcEndpoint,
+    type ConnectivityCheckResult,
+} from '@/lib/stellar/endpoint-connectivity';
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export type ConnectivityStatus = 'idle' | 'checking' | 'ok' | 'error';
+
+export interface StellarConfigFormState {
+    stellar: StellarConfig;
+}
+
+export interface StellarConfigFormReturn {
+    state: StellarConfigFormState;
+    errors: Map<string, string>;
+    isDirty: boolean;
+    connectivityStatus: ConnectivityStatus;
+    connectivityResult: ConnectivityCheckResult | null;
+    sorobanConnectivityStatus: ConnectivityStatus;
+    sorobanConnectivityResult: ConnectivityCheckResult | null;
+    setStellar: <K extends keyof StellarConfig>(key: K, value: StellarConfig[K]) => void;
+    addAssetPair: (pair: AssetPair) => void;
+    removeAssetPair: (index: number) => void;
+    setContractAddress: (name: string, address: string) => void;
+    removeContractAddress: (name: string) => void;
+    validate: () => ValidationError[];
+    checkConnectivity: () => Promise<void>;
+    checkSorobanConnectivity: () => Promise<void>;
+    reset: () => void;
+}
+
+// ── Validation ────────────────────────────────────────────────────────────────
+
+const URL_PATTERN = /^https?:\/\/.+/;
+const MAINNET_HORIZON = 'https://horizon.stellar.org';
+const TESTNET_HORIZON = 'https://horizon-testnet.stellar.org';
+
+function validateStellarFields(state: StellarConfigFormState): ValidationError[] {
+    const errors: ValidationError[] = [];
+    const { network, horizonUrl, sorobanRpcUrl, contractAddresses } = state.stellar;
+
+    if (network !== 'mainnet' && network !== 'testnet') {
+        errors.push({
+            field: 'stellar.network',
+            message: 'Network must be mainnet or testnet',
+            code: 'UNSUPPORTED_NETWORK',
+        });
+    }
+
+    if (!horizonUrl || !URL_PATTERN.test(horizonUrl)) {
+        errors.push({
+            field: 'stellar.horizonUrl',
+            message: 'Horizon URL must be a valid http/https URL',
+            code: 'INVALID_URL',
+        });
+    } else {
+        if (network === 'mainnet' && horizonUrl === TESTNET_HORIZON) {
+            errors.push({
+                field: 'stellar.horizonUrl',
+                message: 'Horizon URL points to testnet but network is mainnet',
+                code: 'HORIZON_NETWORK_MISMATCH',
+            });
+        }
+        if (network === 'testnet' && horizonUrl === MAINNET_HORIZON) {
+            errors.push({
+                field: 'stellar.horizonUrl',
+                message: 'Horizon URL points to mainnet but network is testnet',
+                code: 'HORIZON_NETWORK_MISMATCH',
+            });
+        }
+    }
+
+    if (sorobanRpcUrl && !URL_PATTERN.test(sorobanRpcUrl)) {
+        errors.push({
+            field: 'stellar.sorobanRpcUrl',
+            message: 'Soroban RPC URL must be a valid http/https URL',
+            code: 'INVALID_URL',
+        });
+    }
+
+    const contractValidation = validateContractAddresses(contractAddresses);
+    if (!contractValidation.valid) {
+        errors.push({
+            field: contractValidation.field,
+            message: contractValidation.reason,
+            code: contractValidation.code,
+        });
+    }
+
+    return errors;
+}
+
+// ── Hook ──────────────────────────────────────────────────────────────────────
+
+export function useStellarConfigForm(initial: StellarConfigFormState): StellarConfigFormReturn {
+    const [state, setState] = useState<StellarConfigFormState>(initial);
+    const [validationErrors, setValidationErrors] = useState<ValidationError[]>([]);
+    const [connectivityStatus, setConnectivityStatus] = useState<ConnectivityStatus>('idle');
+    const [connectivityResult, setConnectivityResult] = useState<ConnectivityCheckResult | null>(null);
+    const [sorobanConnectivityStatus, setSorobanConnectivityStatus] = useState<ConnectivityStatus>('idle');
+    const [sorobanConnectivityResult, setSorobanConnectivityResult] = useState<ConnectivityCheckResult | null>(null);
+    const initialRef = useRef(initial);
+
+    const isDirty = useMemo(() => {
+        const init = initialRef.current.stellar;
+        const curr = state.stellar;
+        return (
+            curr.network !== init.network ||
+            curr.horizonUrl !== init.horizonUrl ||
+            curr.sorobanRpcUrl !== init.sorobanRpcUrl ||
+            JSON.stringify(curr.assetPairs) !== JSON.stringify(init.assetPairs) ||
+            JSON.stringify(curr.contractAddresses) !== JSON.stringify(init.contractAddresses)
+        );
+    }, [state]);
+
+    const setStellar = useCallback(<K extends keyof StellarConfig>(key: K, value: StellarConfig[K]) => {
+        setState((prev) => {
+            const updated = { ...prev.stellar, [key]: value };
+            // Auto-update horizonUrl when network changes (only if it matches the old default)
+            if (key === 'network') {
+                const net = value as 'mainnet' | 'testnet';
+                const oldDefault = HORIZON_URLS[prev.stellar.network as 'mainnet' | 'testnet'];
+                if (prev.stellar.horizonUrl === oldDefault) {
+                    updated.horizonUrl = HORIZON_URLS[net];
+                }
+            }
+            return { ...prev, stellar: updated };
+        });
+        setValidationErrors((prev) => prev.filter((e) => e.field !== `stellar.${key}`));
+        // Reset connectivity when URL changes
+        if (key === 'horizonUrl') {
+            setConnectivityStatus('idle');
+            setConnectivityResult(null);
+        }
+        if (key === 'sorobanRpcUrl') {
+            setSorobanConnectivityStatus('idle');
+            setSorobanConnectivityResult(null);
+        }
+    }, []);
+
+    const addAssetPair = useCallback((pair: AssetPair) => {
+        setState((prev) => ({
+            ...prev,
+            stellar: {
+                ...prev.stellar,
+                assetPairs: [...(prev.stellar.assetPairs ?? []), pair],
+            },
+        }));
+    }, []);
+
+    const removeAssetPair = useCallback((index: number) => {
+        setState((prev) => ({
+            ...prev,
+            stellar: {
+                ...prev.stellar,
+                assetPairs: (prev.stellar.assetPairs ?? []).filter((_, i) => i !== index),
+            },
+        }));
+    }, []);
+
+    const setContractAddress = useCallback((name: string, address: string) => {
+        setState((prev) => ({
+            ...prev,
+            stellar: {
+                ...prev.stellar,
+                contractAddresses: { ...(prev.stellar.contractAddresses ?? {}), [name]: address },
+            },
+        }));
+        setValidationErrors((prev) =>
+            prev.filter((e) => e.field !== `stellar.contractAddresses.${name}`)
+        );
+    }, []);
+
+    const removeContractAddress = useCallback((name: string) => {
+        setState((prev) => {
+            const { [name]: _, ...rest } = prev.stellar.contractAddresses ?? {};
+            return {
+                ...prev,
+                stellar: { ...prev.stellar, contractAddresses: rest },
+            };
+        });
+    }, []);
+
+    const validate = useCallback((): ValidationError[] => {
+        const errors = validateStellarFields(state);
+        setValidationErrors(errors);
+        return errors;
+    }, [state]);
+
+    const checkConnectivity = useCallback(async () => {
+        setConnectivityStatus('checking');
+        setConnectivityResult(null);
+        try {
+            const result = await checkHorizonEndpoint(state.stellar.horizonUrl);
+            setConnectivityResult(result);
+            setConnectivityStatus(result.reachable ? 'ok' : 'error');
+        } catch {
+            setConnectivityStatus('error');
+            setConnectivityResult({
+                reachable: false,
+                endpoint: state.stellar.horizonUrl,
+                errorType: 'TRANSIENT',
+                error: 'Unexpected error during connectivity check',
+            });
+        }
+    }, [state.stellar.horizonUrl]);
+
+    const checkSorobanConnectivity = useCallback(async () => {
+        const url = state.stellar.sorobanRpcUrl;
+        if (!url) return;
+        setSorobanConnectivityStatus('checking');
+        setSorobanConnectivityResult(null);
+        try {
+            const result = await checkSorobanRpcEndpoint(url);
+            setSorobanConnectivityResult(result);
+            setSorobanConnectivityStatus(result.reachable ? 'ok' : 'error');
+        } catch {
+            setSorobanConnectivityStatus('error');
+            setSorobanConnectivityResult({
+                reachable: false,
+                endpoint: url,
+                errorType: 'TRANSIENT',
+                error: 'Unexpected error during connectivity check',
+            });
+        }
+    }, [state.stellar.sorobanRpcUrl]);
+
+    const reset = useCallback(() => {
+        setState(initialRef.current);
+        setValidationErrors([]);
+        setConnectivityStatus('idle');
+        setConnectivityResult(null);
+        setSorobanConnectivityStatus('idle');
+        setSorobanConnectivityResult(null);
+    }, []);
+
+    const errors = useMemo(() => {
+        const map = new Map<string, string>();
+        for (const err of validationErrors) {
+            map.set(err.field, err.message);
+        }
+        return map;
+    }, [validationErrors]);
+
+    return {
+        state,
+        errors,
+        isDirty,
+        connectivityStatus,
+        connectivityResult,
+        sorobanConnectivityStatus,
+        sorobanConnectivityResult,
+        setStellar,
+        addAssetPair,
+        removeAssetPair,
+        setContractAddress,
+        removeContractAddress,
+        validate,
+        checkConnectivity,
+        checkSorobanConnectivity,
+        reset,
+    };
+}

--- a/apps/frontend/vitest.config.ts
+++ b/apps/frontend/vitest.config.ts
@@ -13,6 +13,8 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),
+      '@craft/types': path.resolve(__dirname, '../../packages/types/src'),
+      '@craft/stellar': path.resolve(__dirname, '../../packages/stellar/src'),
     },
   },
 });


### PR DESCRIPTION
## What was implemented
 New files in apps/frontend/src/components/app/stellar/:
  
  - AssetPairEditor.tsx — inline form to add/remove asset pairs with base/counter asset
  type, code, and issuer fields
  - ContractAddressInputs.tsx — add/remove Soroban contract addresses with inline
  validation against the existing validateContractAddress utility
  - SorobanRpcInput.tsx — URL input with async connectivity check button and status
  feedback (mirrors HorizonUrlInput)
  - StellarConfigPanel.tsx — main panel composing all four field groups into a form with
  save/reset actions
  - index.ts — barrel export for the whole stellar directory
  
  Updated files:
  
  - useStellarConfigForm.ts — added sorobanConnectivityStatus, sorobanConnectivityResult,
  and checkSorobanConnectivity to the hook and its return type; also resets Soroban
  connectivity state when sorobanRpcUrl changes
  - vitest.config.ts (frontend) — added @craft/stellar and @craft/types source aliases so
  tests resolve without a build step
  - stellar.test.tsx — 44 tests covering all new components and the updated hook
  
  Edge cases handled:
  
  - Auto-updating horizonUrl when network switches only if the URL still matches the old
  default
  - Network/Horizon URL mismatch validation (testnet URL on mainnet config and vice
  - Duplicate contract name detection in ContractAddressInputs
  - Connectivity state reset on URL change for both Horizon and Soroban RPC

closes #19 