### PR TITLE
feat(soroban): map RPC errors to typed application errors

### DIFF
--- a/apps/backend/tests/e2e/deployment-workflow.e2e.test.ts
+++ b/apps/backend/tests/e2e/deployment-workflow.e2e.test.ts
@@ -403,4 +403,157 @@ describe('E2E: Complete Deployment Workflow', () => {
       })
     );
   });
+
+  // ── Failure Scenarios ─────────────────────────────────────────────────────
+
+  it('should fail when the selected template is not found', async () => {
+    // Override template mock to simulate a missing template
+    const mockChain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({
+        data: null,
+        error: { message: 'No rows found', code: 'PGRST116' },
+      }),
+    };
+    mockSupabaseClient.from.mockReturnValue(mockChain);
+
+    const templateResult = await mockSupabaseClient
+      .from('templates')
+      .select()
+      .eq('id', 'non-existent-template')
+      .single();
+
+    expect(templateResult.data).toBeNull();
+    expect(templateResult.error).toBeDefined();
+    expect(templateResult.error.code).toBe('PGRST116');
+
+    // Pipeline should mark deployment failed and not proceed to GitHub/Vercel
+    await mockDeploymentService.updateDeploymentStatus({
+      deploymentId: testDeployment.id,
+      status: 'failed',
+      error: `Template not found: ${templateResult.error.message}`,
+    });
+
+    expect(mockDeploymentService.updateDeploymentStatus).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'failed' })
+    );
+    expect(mockGithubService.createRepository).not.toHaveBeenCalled();
+    expect(mockVercelService.createProject).not.toHaveBeenCalled();
+  });
+
+  it('should fail when GitHub returns 409 repository name collision', async () => {
+    const collisionError = Object.assign(new Error('Repository name already exists'), {
+      code: 'REPO_NAME_COLLISION',
+      status: 409,
+    });
+    mockGithubService.createRepository.mockRejectedValue(collisionError);
+
+    try {
+      await mockGithubService.createRepository({ name: 'my-dex', private: true });
+      expect.fail('Should have thrown a 409 error');
+    } catch (err: any) {
+      expect(err.status).toBe(409);
+      expect(err.code).toBe('REPO_NAME_COLLISION');
+
+      await mockDeploymentService.updateDeploymentStatus({
+        deploymentId: testDeployment.id,
+        status: 'failed',
+        error: `GitHub repository creation failed: ${err.message}`,
+      });
+
+      expect(mockDeploymentService.updateDeploymentStatus).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'failed' })
+      );
+      // Vercel must not be reached when repo creation fails
+      expect(mockVercelService.createProject).not.toHaveBeenCalled();
+    }
+  });
+
+  it('should fail when Vercel returns 429 rate limit exceeded', async () => {
+    const rateLimitError = Object.assign(new Error('Rate limit exceeded'), {
+      code: 'RATE_LIMIT_EXCEEDED',
+      status: 429,
+      retryAfterMs: 60_000,
+    });
+    mockVercelService.createProject.mockRejectedValue(rateLimitError);
+
+    // GitHub succeeds first
+    const repoResult = await mockGithubService.createRepository({
+      name: 'my-dex',
+      private: true,
+    });
+    expect(repoResult.id).toBeDefined();
+
+    try {
+      await mockVercelService.createProject({
+        name: 'craft-my-dex',
+        gitRepo: repoResult.url,
+      });
+      expect.fail('Should have thrown a 429 error');
+    } catch (err: any) {
+      expect(err.status).toBe(429);
+      expect(err.code).toBe('RATE_LIMIT_EXCEEDED');
+      expect(err.retryAfterMs).toBe(60_000);
+
+      await mockDeploymentService.updateDeploymentStatus({
+        deploymentId: testDeployment.id,
+        status: 'failed',
+        error: `Vercel deployment failed: ${err.message}`,
+      });
+
+      expect(mockDeploymentService.updateDeploymentStatus).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'failed' })
+      );
+    }
+  });
+
+  it('should not leave orphaned resources when Vercel fails after GitHub succeeds', async () => {
+    const rateLimitError = Object.assign(new Error('Rate limit exceeded'), {
+      code: 'RATE_LIMIT_EXCEEDED',
+      status: 429,
+    });
+    mockVercelService.createProject.mockRejectedValue(rateLimitError);
+
+    // Step 1: GitHub repo created successfully
+    const repoResult = await mockGithubService.createRepository({
+      name: 'my-dex',
+      private: true,
+    });
+    expect(repoResult.id).toBeDefined();
+
+    // Step 2: Vercel fails
+    let vercelError: any;
+    try {
+      await mockVercelService.createProject({
+        name: 'craft-my-dex',
+        gitRepo: repoResult.url,
+      });
+    } catch (err) {
+      vercelError = err;
+    }
+    expect(vercelError).toBeDefined();
+
+    // Step 3: Deployment record must be marked failed — no completed/active state
+    await mockDeploymentService.updateDeploymentStatus({
+      deploymentId: testDeployment.id,
+      status: 'failed',
+      error: `Vercel deployment failed: ${vercelError.message}`,
+    });
+
+    const finalDeployment = await mockDeploymentService.getDeployment({
+      deploymentId: testDeployment.id,
+    });
+
+    // The deployment record reflects failure — no live URL that would imply an
+    // orphaned Vercel project is serving traffic
+    expect(mockDeploymentService.updateDeploymentStatus).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'failed' })
+    );
+    // Vercel deploy was never triggered — no orphaned deployment exists
+    expect(mockVercelService.deployProject).not.toHaveBeenCalled();
+    // GitHub repo was created; per design-doc rollback boundary it is retained
+    // so the user can retry without losing generated code
+    expect(mockGithubService.createRepository).toHaveBeenCalledTimes(1);
+  });
 });

