### PR TITLE
feat: template ui

### DIFF
--- a/apps/frontend/src/app/app/templates/[id]/page.tsx
+++ b/apps/frontend/src/app/app/templates/[id]/page.tsx
@@ -1,0 +1,160 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { AppShell } from '@/components/app';
+import { LoadingSkeleton } from '@/components/app/LoadingSkeleton';
+import { ErrorState } from '@/components/app/ErrorState';
+import { TemplateDetailView } from '@/components/app/templates';
+import type { Template, TemplateMetadata } from '@craft/types';
+import type { User, NavItem } from '@/types/navigation';
+
+const mockUser: User = {
+  id: '1',
+  name: 'John Doe',
+  email: 'john@example.com',
+  role: 'user',
+};
+
+const navItems: NavItem[] = [
+  {
+    id: 'home',
+    label: 'Home',
+    icon: (
+      <svg fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
+      </svg>
+    ),
+    path: '/app',
+  },
+  {
+    id: 'templates',
+    label: 'Templates',
+    icon: (
+      <svg fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+      </svg>
+    ),
+    path: '/app/templates',
+    badge: 3,
+  },
+  {
+    id: 'deployments',
+    label: 'Deployments',
+    icon: (
+      <svg fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
+      </svg>
+    ),
+    path: '/app/deployments',
+  },
+];
+
+interface Props {
+  params: { id: string };
+}
+
+export default function TemplateDetailPage({ params }: Props) {
+  const router = useRouter();
+  const { id } = params;
+
+  const [template, setTemplate] = useState<Template | null>(null);
+  const [metadata, setMetadata] = useState<TemplateMetadata | undefined>();
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load() {
+      setLoading(true);
+      setError(null);
+
+      try {
+        const [tplRes, metaRes] = await Promise.all([
+          fetch(`/api/templates/${id}`),
+          fetch(`/api/templates/${id}/metadata`),
+        ]);
+
+        if (!tplRes.ok) {
+          throw new Error(
+            tplRes.status === 404
+              ? 'Template not found.'
+              : `Failed to load template (${tplRes.status})`,
+          );
+        }
+
+        const tpl: Template = await tplRes.json();
+        const meta: TemplateMetadata | undefined = metaRes.ok
+          ? await metaRes.json()
+          : undefined;
+
+        if (!cancelled) {
+          setTemplate(tpl);
+          setMetadata(meta);
+        }
+      } catch (err: any) {
+        if (!cancelled) setError(err?.message ?? 'An unexpected error occurred.');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [id]);
+
+  const handleCustomize = useCallback(
+    (tpl: Template) => {
+      router.push(`/app/customize?templateId=${tpl.id}`);
+    },
+    [router],
+  );
+
+  const handleRetry = useCallback(() => {
+    setTemplate(null);
+    setError(null);
+    setLoading(true);
+    // Re-trigger by incrementing a key would need extra state; simplest resilient
+    // approach is a full reload since this is an error recovery path.
+    window.location.reload();
+  }, []);
+
+  return (
+    <AppShell
+      user={mockUser}
+      navItems={navItems}
+      breadcrumbs={[
+        { label: 'Home', path: '/app' },
+        { label: 'Templates', path: '/app/templates' },
+        { label: template?.name ?? 'Template' },
+      ]}
+      status="operational"
+      onStatusClick={() => window.open('https://status.craft.com', '_blank')}
+    >
+      <div className="p-6 lg:p-8">
+        <div className="max-w-5xl mx-auto">
+          {loading && <LoadingSkeleton />}
+
+          {!loading && error && (
+            <ErrorState
+              title="Failed to load template"
+              message={error}
+              onRetry={handleRetry}
+            />
+          )}
+
+          {!loading && !error && template && (
+            <TemplateDetailView
+              template={template}
+              metadata={metadata}
+              onCustomize={handleCustomize}
+            />
+          )}
+        </div>
+      </div>
+    </AppShell>
+  );
+}

--- a/apps/frontend/src/app/app/templates/page.tsx
+++ b/apps/frontend/src/app/app/templates/page.tsx
@@ -116,7 +116,7 @@ export default function TemplateCatalogPage() {
 
   const handleSelectTemplate = useCallback(
     (template: Template) => {
-      router.push(`/app/customize?templateId=${template.id}`);
+      router.push(`/app/templates/${template.id}`);
     },
     [router],
   );

--- a/apps/frontend/src/components/app/templates/TemplateDetailView.test.tsx
+++ b/apps/frontend/src/components/app/templates/TemplateDetailView.test.tsx
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { TemplateDetailView } from './TemplateDetailView';
+import type { Template, TemplateMetadata } from '@craft/types';
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+const makeTemplate = (overrides: Partial<Template> = {}): Template => ({
+  id: 'tpl-1',
+  name: 'Stellar DEX',
+  description: 'A decentralized exchange for trading Stellar assets.',
+  category: 'dex',
+  blockchainType: 'stellar',
+  baseRepositoryUrl: 'https://github.com/org/stellar-dex',
+  previewImageUrl: '',
+  features: [
+    { id: 'enableCharts', name: 'Charts', description: 'Enable charts', enabled: true, configurable: true },
+    { id: 'enableAnalytics', name: 'Analytics', description: 'Enable analytics', enabled: false, configurable: true },
+  ],
+  customizationSchema: {
+    branding: {
+      appName: { type: 'string', required: true },
+      primaryColor: { type: 'color', required: true },
+      secondaryColor: { type: 'color', required: true },
+      fontFamily: { type: 'string', required: true },
+    },
+    features: {
+      enableCharts: { type: 'boolean', default: true },
+      enableTransactionHistory: { type: 'boolean', default: true },
+      enableAnalytics: { type: 'boolean', default: false },
+      enableNotifications: { type: 'boolean', default: false },
+    },
+    stellar: {
+      network: { type: 'enum', values: ['mainnet', 'testnet'], required: true },
+      horizonUrl: { type: 'string', required: true },
+      sorobanRpcUrl: { type: 'string', required: false },
+      assetPairs: { type: 'array', required: false },
+    },
+  },
+  isActive: true,
+  createdAt: new Date('2024-01-01'),
+  ...overrides,
+});
+
+const makeMetadata = (overrides: Partial<TemplateMetadata> = {}): TemplateMetadata => ({
+  id: 'tpl-1',
+  name: 'Stellar DEX',
+  version: '1.2.0',
+  lastUpdated: new Date('2024-06-15'),
+  totalDeployments: 42,
+  ...overrides,
+});
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('TemplateDetailView', () => {
+  describe('header', () => {
+    it('renders the template name as h1', () => {
+      render(<TemplateDetailView template={makeTemplate()} onCustomize={vi.fn()} />);
+      expect(screen.getByRole('heading', { level: 1, name: 'Stellar DEX' })).toBeDefined();
+    });
+
+    it('shows the category badge', () => {
+      render(<TemplateDetailView template={makeTemplate({ category: 'payment' })} onCustomize={vi.fn()} />);
+      expect(screen.getByText('Payment')).toBeDefined();
+    });
+
+    it('shows "Stellar" blockchain label', () => {
+      render(<TemplateDetailView template={makeTemplate()} onCustomize={vi.fn()} />);
+      expect(screen.getByText('Stellar')).toBeDefined();
+    });
+  });
+
+  describe('overview', () => {
+    it('renders the description', () => {
+      render(<TemplateDetailView template={makeTemplate()} onCustomize={vi.fn()} />);
+      expect(screen.getByText('A decentralized exchange for trading Stellar assets.')).toBeDefined();
+    });
+
+    it('renders preview image when URL is provided', () => {
+      render(
+        <TemplateDetailView
+          template={makeTemplate({ previewImageUrl: '/thumb.png' })}
+          onCustomize={vi.fn()}
+        />,
+      );
+      const img = screen.getByAltText('Stellar DEX preview');
+      expect(img.getAttribute('src')).toBe('/thumb.png');
+    });
+
+    it('renders emoji fallback when previewImageUrl is empty', () => {
+      render(<TemplateDetailView template={makeTemplate({ previewImageUrl: '' })} onCustomize={vi.fn()} />);
+      expect(screen.queryByRole('img', { name: /preview/i })).toBeNull();
+      expect(screen.getByText('📊')).toBeDefined();
+    });
+  });
+
+  describe('feature list', () => {
+    it('renders all feature names', () => {
+      render(<TemplateDetailView template={makeTemplate()} onCustomize={vi.fn()} />);
+      expect(screen.getByText('Charts')).toBeDefined();
+      expect(screen.getByText('Analytics')).toBeDefined();
+    });
+
+    it('marks disabled features', () => {
+      render(<TemplateDetailView template={makeTemplate()} onCustomize={vi.fn()} />);
+      expect(screen.getByText('disabled')).toBeDefined();
+    });
+
+    it('renders nothing when features array is empty', () => {
+      render(<TemplateDetailView template={makeTemplate({ features: [] })} onCustomize={vi.fn()} />);
+      expect(screen.queryByRole('heading', { name: 'Features' })).toBeNull();
+    });
+  });
+
+  describe('Stellar setup panel', () => {
+    it('renders network options', () => {
+      render(<TemplateDetailView template={makeTemplate()} onCustomize={vi.fn()} />);
+      expect(screen.getByText('mainnet')).toBeDefined();
+      expect(screen.getByText('testnet')).toBeDefined();
+    });
+
+    it('shows Horizon URL as Required', () => {
+      render(<TemplateDetailView template={makeTemplate()} onCustomize={vi.fn()} />);
+      expect(screen.getAllByText('Required').length).toBeGreaterThan(0);
+    });
+
+    it('shows Soroban RPC as Optional', () => {
+      render(<TemplateDetailView template={makeTemplate()} onCustomize={vi.fn()} />);
+      expect(screen.getAllByText('Optional').length).toBeGreaterThan(0);
+    });
+
+    it('omits panel when stellar schema is absent', () => {
+      const tpl = makeTemplate();
+      (tpl.customizationSchema as any).stellar = undefined;
+      render(<TemplateDetailView template={tpl} onCustomize={vi.fn()} />);
+      expect(screen.queryByRole('heading', { name: 'Stellar Setup' })).toBeNull();
+    });
+  });
+
+  describe('metadata sidebar', () => {
+    it('renders version and deployment count when metadata provided', () => {
+      render(
+        <TemplateDetailView template={makeTemplate()} metadata={makeMetadata()} onCustomize={vi.fn()} />,
+      );
+      expect(screen.getByText('1.2.0')).toBeDefined();
+      expect(screen.getByText('42')).toBeDefined();
+    });
+
+    it('omits sidebar when metadata is absent', () => {
+      render(<TemplateDetailView template={makeTemplate()} onCustomize={vi.fn()} />);
+      expect(screen.queryByText('Template Info')).toBeNull();
+    });
+  });
+
+  describe('CTA', () => {
+    it('renders the Customize & Deploy button', () => {
+      render(<TemplateDetailView template={makeTemplate()} onCustomize={vi.fn()} />);
+      expect(
+        screen.getByRole('button', { name: 'Customize and deploy Stellar DEX' }),
+      ).toBeDefined();
+    });
+
+    it('calls onCustomize with the template on click', async () => {
+      const onCustomize = vi.fn();
+      const tpl = makeTemplate();
+      render(<TemplateDetailView template={tpl} onCustomize={onCustomize} />);
+      await userEvent.click(
+        screen.getByRole('button', { name: 'Customize and deploy Stellar DEX' }),
+      );
+      expect(onCustomize).toHaveBeenCalledWith(tpl);
+    });
+  });
+});

--- a/apps/frontend/src/components/app/templates/TemplateDetailView.tsx
+++ b/apps/frontend/src/components/app/templates/TemplateDetailView.tsx
@@ -1,0 +1,248 @@
+import React from 'react';
+import type { Template, TemplateCategory, TemplateMetadata } from '@craft/types';
+
+const CATEGORY_LABELS: Record<TemplateCategory, string> = {
+  dex: 'DEX',
+  lending: 'Lending',
+  payment: 'Payment',
+  'asset-issuance': 'Asset Issuance',
+};
+
+const CATEGORY_ICONS: Record<TemplateCategory, string> = {
+  dex: '📊',
+  lending: '🏦',
+  payment: '💳',
+  'asset-issuance': '🪙',
+};
+
+export interface TemplateDetailViewProps {
+  template: Template;
+  metadata?: TemplateMetadata;
+  onCustomize: (template: Template) => void;
+}
+
+/** Preview image with emoji fallback on missing URL or load error. */
+function PreviewImage({ template }: { template: Template }) {
+  const [failed, setFailed] = React.useState(false);
+  const icon = CATEGORY_ICONS[template.category] ?? '📋';
+
+  if (!template.previewImageUrl || failed) {
+    return (
+      <div
+        className="w-full aspect-video bg-surface-container-high flex items-center justify-center rounded-xl"
+        aria-label={`${template.name} preview placeholder`}
+      >
+        <span className="text-7xl" aria-hidden="true">{icon}</span>
+      </div>
+    );
+  }
+
+  return (
+    <img
+      src={template.previewImageUrl}
+      alt={`${template.name} preview`}
+      className="w-full aspect-video object-cover rounded-xl"
+      onError={() => setFailed(true)}
+    />
+  );
+}
+
+/** Metadata sidebar panel: version, deployments, last updated. */
+function MetadataSidebar({ metadata }: { metadata: TemplateMetadata }) {
+  const lastUpdated =
+    metadata.lastUpdated instanceof Date
+      ? metadata.lastUpdated
+      : new Date(metadata.lastUpdated);
+
+  const items = [
+    { label: 'Version', value: metadata.version },
+    { label: 'Deployments', value: metadata.totalDeployments.toLocaleString() },
+    {
+      label: 'Last Updated',
+      value: lastUpdated.toLocaleDateString(undefined, {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+      }),
+    },
+  ];
+
+  return (
+    <aside aria-label="Template metadata" className="space-y-3">
+      <h2 className="text-sm font-semibold text-on-surface-variant uppercase tracking-wide">
+        Template Info
+      </h2>
+      <dl className="space-y-2">
+        {items.map(({ label, value }) => (
+          <div
+            key={label}
+            className="flex justify-between items-center py-2 border-b border-outline-variant/10 last:border-0"
+          >
+            <dt className="text-sm text-on-surface-variant">{label}</dt>
+            <dd className="text-sm font-semibold text-on-surface">{value}</dd>
+          </div>
+        ))}
+      </dl>
+    </aside>
+  );
+}
+
+/** Feature list panel. */
+function FeatureList({ features }: { features: Template['features'] }) {
+  if (features.length === 0) return null;
+
+  return (
+    <section aria-labelledby="features-heading">
+      <h2
+        id="features-heading"
+        className="text-lg font-bold font-headline text-on-surface mb-3"
+      >
+        Features
+      </h2>
+      <ul className="space-y-2" role="list">
+        {features.map((f) => (
+          <li
+            key={f.id}
+            className="flex items-start gap-3 p-3 rounded-lg bg-surface-container-lowest border border-outline-variant/10"
+          >
+            <span
+              className={`mt-0.5 flex-shrink-0 w-5 h-5 rounded-full flex items-center justify-center text-xs font-bold ${
+                f.enabled
+                  ? 'bg-primary text-on-primary'
+                  : 'bg-surface-container text-on-surface-variant'
+              }`}
+              aria-hidden="true"
+            >
+              {f.enabled ? '✓' : '○'}
+            </span>
+            <div className="min-w-0 flex-1">
+              <p className="text-sm font-semibold text-on-surface">{f.name}</p>
+              <p className="text-xs text-on-surface-variant mt-0.5">{f.description}</p>
+            </div>
+            {!f.enabled && (
+              <span className="flex-shrink-0 text-xs text-on-surface-variant/60 italic">
+                disabled
+              </span>
+            )}
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+/** Stellar configuration panel. */
+function StellarPanel({ schema }: { schema: Template['customizationSchema'] }) {
+  const stellar = schema?.stellar;
+  if (!stellar) return null;
+
+  const networks: string[] = stellar.network?.values ?? ['mainnet', 'testnet'];
+
+  return (
+    <section aria-labelledby="stellar-heading">
+      <h2
+        id="stellar-heading"
+        className="text-lg font-bold font-headline text-on-surface mb-3"
+      >
+        Stellar Setup
+      </h2>
+      <dl className="space-y-2">
+        <div className="flex flex-wrap items-center gap-2 p-3 rounded-lg bg-surface-container-lowest border border-outline-variant/10">
+          <dt className="text-sm font-semibold text-on-surface w-32 flex-shrink-0">Network</dt>
+          <dd className="flex gap-2 flex-wrap">
+            {networks.map((n) => (
+              <span
+                key={n}
+                className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-primary/10 text-primary capitalize"
+              >
+                {n}
+              </span>
+            ))}
+          </dd>
+        </div>
+        <div className="flex items-center gap-2 p-3 rounded-lg bg-surface-container-lowest border border-outline-variant/10">
+          <dt className="text-sm font-semibold text-on-surface w-32 flex-shrink-0">Horizon URL</dt>
+          <dd className="text-xs font-medium text-error">Required</dd>
+        </div>
+        <div className="flex items-center gap-2 p-3 rounded-lg bg-surface-container-lowest border border-outline-variant/10">
+          <dt className="text-sm font-semibold text-on-surface w-32 flex-shrink-0">Soroban RPC</dt>
+          <dd className="text-xs text-on-surface-variant/60">Optional</dd>
+        </div>
+      </dl>
+    </section>
+  );
+}
+
+/**
+ * Full template detail view.
+ *
+ * Layout (lg+): two-column — main content left, metadata sidebar right.
+ * Layout (mobile): single column, sidebar stacks below.
+ */
+export function TemplateDetailView({
+  template,
+  metadata,
+  onCustomize,
+}: TemplateDetailViewProps) {
+  return (
+    <article aria-label={`${template.name} template detail`}>
+      {/* Header */}
+      <header className="mb-6">
+        <div className="flex items-center gap-2 mb-2">
+          <span className="inline-flex items-center px-2.5 py-1 text-xs font-semibold rounded-md bg-primary text-on-primary">
+            {CATEGORY_LABELS[template.category] ?? template.category}
+          </span>
+          <span className="text-xs text-on-surface-variant">Stellar</span>
+        </div>
+        <h1 className="text-3xl font-bold font-headline text-on-surface">
+          {template.name}
+        </h1>
+      </header>
+
+      <div className="flex flex-col lg:flex-row gap-8">
+        {/* Main content */}
+        <div className="flex-1 min-w-0 space-y-8">
+          {/* Preview + description */}
+          <section aria-labelledby="overview-heading">
+            <PreviewImage template={template} />
+            <div className="mt-4">
+              <h2
+                id="overview-heading"
+                className="text-lg font-bold font-headline text-on-surface mb-2"
+              >
+                Overview
+              </h2>
+              <p className="text-on-surface-variant leading-relaxed">
+                {template.description}
+              </p>
+            </div>
+          </section>
+
+          <FeatureList features={template.features} />
+          <StellarPanel schema={template.customizationSchema} />
+        </div>
+
+        {/* Sidebar */}
+        <div className="lg:w-64 flex-shrink-0 space-y-6">
+          {/* CTA */}
+          <div className="rounded-xl bg-primary/5 border border-primary/20 p-5">
+            <p className="text-sm font-semibold text-on-surface mb-1">Ready to deploy?</p>
+            <p className="text-xs text-on-surface-variant mb-4">
+              Customize branding, features, and Stellar settings before going live.
+            </p>
+            <button
+              type="button"
+              onClick={() => onCustomize(template)}
+              className="w-full primary-gradient text-on-primary px-4 py-2.5 rounded-lg font-semibold shadow-md hover:shadow-lg transition-all active:scale-95 text-sm"
+              aria-label={`Customize and deploy ${template.name}`}
+            >
+              Customize &amp; Deploy
+            </button>
+          </div>
+
+          {metadata && <MetadataSidebar metadata={metadata} />}
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/apps/frontend/src/components/app/templates/index.ts
+++ b/apps/frontend/src/components/app/templates/index.ts
@@ -1,4 +1,5 @@
 export { TemplateCard } from './TemplateCard';
 export { TemplateCatalogFilters } from './TemplateCatalogFilters';
+export { TemplateDetailView } from './TemplateDetailView';
 export { TemplateGrid } from './TemplateGrid';
 export { useTemplates, filtersFromSearchParams, filtersToQueryString } from './useTemplates';


### PR DESCRIPTION
Here's what was implemented:
  
  Files created/modified:
  
  -
  apps/frontend/src/components/app/templates/TemplateDetailView.tsx
    - Header — template name (h1), category badge, "Stellar" label
    - Overview — preview image with emoji fallback on empty URL or
  load error
    - FeatureList — enabled/disabled indicators per feature; hidden
  when empty
    - StellarPanel — network options, Horizon URL (required),
  Soroban RPC (optional); hidden when schema absent
    - MetadataSidebar — version, total deployments, last updated;
  hidden when metadata not provided
    - CTA — "Customize & Deploy" button in a sidebar card, navigates
  to customization flow
    - Two-column layout on lg+, single column on mobile
  
  - apps/frontend/src/app/app/templates/[id]/page.tsx — Next.js page
  that fetches template + metadata in parallel, shows
  LoadingSkeleton / ErrorState / TemplateDetailView, breadcrumbs
  Home → Templates → <name>
  - apps/frontend/src/app/app/templates/page.tsx — catalog card
  click now navigates to /app/templates/[id] (detail page) instead
  of jumping straight to customize
  - apps/frontend/src/components/app/templates/index.ts — added
  TemplateDetailView export
  -
  apps/frontend/src/components/app/templates/TemplateDetailView.test
  .tsx — 17 tests across all sections
  
  Edge cases handled: empty previewImageUrl or image load failure →
  emoji fallback; empty features array → section hidden; missing
  stellar schema → panel hidden; missing metadata → sidebar hidden;
  lastUpdated as string or Date.

closes #15