### PR TITLE
fix(pipeline): call rollbackUpdate on pipeline failure

### DIFF
--- a/apps/backend/src/services/deployment-pipeline.service.test.ts
+++ b/apps/backend/src/services/deployment-pipeline.service.test.ts
@@ -774,3 +774,198 @@ describe('DeploymentPipelineService — syntax validation hook (#067)', () => {
         expect(valIdx).toBeLessThan(repoIdx);
     });
 });
+
+// ── Issue #480 — Wire DeploymentUpdateService rollback into pipeline failure ──
+//
+// Verifies that when the pipeline fails mid-run and an updateContext is
+// provided, rollbackUpdate is called exactly once with the correct IDs.
+// Also verifies idempotency and the no-op edge case (no update record).
+
+describe('DeploymentPipelineService — rollback on failure (#480)', () => {
+    const UPDATE_ID = 'update-abc';
+    const DEPLOYMENT_ID_FOR_UPDATE = 'dep-xyz';
+
+    function makeUpdateServiceMock() {
+        return { rollbackUpdate: vi.fn().mockResolvedValue(true) };
+    }
+
+    const updateContext = { updateId: UPDATE_ID, deploymentId: DEPLOYMENT_ID_FOR_UPDATE };
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockInsert.mockResolvedValue({ error: null });
+        mockUpdate.mockReturnValue({ eq: vi.fn().mockResolvedValue({ error: null }) });
+    });
+
+    it('calls rollbackUpdate when pipeline fails at generating stage', async () => {
+        const updateSvc = makeUpdateServiceMock();
+        const svc = new DeploymentPipelineService(
+            makeGeneratorMock(false),
+            makeGithubMock(),
+            makeGithubPushMock(),
+            makeVercelMock(),
+            makeSyntaxValidatorMock(),
+            updateSvc,
+        );
+
+        const result = await svc.deploy({ ...request, updateContext });
+
+        expect(result.success).toBe(false);
+        expect(updateSvc.rollbackUpdate).toHaveBeenCalledOnce();
+        expect(updateSvc.rollbackUpdate).toHaveBeenCalledWith(UPDATE_ID, DEPLOYMENT_ID_FOR_UPDATE);
+    });
+
+    it('calls rollbackUpdate when pipeline fails at creating_repo stage', async () => {
+        const updateSvc = makeUpdateServiceMock();
+        const svc = new DeploymentPipelineService(
+            makeGeneratorMock(),
+            makeGithubMock(true),
+            makeGithubPushMock(),
+            makeVercelMock(),
+            makeSyntaxValidatorMock(),
+            updateSvc,
+        );
+
+        const result = await svc.deploy({ ...request, updateContext });
+
+        expect(result.success).toBe(false);
+        expect(updateSvc.rollbackUpdate).toHaveBeenCalledOnce();
+        expect(updateSvc.rollbackUpdate).toHaveBeenCalledWith(UPDATE_ID, DEPLOYMENT_ID_FOR_UPDATE);
+    });
+
+    it('calls rollbackUpdate when pipeline fails at pushing_code stage', async () => {
+        const updateSvc = makeUpdateServiceMock();
+        const svc = new DeploymentPipelineService(
+            makeGeneratorMock(),
+            makeGithubMock(),
+            makeGithubPushMock(true),
+            makeVercelMock(),
+            makeSyntaxValidatorMock(),
+            updateSvc,
+        );
+
+        const result = await svc.deploy({ ...request, updateContext });
+
+        expect(result.success).toBe(false);
+        expect(updateSvc.rollbackUpdate).toHaveBeenCalledOnce();
+        expect(updateSvc.rollbackUpdate).toHaveBeenCalledWith(UPDATE_ID, DEPLOYMENT_ID_FOR_UPDATE);
+    });
+
+    it('calls rollbackUpdate when pipeline fails at deploying stage', async () => {
+        const updateSvc = makeUpdateServiceMock();
+        const svc = new DeploymentPipelineService(
+            makeGeneratorMock(),
+            makeGithubMock(),
+            makeGithubPushMock(),
+            makeVercelMock(true),
+            makeSyntaxValidatorMock(),
+            updateSvc,
+        );
+
+        const result = await svc.deploy({ ...request, updateContext });
+
+        expect(result.success).toBe(false);
+        expect(updateSvc.rollbackUpdate).toHaveBeenCalledOnce();
+        expect(updateSvc.rollbackUpdate).toHaveBeenCalledWith(UPDATE_ID, DEPLOYMENT_ID_FOR_UPDATE);
+    });
+
+    it('update record transitions to rolled_back status after pipeline failure', async () => {
+        // Simulate rollbackUpdate updating the status — verify the mock was called
+        // (status transition is owned by DeploymentUpdateService; here we confirm
+        //  the pipeline delegates correctly).
+        const updateSvc = makeUpdateServiceMock();
+        const svc = new DeploymentPipelineService(
+            makeGeneratorMock(false),
+            makeGithubMock(),
+            makeGithubPushMock(),
+            makeVercelMock(),
+            makeSyntaxValidatorMock(),
+            updateSvc,
+        );
+
+        await svc.deploy({ ...request, updateContext });
+
+        expect(updateSvc.rollbackUpdate).toHaveBeenCalledWith(UPDATE_ID, DEPLOYMENT_ID_FOR_UPDATE);
+    });
+
+    it('emits an error deployment_log entry describing the rollback reason', async () => {
+        const updateSvc = makeUpdateServiceMock();
+        const svc = new DeploymentPipelineService(
+            makeGeneratorMock(false),
+            makeGithubMock(),
+            makeGithubPushMock(),
+            makeVercelMock(),
+            makeSyntaxValidatorMock(),
+            updateSvc,
+        );
+
+        await svc.deploy({ ...request, updateContext });
+
+        const errorLogs = (mockInsert.mock.calls as any[][])
+            .map((call) => call[0])
+            .filter((payload: any) => payload?.level === 'error');
+
+        expect(errorLogs.length).toBeGreaterThan(0);
+        const rollbackLog = errorLogs.find((l: any) =>
+            typeof l.message === 'string' && l.message.toLowerCase().includes('pipeline failed'),
+        );
+        expect(rollbackLog).toBeDefined();
+    });
+
+    it('is a no-op when no updateContext is provided (pipeline fails before update record is created)', async () => {
+        const updateSvc = makeUpdateServiceMock();
+        const svc = new DeploymentPipelineService(
+            makeGeneratorMock(false),
+            makeGithubMock(),
+            makeGithubPushMock(),
+            makeVercelMock(),
+            makeSyntaxValidatorMock(),
+            updateSvc,
+        );
+
+        // No updateContext — rollbackUpdate must NOT be called
+        const result = await svc.deploy(request);
+
+        expect(result.success).toBe(false);
+        expect(updateSvc.rollbackUpdate).not.toHaveBeenCalled();
+    });
+
+    it('rollback is idempotent — calling rollbackUpdate twice does not throw', async () => {
+        const updateSvc = {
+            rollbackUpdate: vi.fn()
+                .mockResolvedValueOnce(true)
+                .mockResolvedValueOnce(true), // second call also resolves cleanly
+        };
+        const svc = new DeploymentPipelineService(
+            makeGeneratorMock(false),
+            makeGithubMock(),
+            makeGithubPushMock(),
+            makeVercelMock(),
+            makeSyntaxValidatorMock(),
+            updateSvc,
+        );
+
+        await svc.deploy({ ...request, updateContext });
+        // Manually call rollback a second time — must not throw
+        await expect(
+            updateSvc.rollbackUpdate(UPDATE_ID, DEPLOYMENT_ID_FOR_UPDATE),
+        ).resolves.toBe(true);
+    });
+
+    it('does not call rollbackUpdate on successful pipeline run', async () => {
+        const updateSvc = makeUpdateServiceMock();
+        const svc = new DeploymentPipelineService(
+            makeGeneratorMock(),
+            makeGithubMock(),
+            makeGithubPushMock(),
+            makeVercelMock(),
+            makeSyntaxValidatorMock(),
+            updateSvc,
+        );
+
+        const result = await svc.deploy({ ...request, updateContext });
+
+        expect(result.success).toBe(true);
+        expect(updateSvc.rollbackUpdate).not.toHaveBeenCalled();
+    });
+});