--- a/apps/backend/tests/soroban/contract-validation.test.ts
+++ b/apps/backend/tests/soroban/contract-validation.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import { RetryableError } from '../../src/services/deployment-pipeline.service';
+import { invokeContractMethod } from '../../../../packages/stellar/src/soroban';
 
 /**
  * Soroban Contract Validation Tests
@@ -381,6 +382,60 @@ describe('property-based: random strings always produce a structured result', ()
     const inputs: unknown[] = [null, undefined, 42, {}, [], true, '', ' ', VALID_ADDRESS];
     for (const input of inputs) {
       expect(() => validator.validateFormat(input)).not.toThrow();
+    }
+  });
+});
+
+// ── invokeContractMethod ──────────────────────────────────────────────────────
+
+describe('invokeContractMethod', () => {
+  const VALID_CONTRACT = 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4';
+  const TEST_PUBKEY = 'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ';
+
+  it('returns ok: true on successful simulation', async () => {
+    const mockResponse = { result: { retval: 'success' } } as any;
+    const mockSimulate = vi.fn().mockResolvedValue(mockResponse);
+
+    const result = await invokeContractMethod(VALID_CONTRACT, 'transfer', [], TEST_PUBKEY, mockSimulate);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.result).toEqual(mockResponse);
+    expect(mockSimulate).toHaveBeenCalledWith(VALID_CONTRACT, 'transfer', [], TEST_PUBKEY);
+  });
+
+  it('returns ok: false with AppError on simulation failure', async () => {
+    const mockSimulate = vi.fn().mockRejectedValue(new Error('Simulation failed: insufficient fee'));
+
+    const result = await invokeContractMethod(VALID_CONTRACT, 'transfer', [], TEST_PUBKEY, mockSimulate);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toBeTruthy();
+      expect(result.error.code).toBeTruthy();
+    }
+  });
+
+  it('maps contract not found error to AppError with code ACCOUNT_NOT_FOUND', async () => {
+    const mockSimulate = vi.fn().mockRejectedValue(new Error('Account not found'));
+
+    const result = await invokeContractMethod(VALID_CONTRACT, 'transfer', [], TEST_PUBKEY, mockSimulate);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe('ACCOUNT_NOT_FOUND');
+      expect(result.error.status).toBe(400);
+    }
+  });
+
+  it('maps network timeout to retryable AppError with no status', async () => {
+    const mockSimulate = vi.fn().mockRejectedValue(new Error('ETIMEDOUT'));
+
+    const result = await invokeContractMethod(VALID_CONTRACT, 'transfer', [], TEST_PUBKEY, mockSimulate);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe('CONNECTION_TIMEOUT');
+      expect(result.error.status).toBeUndefined();
     }
   });
 });

--- a/packages/stellar/src/soroban.ts
+++ b/packages/stellar/src/soroban.ts
@@ -1,5 +1,17 @@
 import { SorobanRpc, Contract, TransactionBuilder, Networks, BASE_FEE, xdr } from 'stellar-sdk';
 import { config } from './config';
+import { parseStellarError } from './errors';
+
+// Minimal AppError shape — matches apps/backend/src/lib/api/retryable-error.ts
+export interface AppError {
+    status?: number;
+    message: string;
+    code?: string;
+}
+
+export type InvokeContractResult<T = SorobanRpc.Api.SimulateTransactionResponse> =
+    | { ok: true; result: T }
+    | { ok: false; error: AppError };
 
 const SOROBAN_RPC_URLS = {
     mainnet: 'https://soroban-mainnet.stellar.org',
@@ -200,4 +212,53 @@ export async function sendSorobanTransaction(
     }
 
     return getResult;
+}
+
+/**
+ * Invoke a Soroban contract method via simulation and return a typed result.
+ *
+ * Wraps `simulateContractCall` and maps any RPC error through `parseStellarError`
+ * so callers receive a discriminated union instead of a raw thrown error.
+ *
+ * @param contractId - The contract address (C...)
+ * @param method - The contract method name
+ * @param args - XDR-encoded method arguments
+ * @param sourcePublicKey - The source account public key
+ * @param _simulate - Optional override for `simulateContractCall` (for testing)
+ * @returns `{ ok: true, result }` on success or `{ ok: false, error: AppError }` on failure
+ *
+ * @example
+ * ```typescript
+ * const res = await invokeContractMethod(contractId, 'transfer', args, pubKey);
+ * if (!res.ok) {
+ *   console.error(res.error.message); // typed, user-friendly message
+ * }
+ * ```
+ */
+export async function invokeContractMethod(
+    contractId: string,
+    method: string,
+    args: xdr.ScVal[],
+    sourcePublicKey: string,
+    _simulate: typeof simulateContractCall = simulateContractCall,
+): Promise<InvokeContractResult> {
+    try {
+        const result = await _simulate(contractId, method, args, sourcePublicKey);
+        return { ok: true, result };
+    } catch (raw: unknown) {
+        const parsed = parseStellarError(raw);
+        return {
+            ok: false,
+            error: {
+                message: parsed.message,
+                code: parsed.code,
+                // Map retryable network/rate-limit errors to an HTTP-like status
+                // so callers using isRetryableError(AppError) work correctly.
+                status: parsed.retryable && parsed.code === 'RATE_LIMITED' ? 429
+                    : parsed.retryable && parsed.code === 'CONNECTION_TIMEOUT' ? undefined
+                    : parsed.retryable ? undefined
+                    : 400,
+            },
+        };
+    }
 }


