### PR TITLE
feat: webhook DLQ, health dependency graph, CSP headers, RBAC middleware (#601–#604)

### DIFF
--- a/apps/backend/next.config.js
+++ b/apps/backend/next.config.js
@@ -1,4 +1,49 @@
 /** @type {import('next').NextConfig} */
+
+const isDev = process.env.NODE_ENV !== 'production';
+
+const CSP_DIRECTIVES = {
+  'default-src': ["'self'"],
+  'script-src': ["'self'"],
+  'style-src': ["'self'", "'unsafe-inline'"],
+  'img-src': ["'self'", 'data:', 'https:'],
+  'font-src': ["'self'"],
+  'connect-src': [
+    "'self'",
+    'https://*.supabase.co',
+    'https://api.stripe.com',
+    'https://api.vercel.com',
+    'https://horizon-testnet.stellar.org',
+    'https://horizon.stellar.org',
+  ],
+  'frame-src': ["'none'"],
+  'object-src': ["'none'"],
+  'base-uri': ["'self'"],
+  'form-action': ["'self'"],
+  'upgrade-insecure-requests': [],
+};
+
+function buildCsp() {
+  return Object.entries(CSP_DIRECTIVES)
+    .map(([directive, values]) =>
+      values.length ? `${directive} ${values.join(' ')}` : directive
+    )
+    .join('; ');
+}
+
+const cspHeaderName = isDev
+  ? 'Content-Security-Policy-Report-Only'
+  : 'Content-Security-Policy';
+
+const securityHeaders = [
+  { key: cspHeaderName, value: buildCsp() },
+  { key: 'Strict-Transport-Security', value: 'max-age=63072000; includeSubDomains; preload' },
+  { key: 'X-Content-Type-Options', value: 'nosniff' },
+  { key: 'X-Frame-Options', value: 'DENY' },
+  { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+  { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=()' },
+];
+
 const nextConfig = {
   reactStrictMode: true,
   transpilePackages: ['@craft/types', '@craft/stellar', '@craft/ui'],
@@ -16,6 +61,7 @@ const nextConfig = {
           { key: 'Access-Control-Allow-Methods', value: 'GET, POST, PUT, PATCH, DELETE, OPTIONS' },
           { key: 'Access-Control-Allow-Headers', value: 'Content-Type, Authorization, X-Requested-With' },
           { key: 'Access-Control-Max-Age', value: '86400' },
+          ...securityHeaders,
         ],
       },
     ];

--- a/apps/backend/src/app/api/admin/analytics/route.ts
+++ b/apps/backend/src/app/api/admin/analytics/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { withRole } from '@/lib/api/with-role';
+import { createClient } from '@/lib/supabase/server';
+
+/**
+ * GET /api/admin/analytics
+ *
+ * Aggregate platform analytics across all deployments. Admin role required.
+ *
+ * Query params:
+ *   startDate  ISO 8601 date (optional)
+ *   endDate    ISO 8601 date (optional)
+ *   metricType string (optional)
+ */
+export const GET = withRole('admin', async (req: NextRequest) => {
+    const { searchParams } = req.nextUrl;
+    const metricType = searchParams.get('metricType') ?? undefined;
+    const startDate = searchParams.get('startDate') ?? undefined;
+    const endDate = searchParams.get('endDate') ?? undefined;
+
+    const supabase = createClient();
+
+    let query = supabase
+        .from('deployment_analytics')
+        .select('metric_type, metric_value, recorded_at, deployment_id');
+
+    if (metricType) query = query.eq('metric_type', metricType);
+    if (startDate) query = query.gte('recorded_at', new Date(startDate).toISOString());
+    if (endDate) query = query.lte('recorded_at', new Date(endDate).toISOString());
+
+    const { data, error } = await query.order('recorded_at', { ascending: false }).limit(1000);
+
+    if (error) {
+        return NextResponse.json(
+            { error: 'Failed to fetch analytics', detail: error.message },
+            { status: 500 }
+        );
+    }
+
+    const totals: Record<string, number> = {};
+    for (const row of data ?? []) {
+        totals[row.metric_type] = (totals[row.metric_type] ?? 0) + row.metric_value;
+    }
+
+    return NextResponse.json({
+        total: data?.length ?? 0,
+        aggregates: totals,
+        rows: data ?? [],
+    });
+});

--- a/apps/backend/src/app/api/admin/webhooks/dlq/route.ts
+++ b/apps/backend/src/app/api/admin/webhooks/dlq/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { withRole } from '@/lib/api/with-role';
+import { webhookDLQ } from '@/lib/webhook-dlq/dead-letter-queue';
+
+/**
+ * GET /api/admin/webhooks/dlq
+ * List all dead-letter queue entries (admin only).
+ */
+export const GET = withRole('admin', async (_req: NextRequest) => {
+    const entries = webhookDLQ.list();
+    return NextResponse.json({ total: entries.length, entries });
+});
+
+/**
+ * POST /api/admin/webhooks/dlq/:id/reprocess
+ * Reprocess a single DLQ entry by id, passed in the request body.
+ *
+ * Body: { id: string }
+ */
+export const POST = withRole('admin', async (req: NextRequest) => {
+    let body: unknown;
+    try {
+        body = await req.json();
+    } catch {
+        return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+    }
+
+    const id = (body as Record<string, unknown>)?.id;
+    if (!id || typeof id !== 'string') {
+        return NextResponse.json({ error: 'Missing required field: id' }, { status: 400 });
+    }
+
+    const entry = webhookDLQ.get(id);
+    if (!entry) {
+        return NextResponse.json({ error: 'DLQ entry not found' }, { status: 404 });
+    }
+
+    const result = await webhookDLQ.reprocess(id);
+
+    if (!result.success) {
+        return NextResponse.json(
+            { error: result.error, entry: webhookDLQ.get(id) },
+            { status: 422 }
+        );
+    }
+
+    return NextResponse.json({ success: true, entry: webhookDLQ.get(id) });
+});

--- a/apps/backend/src/app/api/cron/health-check/route.ts
+++ b/apps/backend/src/app/api/cron/health-check/route.ts
@@ -1,46 +1,170 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { healthMonitorService } from '@/services/health-monitor.service';
 import { VercelService } from '@/services/vercel.service';
+import { createClient } from '@/lib/supabase/server';
+
+const DEPENDENCY_TIMEOUT_MS = 5000;
+
+type DependencyStatus = 'healthy' | 'degraded' | 'down';
+
+interface DependencyResult {
+    status: DependencyStatus;
+    responseTimeMs: number;
+    error?: string;
+}
+
+interface HealthGraph {
+    overall: DependencyStatus;
+    checkedAt: string;
+    dependencies: {
+        database: DependencyResult;
+        stellar: DependencyResult;
+        vercel: DependencyResult;
+        stripe: DependencyResult;
+    };
+}
+
+async function timed<T>(
+    fn: () => Promise<T>,
+    timeoutMs: number
+): Promise<{ result?: T; responseTimeMs: number; error?: string }> {
+    const start = Date.now();
+    try {
+        const result = await Promise.race([
+            fn(),
+            new Promise<never>((_, reject) =>
+                setTimeout(() => reject(new Error('Dependency check timed out')), timeoutMs)
+            ),
+        ]);
+        return { result, responseTimeMs: Date.now() - start };
+    } catch (err: any) {
+        return { responseTimeMs: Date.now() - start, error: err?.message ?? 'Unknown error' };
+    }
+}
+
+async function checkDatabase(): Promise<DependencyResult> {
+    const { responseTimeMs, error } = await timed(async () => {
+        const supabase = createClient();
+        const { error: dbError } = await supabase.from('profiles').select('id').limit(1);
+        if (dbError) throw new Error(dbError.message);
+    }, DEPENDENCY_TIMEOUT_MS);
+
+    return {
+        status: error ? 'down' : 'healthy',
+        responseTimeMs,
+        ...(error ? { error } : {}),
+    };
+}
+
+async function checkStellar(): Promise<DependencyResult> {
+    const horizonUrl = process.env.NEXT_PUBLIC_HORIZON_URL || 'https://horizon-testnet.stellar.org';
+    const { responseTimeMs, error } = await timed(async () => {
+        const res = await fetch(`${horizonUrl}`, {
+            method: 'HEAD',
+            signal: AbortSignal.timeout(DEPENDENCY_TIMEOUT_MS),
+        });
+        if (!res.ok) throw new Error(`Stellar Horizon returned ${res.status}`);
+    }, DEPENDENCY_TIMEOUT_MS);
+
+    return {
+        status: error ? 'down' : 'healthy',
+        responseTimeMs,
+        ...(error ? { error } : {}),
+    };
+}
+
+async function checkVercel(): Promise<DependencyResult> {
+    const token = process.env.VERCEL_TOKEN;
+    const { responseTimeMs, error } = await timed(async () => {
+        if (!token) throw new Error('VERCEL_TOKEN not configured');
+        const res = await fetch('https://api.vercel.com/v2/user', {
+            headers: { Authorization: `Bearer ${token}` },
+            signal: AbortSignal.timeout(DEPENDENCY_TIMEOUT_MS),
+        });
+        if (res.status === 401) throw new Error('Vercel token invalid');
+        if (!res.ok) throw new Error(`Vercel API returned ${res.status}`);
+    }, DEPENDENCY_TIMEOUT_MS);
+
+    return {
+        status: error
+            ? error.includes('not configured')
+                ? 'degraded'
+                : 'down'
+            : 'healthy',
+        responseTimeMs,
+        ...(error ? { error } : {}),
+    };
+}
+
+async function checkStripe(): Promise<DependencyResult> {
+    const { responseTimeMs, error } = await timed(async () => {
+        const { stripe } = await import('@/lib/stripe/client');
+        await stripe.balance.retrieve();
+    }, DEPENDENCY_TIMEOUT_MS);
+
+    return {
+        status: error ? 'down' : 'healthy',
+        responseTimeMs,
+        ...(error ? { error } : {}),
+    };
+}
+
+function aggregateStatus(results: DependencyResult[]): DependencyStatus {
+    if (results.some((r) => r.status === 'down')) return 'down';
+    if (results.some((r) => r.status === 'degraded')) return 'degraded';
+    return 'healthy';
+}
 
 /**
- * Cron endpoint to check health of all deployments
- * This should be called periodically (e.g., every 5 minutes) by a cron service
+ * GET /api/cron/health-check
  *
- * Vercel Cron: https://vercel.com/docs/cron-jobs
- * Configure in vercel.json with crons array containing path and schedule.
+ * Reports health of all system dependencies as a structured dependency graph.
+ * Returns 503 when critical dependencies (database) are down.
  */
 export async function GET(req: NextRequest) {
-    try {
-        // Verify cron secret to prevent unauthorized access
-        const authHeader = req.headers.get('authorization');
-        const cronSecret = process.env.CRON_SECRET;
+    const authHeader = req.headers.get('authorization');
+    const cronSecret = process.env.CRON_SECRET;
 
-        if (cronSecret && authHeader !== `Bearer ${cronSecret}`) {
-            return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-        }
-
-        console.log('Running health check for all deployments...');
-
-        const results = await healthMonitorService.checkAllDeployments();
-
-        const unhealthyCount = results.filter((r) => !r.isHealthy).length;
-
-        console.log(
-            `Health check complete: ${results.length} deployments checked, ${unhealthyCount} unhealthy`
-        );
-
-        return NextResponse.json({
-            success: true,
-            totalChecked: results.length,
-            unhealthyCount,
-            results,
-            vercelCircuitState: new VercelService().breaker.currentState,
-        });
-    } catch (error: any) {
-        console.error('Error running health check cron:', error);
-        return NextResponse.json(
-            { error: error.message || 'Health check failed' },
-            { status: 500 }
-        );
+    if (cronSecret && authHeader !== `Bearer ${cronSecret}`) {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
+
+    const [database, stellar, vercel, stripe] = await Promise.all([
+        checkDatabase(),
+        checkStellar(),
+        checkVercel(),
+        checkStripe(),
+    ]);
+
+    const graph: HealthGraph = {
+        overall: aggregateStatus([database, stellar, vercel, stripe]),
+        checkedAt: new Date().toISOString(),
+        dependencies: { database, stellar, vercel, stripe },
+    };
+
+    // Also run the existing per-deployment health checks.
+    let deploymentResults: Awaited<ReturnType<typeof healthMonitorService.checkAllDeployments>> = [];
+    try {
+        deploymentResults = await healthMonitorService.checkAllDeployments();
+    } catch {
+        // Non-critical; don't let it block the dependency graph response.
+    }
+
+    const unhealthyCount = deploymentResults.filter((r) => !r.isHealthy).length;
+
+    const isCriticalDown = database.status === 'down';
+    const httpStatus = isCriticalDown ? 503 : 200;
+
+    return NextResponse.json(
+        {
+            ...graph,
+            vercelCircuitState: new VercelService().breaker.currentState,
+            deployments: {
+                totalChecked: deploymentResults.length,
+                unhealthyCount,
+                results: deploymentResults,
+            },
+        },
+        { status: httpStatus }
+    );
 }

--- a/apps/backend/src/app/api/webhooks/github/route.ts
+++ b/apps/backend/src/app/api/webhooks/github/route.ts
@@ -1,11 +1,23 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { verifyGitHubWebhookSignature } from '@/lib/github/webhook-verification';
 import { createLogger, resolveCorrelationId, CORRELATION_ID_HEADER } from '@/lib/api/logger';
+import { webhookDLQ } from '@/lib/webhook-dlq/dead-letter-queue';
 
 const SUPPORTED_EVENTS = new Set([
     'push',
     'ping',
 ]);
+
+const MAX_ATTEMPTS = 3;
+
+// Register a reprocessing handler so DLQ entries can be retried via the admin endpoint.
+webhookDLQ.registerProcessor('github', async (entry) => {
+    const payload = JSON.parse(entry.payload);
+    if (entry.eventType === 'push') {
+        const log = createLogger({ correlationId: 'dlq-reprocess', service: 'github-webhook' });
+        await handlePushEvent(payload, log);
+    }
+});
 
 /**
  * POST /api/webhooks/github
@@ -80,25 +92,28 @@ export async function POST(req: NextRequest) {
         return res;
     }
 
-    try {
-        if (eventType === 'push') {
-            await handlePushEvent(payload, log);
-        } else if (eventType === 'ping') {
-            log.info('Ping event received');
+    let lastError: Error | null = null;
+    for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+        try {
+            if (eventType === 'push') {
+                await handlePushEvent(payload, log);
+            } else if (eventType === 'ping') {
+                log.info('Ping event received');
+            }
+            const res = NextResponse.json({ received: true, processed: true });
+            res.headers.set(CORRELATION_ID_HEADER, correlationId);
+            return res;
+        } catch (error: any) {
+            lastError = error;
+            log.error(`Webhook attempt ${attempt}/${MAX_ATTEMPTS} failed`, error);
         }
-
-        const res = NextResponse.json({ received: true, processed: true });
-        res.headers.set(CORRELATION_ID_HEADER, correlationId);
-        return res;
-    } catch (error: any) {
-        log.error('Error processing webhook', error);
-        const res = NextResponse.json(
-            { error: 'Webhook processing failed' },
-            { status: 500 }
-        );
-        res.headers.set(CORRELATION_ID_HEADER, correlationId);
-        return res;
     }
+
+    webhookDLQ.capture('github', eventType, body, lastError?.message ?? 'Unknown error', MAX_ATTEMPTS);
+    // Return 200 so GitHub stops retrying — the event is safely in the DLQ.
+    const res = NextResponse.json({ received: true, processed: false, dlq: true });
+    res.headers.set(CORRELATION_ID_HEADER, correlationId);
+    return res;
 }
 
 /**

--- a/apps/backend/src/app/api/webhooks/stripe/route.ts
+++ b/apps/backend/src/app/api/webhooks/stripe/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { stripe } from '@/lib/stripe/client';
 import { paymentService } from '@/services/payment.service';
+import { webhookDLQ } from '@/lib/webhook-dlq/dead-letter-queue';
 
 const SUPPORTED_EVENTS = new Set([
     'checkout.session.completed',
@@ -11,12 +12,23 @@ const SUPPORTED_EVENTS = new Set([
     'invoice.payment_failed',
 ]);
 
+const MAX_ATTEMPTS = 3;
+
+// Register a reprocessing handler so DLQ entries can be retried via the admin endpoint.
+webhookDLQ.registerProcessor('stripe', async (entry) => {
+    const parsed = JSON.parse(entry.payload);
+    if (!SUPPORTED_EVENTS.has(parsed.type)) return;
+    await paymentService.handleWebhook(parsed);
+});
+
 /**
  * POST /api/webhooks/stripe
  *
  * Receives Stripe webhook events, verifies the signature, and delegates
  * to the payment service. Returns 200 for all successfully verified events
  * (including unsupported types) so Stripe does not retry unnecessarily.
+ *
+ * Failed events that exceed MAX_ATTEMPTS are captured in the DLQ.
  */
 export async function POST(req: NextRequest) {
     const body = await req.text();
@@ -52,14 +64,18 @@ export async function POST(req: NextRequest) {
         return NextResponse.json({ received: true });
     }
 
-    try {
-        await paymentService.handleWebhook(event);
-        return NextResponse.json({ received: true });
-    } catch (error: any) {
-        console.error('Error processing webhook:', error);
-        return NextResponse.json(
-            { error: 'Webhook processing failed' },
-            { status: 500 }
-        );
+    let lastError: Error | null = null;
+    for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+        try {
+            await paymentService.handleWebhook(event);
+            return NextResponse.json({ received: true });
+        } catch (error: any) {
+            lastError = error;
+            console.error(`Stripe webhook attempt ${attempt}/${MAX_ATTEMPTS} failed:`, error);
+        }
     }
+
+    webhookDLQ.capture('stripe', event.type, body, lastError?.message ?? 'Unknown error', MAX_ATTEMPTS);
+    // Return 200 so Stripe stops retrying — the event is safely in the DLQ.
+    return NextResponse.json({ received: true, dlq: true });
 }

--- a/apps/backend/src/lib/api/security-headers.ts
+++ b/apps/backend/src/lib/api/security-headers.ts
@@ -1,0 +1,68 @@
+/**
+ * Security headers applied to all API responses.
+ *
+ * CSP is in report-only mode in development so violations are visible in the
+ * browser console without breaking the app. In production the policy is
+ * enforced via Content-Security-Policy.
+ *
+ * References:
+ *   https://owasp.org/www-project-secure-headers/
+ *   https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
+ */
+
+const isDev = process.env.NODE_ENV !== 'production';
+
+const CSP_DIRECTIVES = {
+    'default-src': ["'self'"],
+    'script-src': ["'self'"],
+    'style-src': ["'self'", "'unsafe-inline'"],
+    'img-src': ["'self'", 'data:', 'https:'],
+    'font-src': ["'self'"],
+    'connect-src': [
+        "'self'",
+        'https://*.supabase.co',
+        'https://api.stripe.com',
+        'https://api.vercel.com',
+        'https://horizon-testnet.stellar.org',
+        'https://horizon.stellar.org',
+    ],
+    'frame-src': ["'none'"],
+    'object-src': ["'none'"],
+    'base-uri': ["'self'"],
+    'form-action': ["'self'"],
+    'upgrade-insecure-requests': [],
+};
+
+function buildCsp(): string {
+    return Object.entries(CSP_DIRECTIVES)
+        .map(([directive, values]) =>
+            values.length ? `${directive} ${values.join(' ')}` : directive
+        )
+        .join('; ');
+}
+
+const cspValue = buildCsp();
+
+export interface SecurityHeader {
+    key: string;
+    value: string;
+}
+
+/**
+ * Returns the full set of security headers.
+ * In development, CSP is report-only; in production it is enforced.
+ */
+export function getSecurityHeaders(): SecurityHeader[] {
+    const cspHeaderName = isDev
+        ? 'Content-Security-Policy-Report-Only'
+        : 'Content-Security-Policy';
+
+    return [
+        { key: cspHeaderName, value: cspValue },
+        { key: 'Strict-Transport-Security', value: 'max-age=63072000; includeSubDomains; preload' },
+        { key: 'X-Content-Type-Options', value: 'nosniff' },
+        { key: 'X-Frame-Options', value: 'DENY' },
+        { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+        { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=()' },
+    ];
+}

--- a/apps/backend/src/lib/api/with-role.ts
+++ b/apps/backend/src/lib/api/with-role.ts
@@ -1,0 +1,65 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '../supabase/server';
+import { withLogging, type Logger } from './logger';
+
+export type AppRole = 'admin';
+
+export type RoleRouteContext = {
+    userId: string;
+    correlationId: string;
+    log: Logger;
+};
+
+type RoleRouteHandler = (
+    req: NextRequest,
+    ctx: RoleRouteContext
+) => Promise<NextResponse>;
+
+/**
+ * RBAC middleware for admin analytics and aggregate-data routes.
+ *
+ * - Returns 401 for unauthenticated requests.
+ * - Returns 403 for authenticated users whose role doesn't match.
+ * - Role is resolved from user_metadata.role (set server-side via Supabase
+ *   admin) with a fallback to the ADMIN_USER_IDS env variable (comma-separated
+ *   user IDs). Roles are never trusted from client-supplied headers.
+ */
+export function withRole(requiredRole: AppRole, handler: RoleRouteHandler) {
+    return withLogging(async (req: NextRequest, { correlationId, log }) => {
+        const supabase = createClient();
+        const { data: { user }, error } = await supabase.auth.getUser();
+
+        if (error || !user) {
+            return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+        }
+
+        if (!hasRole(user, requiredRole)) {
+            log.warn('Access denied: insufficient role', {
+                userId: user.id,
+                requiredRole,
+            });
+            return NextResponse.json(
+                { error: 'Forbidden: insufficient role' },
+                { status: 403 }
+            );
+        }
+
+        return handler(req, { userId: user.id, correlationId, log });
+    });
+}
+
+function hasRole(
+    user: { id: string; user_metadata?: Record<string, unknown> },
+    role: AppRole
+): boolean {
+    // Primary: role stored in server-side user metadata (set via Supabase admin API).
+    if (user.user_metadata?.role === role) return true;
+
+    // Fallback: comma-separated allowlist in env (useful before metadata is provisioned).
+    const adminIds = process.env.ADMIN_USER_IDS;
+    if (role === 'admin' && adminIds) {
+        return adminIds.split(',').map((s) => s.trim()).includes(user.id);
+    }
+
+    return false;
+}

--- a/apps/backend/src/lib/webhook-dlq/dead-letter-queue.ts
+++ b/apps/backend/src/lib/webhook-dlq/dead-letter-queue.ts
@@ -1,0 +1,113 @@
+/**
+ * Webhook Dead Letter Queue (DLQ)
+ *
+ * Captures webhook events that exhaust all retry attempts so no event is
+ * silently lost. The in-process store is sufficient for single-instance
+ * deployments; replace the backing store with Redis / a DB table for
+ * horizontally-scaled environments.
+ *
+ * Reprocessing is guarded by a single-attempt-per-entry flag so the same
+ * entry cannot be requeued in an infinite loop.
+ */
+
+export type WebhookSource = 'stripe' | 'github';
+
+export interface DLQEntry {
+    id: string;
+    source: WebhookSource;
+    eventType: string;
+    payload: string;
+    failureReason: string;
+    attempts: number;
+    createdAt: Date;
+    reprocessedAt?: Date;
+    reprocessStatus?: 'pending' | 'succeeded' | 'failed';
+}
+
+type ProcessorFn = (entry: DLQEntry) => Promise<void>;
+
+const store = new Map<string, DLQEntry>();
+
+let _stripeProcessor: ProcessorFn | null = null;
+let _githubProcessor: ProcessorFn | null = null;
+
+function generateId(): string {
+    return `dlq_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`;
+}
+
+export const webhookDLQ = {
+    registerProcessor(source: WebhookSource, fn: ProcessorFn): void {
+        if (source === 'stripe') _stripeProcessor = fn;
+        else _githubProcessor = fn;
+    },
+
+    capture(
+        source: WebhookSource,
+        eventType: string,
+        payload: string,
+        failureReason: string,
+        attempts: number
+    ): DLQEntry {
+        const entry: DLQEntry = {
+            id: generateId(),
+            source,
+            eventType,
+            payload,
+            failureReason,
+            attempts,
+            createdAt: new Date(),
+            reprocessStatus: 'pending',
+        };
+        store.set(entry.id, entry);
+        console.error('[DLQ] Event captured', {
+            id: entry.id,
+            source,
+            eventType,
+            attempts,
+            failureReason,
+        });
+        return entry;
+    },
+
+    list(): DLQEntry[] {
+        return Array.from(store.values()).sort(
+            (a, b) => b.createdAt.getTime() - a.createdAt.getTime()
+        );
+    },
+
+    get(id: string): DLQEntry | undefined {
+        return store.get(id);
+    },
+
+    async reprocess(id: string): Promise<{ success: boolean; error?: string }> {
+        const entry = store.get(id);
+        if (!entry) return { success: false, error: 'Entry not found' };
+
+        if (entry.reprocessStatus === 'succeeded') {
+            return { success: false, error: 'Entry already successfully reprocessed' };
+        }
+
+        const processor = entry.source === 'stripe' ? _stripeProcessor : _githubProcessor;
+        if (!processor) {
+            return { success: false, error: `No processor registered for source: ${entry.source}` };
+        }
+
+        try {
+            await processor(entry);
+            entry.reprocessedAt = new Date();
+            entry.reprocessStatus = 'succeeded';
+            store.set(id, entry);
+            return { success: true };
+        } catch (err: any) {
+            entry.reprocessedAt = new Date();
+            entry.reprocessStatus = 'failed';
+            entry.failureReason = err?.message ?? 'Reprocessing failed';
+            store.set(id, entry);
+            return { success: false, error: entry.failureReason };
+        }
+    },
+
+    size(): number {
+        return store.size;
+    },
+};

--- a/docs/rbac-admin-middleware.md
+++ b/docs/rbac-admin-middleware.md
@@ -1,0 +1,60 @@
+# Role-Based Access Control (RBAC) — Admin Routes
+
+## Model
+
+| Role | Access |
+|---|---|
+| `admin` | Admin analytics, DLQ inspection/reprocessing |
+| (all authenticated users) | Own deployment analytics, profile data |
+| (unauthenticated) | Public routes only |
+
+## HTTP Status Codes
+
+| Scenario | Status |
+|---|---|
+| No session / invalid token | `401 Unauthorized` |
+| Authenticated but wrong role | `403 Forbidden` |
+| Correct role | `200` / route-specific |
+
+## Role Resolution
+
+Roles are resolved **server-side** from two sources in priority order:
+
+1. **Supabase `user_metadata.role`** — set via the Supabase admin API or a server-side migration. Never trusted from client-supplied input.
+2. **`ADMIN_USER_IDS` environment variable** — comma-separated list of Supabase user UUIDs that should be treated as admins. Useful during bootstrapping before metadata is provisioned.
+
+**Client-supplied roles are never trusted.**
+
+## Applying `withRole` to a Route
+
+```ts
+import { withRole } from '@/lib/api/with-role';
+
+export const GET = withRole('admin', async (req, { userId, log }) => {
+  // Only reachable by admin users
+  return NextResponse.json({ data: await fetchAdminData() });
+});
+```
+
+## Provisioning an Admin
+
+### Via Supabase admin API
+```bash
+curl -X PATCH https://<project>.supabase.co/auth/v1/admin/users/<user-id> \
+  -H "apikey: <service-role-key>" \
+  -H "Content-Type: application/json" \
+  -d '{"user_metadata": {"role": "admin"}}'
+```
+
+### Via environment variable (development/bootstrap)
+```env
+ADMIN_USER_IDS=uuid-1,uuid-2
+```
+
+## Protected Routes
+
+| Route | Method | Required Role |
+|---|---|---|
+| `/api/admin/analytics` | `GET` | `admin` |
+| `/api/admin/webhooks/dlq` | `GET` | `admin` |
+| `/api/admin/webhooks/dlq` | `POST` | `admin` |

--- a/docs/security-scanning.md
+++ b/docs/security-scanning.md
@@ -350,3 +350,44 @@ chmod +x scripts/security-scan.sh
 - [Dependency Management](./dependencies.md)
 - [CI/CD Pipeline](./deployment-guide.md)
 - [npm audit Documentation](https://docs.npmjs.com/cli/v8/commands/npm-audit)
+
+---
+
+## HTTP Security Headers
+
+Security headers are applied to all `/api/*` responses via `next.config.js`. The policy is based on the [OWASP Secure Headers Project](https://owasp.org/www-project-secure-headers/).
+
+### Applied Headers
+
+| Header | Value | Purpose |
+|---|---|---|
+| `Content-Security-Policy` | see below | Prevents XSS and data injection |
+| `Strict-Transport-Security` | `max-age=63072000; includeSubDomains; preload` | Enforces HTTPS |
+| `X-Content-Type-Options` | `nosniff` | Prevents MIME-type sniffing |
+| `X-Frame-Options` | `DENY` | Prevents clickjacking |
+| `Referrer-Policy` | `strict-origin-when-cross-origin` | Limits referrer leakage |
+| `Permissions-Policy` | `camera=(), microphone=(), geolocation=()` | Disables unused browser APIs |
+
+### Content Security Policy Directives
+
+```
+default-src 'self';
+script-src 'self';
+style-src 'self' 'unsafe-inline';
+img-src 'self' data: https:;
+font-src 'self';
+connect-src 'self' https://*.supabase.co https://api.stripe.com
+            https://api.vercel.com https://horizon-testnet.stellar.org
+            https://horizon.stellar.org;
+frame-src 'none';
+object-src 'none';
+base-uri 'self';
+form-action 'self';
+upgrade-insecure-requests
+```
+
+### Development vs Production
+
+In `NODE_ENV=development` the policy is sent as `Content-Security-Policy-Report-Only` so violations appear in the browser console without blocking requests. In production it is enforced via `Content-Security-Policy`.
+
+To adjust directives, edit `next.config.js` (`CSP_DIRECTIVES` object). The canonical utility that produces the same set of headers programmatically lives in `src/lib/api/security-headers.ts`.

--- a/docs/webhook-dead-letter-queue.md
+++ b/docs/webhook-dead-letter-queue.md
@@ -1,0 +1,96 @@
+# Webhook Dead Letter Queue (DLQ)
+
+## Overview
+
+When a webhook event (Stripe or GitHub) fails to process after `MAX_ATTEMPTS` (3) retries, the full original payload and failure reason are captured in the Dead Letter Queue instead of being silently dropped.
+
+## DLQ Workflow
+
+```
+Webhook received
+       │
+  verify signature
+       │
+  attempt processing ──► success ──► 200 OK
+       │ (up to 3x)
+       ▼ all attempts failed
+  capture to DLQ ──► 200 OK (so provider stops retrying)
+       │
+  Admin inspects via GET /api/admin/webhooks/dlq
+       │
+  Admin triggers reprocess via POST /api/admin/webhooks/dlq
+       │
+  processor re-runs ──► success: entry marked succeeded
+                    └──► failure: entry marked failed, reason updated
+```
+
+## DLQ Entry Schema
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | string | Unique DLQ entry ID (`dlq_<timestamp>_<random>`) |
+| `source` | `stripe` \| `github` | Webhook origin |
+| `eventType` | string | Event type (e.g. `invoice.payment_failed`, `push`) |
+| `payload` | string | Full original raw JSON payload |
+| `failureReason` | string | Error message from the last failed attempt |
+| `attempts` | number | Number of processing attempts made before capture |
+| `createdAt` | ISO 8601 | When the entry was captured |
+| `reprocessedAt` | ISO 8601 \| undefined | When reprocessing was last attempted |
+| `reprocessStatus` | `pending` \| `succeeded` \| `failed` | Outcome of latest reprocess attempt |
+
+## Admin Endpoints
+
+Both endpoints require the `admin` role (see [RBAC docs](./rbac-admin-middleware.md)).
+
+### `GET /api/admin/webhooks/dlq`
+
+Returns all DLQ entries sorted newest-first.
+
+```json
+{
+  "total": 1,
+  "entries": [
+    {
+      "id": "dlq_1716900000000_abc1234",
+      "source": "stripe",
+      "eventType": "invoice.payment_failed",
+      "payload": "{...}",
+      "failureReason": "Payment service unavailable",
+      "attempts": 3,
+      "createdAt": "2024-05-28T12:00:00.000Z",
+      "reprocessStatus": "pending"
+    }
+  ]
+}
+```
+
+### `POST /api/admin/webhooks/dlq`
+
+Reprocess a single DLQ entry.
+
+**Request body:**
+```json
+{ "id": "dlq_1716900000000_abc1234" }
+```
+
+**Response (success):**
+```json
+{ "success": true, "entry": { ...updated entry... } }
+```
+
+**Response (failure):**
+```json
+{ "error": "Payment service unavailable", "entry": { ...entry with failed status... } }
+```
+
+## Preventing Infinite Loops
+
+- Each entry can only be marked `succeeded` once; reprocessing a succeeded entry returns a 422.
+- There is no automatic re-enqueueing; reprocessing is always manually triggered by an admin.
+
+## Production Recommendations
+
+The current backing store is in-process memory, suitable for single-instance deployments. For multi-instance or durable storage requirements:
+
+1. Replace the `Map` in `src/lib/webhook-dlq/dead-letter-queue.ts` with a Supabase table or Redis sorted set.
+2. Add a database migration to create a `webhook_dlq` table with columns matching `DLQEntry`.


### PR DESCRIPTION
## Summary

- **#601** — Webhook Dead Letter Queue: captures failed Stripe/GitHub events after 3 retry attempts; adds `GET/POST /api/admin/webhooks/dlq` for admin inspection and reprocessing; prevents infinite loops.
- **#602** — Health Check Dependency Graph: extends `/api/cron/health-check` to check database, Stellar, Vercel, and Stripe connectivity with per-dependency response times; returns `503` when the database is down.
- **#603** — CSP & Security Headers: applies CSP, HSTS, `X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`, and `Permissions-Policy` to all `/api/*` routes via `next.config.js`; report-only in development, enforced in production.
- **#604** — RBAC Middleware: `withRole('admin', handler)` checks `user_metadata.role` (Supabase) or `ADMIN_USER_IDS` env var; returns `401` for unauthenticated, `403` for insufficient role; applied to admin analytics and DLQ routes.

## New files

| File | Purpose |
|---|---|
| `src/lib/webhook-dlq/dead-letter-queue.ts` | DLQ store + reprocessor registry |
| `src/app/api/admin/webhooks/dlq/route.ts` | Admin DLQ inspect/reprocess endpoint |
| `src/lib/api/with-role.ts` | RBAC middleware |
| `src/app/api/admin/analytics/route.ts` | Admin aggregate analytics (admin-only) |
| `src/lib/api/security-headers.ts` | Security headers utility |
| `docs/webhook-dead-letter-queue.md` | DLQ workflow documentation |
| `docs/rbac-admin-middleware.md` | RBAC model documentation |

## Modified files

| File | Change |
|---|---|
| `src/app/api/webhooks/stripe/route.ts` | 3-retry loop + DLQ capture |
| `src/app/api/webhooks/github/route.ts` | 3-retry loop + DLQ capture + reprocessor |
| `src/app/api/cron/health-check/route.ts` | Full dependency graph with response times |
| `next.config.js` | Security headers on all `/api/*` routes |
| `docs/security-scanning.md` | CSP policy documentation section |

Closes #601 
closes #602 
closes  #603 
closes #604 

🤖 Generated with [Claude Code](https://claude.com/claude-code)