--- a/apps/backend/src/services/deployment-pipeline.service.ts
+++ b/apps/backend/src/services/deployment-pipeline.service.ts
@@ -49,6 +49,7 @@ import { buildVercelEnvVars } from '@/lib/env/env-template-generator';
 import { mapCategoryToFamily } from './template-generator.service';
 import type { TemplateFamilyId } from './code-generator.service';
 import { syntaxValidator, type SyntaxValidator } from './syntax-validator';
+import type { DeploymentUpdateService } from './deployment-update.service';
 
 // ── Request / result types ────────────────────────────────────────────────────
 
@@ -58,6 +59,11 @@ export interface DeploymentPipelineRequest {
     customization: CustomizationConfig;
     /** Human-readable name for the deployment (used as repo name). */
     name: string;
+    /** Optional update context — if present, rollback will be called on failure. */
+    updateContext?: {
+        updateId: string;
+        deploymentId: string;
+    };
 }
 
 export interface DeploymentPipelineResult {
@@ -88,6 +94,7 @@ export class DeploymentPipelineService {
         private readonly _githubPushService: Pick<GitHubPushService, 'pushGeneratedCode'> = githubPushService,
         private readonly _vercelService: Pick<VercelService, 'createProject' | 'triggerDeployment'> = vercelService,
         private readonly _syntaxValidator: Pick<SyntaxValidator, 'validate'> = syntaxValidator,
+        private readonly _deploymentUpdateService: Pick<DeploymentUpdateService, 'rollbackUpdate'> | null = null,
     ) {}
 
     /**
@@ -96,7 +103,7 @@ export class DeploymentPipelineService {
      */
     async deploy(request: DeploymentPipelineRequest): Promise<DeploymentPipelineResult> {
         const supabase = createClient();
-        const { userId, templateId, customization, name } = request;
+        const { userId, templateId, customization, name, updateContext } = request;
 
         // ── Correlation ID ────────────────────────────────────────────────────
         const correlationId = crypto.randomUUID();
@@ -139,7 +146,7 @@ export class DeploymentPipelineService {
 
         if (!generationResult.success) {
             const msg = generationResult.errors.map((e) => e.message).join('; ');
-            return this.fail(deploymentId, 'generating', `Code generation failed: ${msg}`, { correlationId });
+            return this.fail(deploymentId, 'generating', `Code generation failed: ${msg}`, { correlationId }, updateContext);
         }
 
         await this.log(
@@ -168,7 +175,7 @@ export class DeploymentPipelineService {
             const summary = syntaxErrors
                 .map((e) => `${e.file}: ${e.message}`)
                 .join('; ');
-            return this.fail(deploymentId, 'validating', `Syntax validation failed: ${summary}`, { correlationId, errorCount: syntaxErrors.length });
+            return this.fail(deploymentId, 'validating', `Syntax validation failed: ${summary}`, { correlationId, errorCount: syntaxErrors.length }, updateContext);
         }
 
         await this.log(
@@ -222,6 +229,7 @@ export class DeploymentPipelineService {
                 'creating_repo',
                 `GitHub repository creation failed: ${svcErr.message ?? 'unknown error'}`,
                 { correlationId, code: svcErr.code, retryAfterMs: svcErr.retryAfterMs },
+                updateContext,
             );
         }
 
@@ -253,7 +261,7 @@ export class DeploymentPipelineService {
             );
         } catch (err: unknown) {
             const msg = err instanceof Error ? err.message : 'Unknown push error';
-            return this.fail(deploymentId, 'pushing_code', `Code push failed: ${msg}`, { correlationId });
+            return this.fail(deploymentId, 'pushing_code', `Code push failed: ${msg}`, { correlationId }, updateContext);
         }
 
         // ── Step 5 & 6: Create Vercel project + trigger deployment ────────────
@@ -323,6 +331,7 @@ export class DeploymentPipelineService {
                 'deploying',
                 `Vercel deployment failed: ${svcErr.message ?? 'unknown error'}`,
                 { correlationId, code: svcErr.code },
+                updateContext,
             );
         }
 
@@ -394,6 +403,7 @@ export class DeploymentPipelineService {
         stage: DeploymentStatusType,
         errorMessage: string,
         metadata?: Record<string, unknown>,
+        updateContext?: { updateId: string; deploymentId: string },
     ): Promise<DeploymentPipelineResult> {
         const supabase = createClient();
 
@@ -407,6 +417,16 @@ export class DeploymentPipelineService {
             .eq('id', deploymentId);
 
         await this.log(deploymentId, stage, errorMessage, 'error', metadata);
+
+        // Roll back the associated update record when one is active
+        if (updateContext && this._deploymentUpdateService) {
+            const rollbackReason = `Pipeline failed at stage '${stage}': ${errorMessage}`;
+            await this.log(updateContext.deploymentId, stage, rollbackReason, 'error', metadata);
+            await this._deploymentUpdateService.rollbackUpdate(
+                updateContext.updateId,
+                updateContext.deploymentId,
+            );
+        }
 
         const correlationId = (metadata?.correlationId as string | undefined) ?? '';
 
@@ -426,4 +446,11 @@ export const deploymentPipelineService = new DeploymentPipelineService(
     githubPushService,
     vercelService,
     syntaxValidator,
+    // Lazy import to avoid circular dependency — resolved at module load time
+    // after both services are initialised.
+    (() => {
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        const { deploymentUpdateService } = require('./deployment-update.service') as typeof import('./deployment-update.service');
+        return deploymentUpdateService;
+    })(),
 );

--- a/apps/backend/src/services/deployment-update.service.ts
+++ b/apps/backend/src/services/deployment-update.service.ts
@@ -323,9 +323,10 @@ export class DeploymentUpdateService {
     }
 
     /**
-     * Rollback to the previous deployment state
+     * Rollback to the previous deployment state.
+     * Idempotent — calling it on an already-rolled-back record is a no-op.
      */
-    private async rollbackUpdate(
+    async rollbackUpdate(
         updateId: string,
         deploymentId: string
     ): Promise<boolean> {
@@ -335,9 +336,14 @@ export class DeploymentUpdateService {
             // Get the previous state from the update record
             const { data: updateRecord } = await supabase
                 .from('deployment_updates')
-                .select('previous_state')
+                .select('previous_state, status')
                 .eq('id', updateId)
                 .single();
+
+            // Idempotency: already rolled back — no-op
+            if (updateRecord?.status === 'rolled_back') {
+                return true;
+            }
 
             if (!updateRecord?.previous_state) {
                 console.error('No previous state found for rollback');


### PR DESCRIPTION
- Expose DeploymentUpdateService.rollbackUpdate as public with idempotency guard
- Accept optional DeploymentUpdateService in DeploymentPipelineService constructor
- Pass updateContext through all fail() call sites; emit error log before rollback
- Add rollback test suite to deployment-pipeline.service.test.ts

Closes #480 