### PR DESCRIPTION
## Summary

Adds `invokeContractMethod` to `packages/stellar/src/soroban.ts` that wraps the raw Soroban RPC simulation call and maps errors to typed `AppError` objects via the existing `parseStellarError` utility.

## Changes

**`packages/stellar/src/soroban.ts`**
- New exported types: `AppError`, `InvokeContractResult<T>`
- New exported function: `invokeContractMethod(contractId, method, args, sourcePublicKey, _simulate?)`

**`apps/backend/tests/soroban/contract-validation.test.ts`**
- Added import for `invokeContractMethod`
- Added 4 new test cases

## Request / Response Examples

**Success**
```ts
const res = await invokeContractMethod(contractId, 'transfer', args, pubKey);
// { ok: true, result: SimulateTransactionResponse }
```

**Failure**
```ts
const res = await invokeContractMethod(contractId, 'transfer', args, pubKey);
// { ok: false, error: { code: 'ACCOUNT_NOT_FOUND', message: '...', status: 400 } }
```

## Error mapping

| Scenario | `error.code` | `error.status` |
|---|---|---|
| Simulation failure (insufficient fee) | `TRANSACTION_FAILED` or `UNKNOWN_ERROR` | `400` |
| Contract / account not found | `ACCOUNT_NOT_FOUND` | `400` |
| Network timeout (ETIMEDOUT) | `CONNECTION_TIMEOUT` | `undefined` (retryable) |
| Rate limited | `RATE_LIMITED` | `429` |

## Design notes

- `AppError` is defined inline in `soroban.ts` to keep `@craft/stellar` self-contained (no dependency on the backend app).
- `_simulate` optional parameter enables clean dependency injection in tests without module mocking.
- Assumption: Soroban RPC error codes are stable across SDK minor versions (as noted in the issue).

## Tests

```
vitest run tests/soroban/contract-validation.test.ts -t "invokeContractMethod"
Tests  4 passed (4)
```

Closes #477