### PR TITLE
feat(github): add commit status reporting for deployment pipeline progress

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,10 @@ GITHUB_APP_INSTALLATION_ID=12345678
 GITHUB_API_BASE_URL=https://api.github.com
 GITHUB_ORG=craft-templates
 GITHUB_WEBHOOK_SECRET=whsec_xxxxxxxxxxxxx
+# Context label used in GitHub commit status checks.
+# Appears as the "check name" in GitHub PR and commit views.
+# Default: craft/deployment
+GITHUB_COMMIT_STATUS_CONTEXT=craft/deployment
 
 # Vercel
 VERCEL_TOKEN=xxxxxxxxxxxxx

--- a/apps/backend/src/lib/retry/exponential-backoff.ts
+++ b/apps/backend/src/lib/retry/exponential-backoff.ts
@@ -11,16 +11,18 @@ export interface RetryOptions {
     backoffMultiplier?: number;
 }
 
-export interface RetryResult<T> {
-    success: true;
-    data: T;
-    attempts: number;
-} | {
-    success: false;
-    error: Error;
-    attempts: number;
-    totalDurationMs: number;
-}
+export type RetryResult<T> =
+    | {
+          success: true;
+          data: T;
+          attempts: number;
+      }
+    | {
+          success: false;
+          error: Error;
+          attempts: number;
+          totalDurationMs: number;
+      };
 
 const DEFAULT_MAX_ATTEMPTS = 5;
 const DEFAULT_INITIAL_DELAY_MS = 100;

--- a/apps/backend/src/services/deployment-pipeline.service.test.ts
+++ b/apps/backend/src/services/deployment-pipeline.service.test.ts
@@ -1090,3 +1090,239 @@ describe('DeploymentPipelineService — rollback on failure (#480)', () => {
         expect(updateSvc.rollbackUpdate).not.toHaveBeenCalled();
     });
 });
+
+// ── Issue #651 — GitHub Commit Status Reporting ───────────────────────────────
+//
+// Verifies that the deployment pipeline calls the GitHubCommitStatusService at
+// the correct stages and that status-reporting failures NEVER block the pipeline.
+
+describe('DeploymentPipelineService — GitHub commit status reporting (#651)', () => {
+    function makeCommitStatusMock(reportResult: { success: boolean; error?: string } = { success: true }) {
+        return {
+            reportPending: vi.fn().mockResolvedValue(reportResult),
+            reportSuccess: vi.fn().mockResolvedValue(reportResult),
+            reportFailure: vi.fn().mockResolvedValue(reportResult),
+        };
+    }
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockInsert.mockResolvedValue({ error: null });
+        mockUpdate.mockReturnValue({ eq: vi.fn().mockResolvedValue({ error: null }) });
+    });
+
+    it('reports pending status after a successful code push', async () => {
+        const commitStatusMock = makeCommitStatusMock();
+        const svc = new DeploymentPipelineService(
+            makeGeneratorMock(),
+            makeGithubMock(),
+            makeGithubPushMock(),
+            makeVercelMock(),
+            makeSyntaxValidatorMock(),
+            makeArtifactSigningMock(),
+            null,
+            commitStatusMock,
+        );
+
+        const result = await svc.deploy(request);
+
+        expect(result.success).toBe(true);
+        expect(commitStatusMock.reportPending).toHaveBeenCalledOnce();
+    });
+
+    it('reports success status after the pipeline completes', async () => {
+        const commitStatusMock = makeCommitStatusMock();
+        const svc = new DeploymentPipelineService(
+            makeGeneratorMock(),
+            makeGithubMock(),
+            makeGithubPushMock(),
+            makeVercelMock(),
+            makeSyntaxValidatorMock(),
+            makeArtifactSigningMock(),
+            null,
+            commitStatusMock,
+        );
+
+        const result = await svc.deploy(request);
+
+        expect(result.success).toBe(true);
+        expect(commitStatusMock.reportSuccess).toHaveBeenCalledOnce();
+        expect(commitStatusMock.reportFailure).not.toHaveBeenCalled();
+    });
+
+    it('reports pending with the commit SHA from the push result', async () => {
+        const commitStatusMock = makeCommitStatusMock();
+        const svc = new DeploymentPipelineService(
+            makeGeneratorMock(),
+            makeGithubMock(),
+            makeGithubPushMock(),
+            makeVercelMock(),
+            makeSyntaxValidatorMock(),
+            makeArtifactSigningMock(),
+            null,
+            commitStatusMock,
+        );
+
+        await svc.deploy(request);
+
+        const [, , sha] = commitStatusMock.reportPending.mock.calls[0] as string[];
+        // makeGithubPushMock returns commitSha: 'abc1234'
+        expect(sha).toBe('abc1234');
+    });
+
+    it('does NOT report a commit status when the pipeline fails before pushing code', async () => {
+        const commitStatusMock = makeCommitStatusMock();
+        const svc = new DeploymentPipelineService(
+            makeGeneratorMock(false), // fails at generating — no commit SHA yet
+            makeGithubMock(),
+            makeGithubPushMock(),
+            makeVercelMock(),
+            makeSyntaxValidatorMock(),
+            makeArtifactSigningMock(),
+            null,
+            commitStatusMock,
+        );
+
+        const result = await svc.deploy(request);
+
+        expect(result.success).toBe(false);
+        expect(commitStatusMock.reportPending).not.toHaveBeenCalled();
+        expect(commitStatusMock.reportSuccess).not.toHaveBeenCalled();
+        expect(commitStatusMock.reportFailure).not.toHaveBeenCalled();
+    });
+
+    it('does NOT report success when the Vercel deployment step fails', async () => {
+        const commitStatusMock = makeCommitStatusMock();
+        const svc = new DeploymentPipelineService(
+            makeGeneratorMock(),
+            makeGithubMock(),
+            makeGithubPushMock(),
+            makeVercelMock(true), // Vercel fails
+            makeSyntaxValidatorMock(),
+            makeArtifactSigningMock(),
+            null,
+            commitStatusMock,
+        );
+
+        const result = await svc.deploy(request);
+
+        expect(result.success).toBe(false);
+        expect(commitStatusMock.reportSuccess).not.toHaveBeenCalled();
+    });
+
+    it('does NOT block the pipeline when reportPending returns a failure result', async () => {
+        const commitStatusMock = makeCommitStatusMock({ success: false, error: 'GitHub API unreachable' });
+        const svc = new DeploymentPipelineService(
+            makeGeneratorMock(),
+            makeGithubMock(),
+            makeGithubPushMock(),
+            makeVercelMock(),
+            makeSyntaxValidatorMock(),
+            makeArtifactSigningMock(),
+            null,
+            commitStatusMock,
+        );
+
+        // Entire pipeline must still succeed even though status reporting failed
+        const result = await svc.deploy(request);
+
+        expect(result.success).toBe(true);
+        expect(result.deploymentUrl).toBe('https://craft-my-dex-app.vercel.app');
+    });
+
+    it('does NOT block the pipeline when reportSuccess throws unexpectedly', async () => {
+        const commitStatusMock = {
+            reportPending: vi.fn().mockResolvedValue({ success: true }),
+            reportSuccess: vi.fn().mockRejectedValue(new Error('Unexpected commit status error')),
+            reportFailure: vi.fn().mockResolvedValue({ success: true }),
+        };
+        const svc = new DeploymentPipelineService(
+            makeGeneratorMock(),
+            makeGithubMock(),
+            makeGithubPushMock(),
+            makeVercelMock(),
+            makeSyntaxValidatorMock(),
+            makeArtifactSigningMock(),
+            null,
+            commitStatusMock,
+        );
+
+        const result = await svc.deploy(request);
+
+        expect(result.success).toBe(true);
+    });
+
+    it('does NOT block the pipeline when reportPending throws unexpectedly', async () => {
+        const commitStatusMock = {
+            reportPending: vi.fn().mockRejectedValue(new Error('Status API down')),
+            reportSuccess: vi.fn().mockResolvedValue({ success: true }),
+            reportFailure: vi.fn().mockResolvedValue({ success: true }),
+        };
+        const svc = new DeploymentPipelineService(
+            makeGeneratorMock(),
+            makeGithubMock(),
+            makeGithubPushMock(),
+            makeVercelMock(),
+            makeSyntaxValidatorMock(),
+            makeArtifactSigningMock(),
+            null,
+            commitStatusMock,
+        );
+
+        const result = await svc.deploy(request);
+
+        // Pipeline must complete successfully regardless of status reporting failure
+        expect(result.success).toBe(true);
+        expect(result.deploymentUrl).toBeDefined();
+    });
+
+    it('writes a warn log when commit status reporting returns a failure result', async () => {
+        const commitStatusMock = makeCommitStatusMock({ success: false, error: 'token missing' });
+        const svc = new DeploymentPipelineService(
+            makeGeneratorMock(),
+            makeGithubMock(),
+            makeGithubPushMock(),
+            makeVercelMock(),
+            makeSyntaxValidatorMock(),
+            makeArtifactSigningMock(),
+            null,
+            commitStatusMock,
+        );
+
+        await svc.deploy(request);
+
+        const warnLogs = mockInsert.mock.calls
+            .map((call: any[]) => call[0])
+            .filter((p: any) => p?.level === 'warn' && p?.stage === 'commit_status');
+
+        expect(warnLogs.length).toBeGreaterThan(0);
+        expect(warnLogs[0].message).toContain('token missing');
+    });
+
+    it('writes a warn log when commit status reporting throws unexpectedly', async () => {
+        const commitStatusMock = {
+            reportPending: vi.fn().mockRejectedValue(new Error('unexpected throw')),
+            reportSuccess: vi.fn().mockResolvedValue({ success: true }),
+            reportFailure: vi.fn().mockResolvedValue({ success: true }),
+        };
+        const svc = new DeploymentPipelineService(
+            makeGeneratorMock(),
+            makeGithubMock(),
+            makeGithubPushMock(),
+            makeVercelMock(),
+            makeSyntaxValidatorMock(),
+            makeArtifactSigningMock(),
+            null,
+            commitStatusMock,
+        );
+
+        await svc.deploy(request);
+
+        const warnLogs = mockInsert.mock.calls
+            .map((call: any[]) => call[0])
+            .filter((p: any) => p?.level === 'warn' && p?.stage === 'commit_status');
+
+        expect(warnLogs.length).toBeGreaterThan(0);
+        expect(warnLogs[0].message).toContain('unexpected throw');
+    });
+});

--- a/apps/backend/src/services/deployment-pipeline.service.ts
+++ b/apps/backend/src/services/deployment-pipeline.service.ts
@@ -22,6 +22,15 @@
  *   - Partial code push → deployment marked failed; the repo may be empty
  *     or partial — the UI should prompt a retry.
  *
+ * GitHub Commit Status Reporting:
+ *   After the commit SHA is known (post-push), GitHub commit statuses are
+ *   posted at each terminal transition:
+ *     pending  → pipeline started
+ *     success  → deployment completed
+ *     failure  → any stage failed
+ *   Status-reporting failures are silently caught and logged — they NEVER
+ *   block or abort the deployment pipeline.
+ *
  * Design doc properties satisfied:
  *   Property 20 — Deployment Pipeline Sequence (generation → repo → push → vercel → URL)
  *   Property 21 — Vercel Environment Variable Configuration
@@ -35,6 +44,9 @@
  *
  * Issue: #114
  * Branch: issue-114-add-structured-logging-with-correlation-ids
+ *
+ * Issue: #651
+ * Branch: feat/issue-115-github-commit-status-reporting
  */
 
 import { createClient } from '@/lib/supabase/server';
@@ -52,6 +64,7 @@ import type { TemplateFamilyId } from './code-generator.service';
 import { syntaxValidator, type SyntaxValidator } from './syntax-validator';
 import { artifactSigningService, ArtifactSigningService } from './artifact-signing.service';
 import { deploymentUpdateService, DeploymentUpdateService } from './deployment-update.service';
+import { githubCommitStatusService, GitHubCommitStatusService } from './github-commit-status.service';
 
 // ── Request / result types ────────────────────────────────────────────────────
 
@@ -106,6 +119,7 @@ export class DeploymentPipelineService {
         private readonly _syntaxValidator: Pick<SyntaxValidator, 'validate'> = syntaxValidator,
         private readonly _artifactSigningService: ArtifactSigningService = artifactSigningService,
         private readonly _deploymentUpdateService: Pick<DeploymentUpdateService, 'rollbackUpdate'> | null = null,
+        private readonly _commitStatusService: Pick<GitHubCommitStatusService, 'reportPending' | 'reportSuccess' | 'reportFailure'> = githubCommitStatusService,
     ) {}
 
     /**
@@ -321,6 +335,8 @@ export class DeploymentPipelineService {
         const githubToken = process.env.GITHUB_TOKEN ?? '';
         const [owner, repo] = repoFullName.split('/');
 
+        let commitSha: string | undefined;
+
         try {
             const commitRef = await this._githubPushService.pushGeneratedCode({
                 owner,
@@ -333,12 +349,23 @@ export class DeploymentPipelineService {
                 authorEmail: 'craft@stellercraft.io',
             });
 
+            commitSha = commitRef.commitSha;
+
             await this.log(
                 deploymentId,
                 'pushing_code',
                 `Pushed ${commitRef.fileCount} files — commit ${commitRef.commitSha.slice(0, 7)}`,
                 'info',
                 { correlationId, commitSha: commitRef.commitSha, fileCount: commitRef.fileCount },
+            );
+
+            // ── Post "pending" commit status now that we have a commit SHA ──────
+            // Non-fatal: any error is caught and logged but does not block the pipeline.
+            await this.reportCommitStatus(
+                () => this._commitStatusService.reportPending(owner, repo, commitSha!, deploymentId, 'Deployment'),
+                deploymentId,
+                correlationId,
+                'pending',
             );
         } catch (err: unknown) {
             const msg = err instanceof Error ? err.message : 'Unknown push error';
@@ -459,6 +486,16 @@ export class DeploymentPipelineService {
             { correlationId, deploymentUrl },
         );
 
+        // ── Post "success" commit status ──────────────────────────────────────
+        if (commitSha) {
+            await this.reportCommitStatus(
+                () => this._commitStatusService.reportSuccess(owner, repo, commitSha!, deploymentId, deploymentUrl),
+                deploymentId,
+                correlationId,
+                'success',
+            );
+        }
+
         logger.info('Deployment pipeline completed', { deploymentId, deploymentUrl });
 
         return {
@@ -507,6 +544,7 @@ export class DeploymentPipelineService {
         errorMessage: string,
         metadata?: Record<string, unknown>,
         updateContext?: { updateId: string; deploymentId: string },
+        commitContext?: { owner: string; repo: string; sha: string },
     ): Promise<DeploymentPipelineResult> {
         const supabase = createClient();
 
@@ -531,7 +569,22 @@ export class DeploymentPipelineService {
             );
         }
 
+        // ── Post "failure" commit status (best-effort) ────────────────────────
         const correlationId = (metadata?.correlationId as string | undefined) ?? '';
+        if (commitContext) {
+            await this.reportCommitStatus(
+                () => this._commitStatusService.reportFailure(
+                    commitContext.owner,
+                    commitContext.repo,
+                    commitContext.sha,
+                    deploymentId,
+                    stage,
+                ),
+                deploymentId,
+                correlationId,
+                'failure',
+            );
+        }
 
         return {
             success: false,
@@ -540,6 +593,39 @@ export class DeploymentPipelineService {
             errorMessage,
             failedStage: stage,
         };
+    }
+
+    /**
+     * Calls `fn` and swallows any error, logging a warning instead.
+     * This ensures commit status reporting failures never block the pipeline.
+     */
+    private async reportCommitStatus(
+        fn: () => Promise<{ success: boolean; error?: string }>,
+        deploymentId: string,
+        correlationId: string,
+        label: string,
+    ): Promise<void> {
+        try {
+            const result = await fn();
+            if (!result.success) {
+                await this.log(
+                    deploymentId,
+                    'commit_status',
+                    `GitHub commit status (${label}) not posted: ${result.error ?? 'unknown error'}`,
+                    'warn',
+                    { correlationId },
+                );
+            }
+        } catch (err: unknown) {
+            const msg = err instanceof Error ? err.message : 'Unknown error';
+            await this.log(
+                deploymentId,
+                'commit_status',
+                `GitHub commit status reporting threw unexpectedly (${label}): ${msg}`,
+                'warn',
+                { correlationId },
+            );
+        }
     }
 
     /**
@@ -572,4 +658,5 @@ export const deploymentPipelineService = new DeploymentPipelineService(
     syntaxValidator,
     artifactSigningService,
     deploymentUpdateService,
+    githubCommitStatusService,
 );

--- a/apps/backend/src/services/github-commit-status.service.test.ts
+++ b/apps/backend/src/services/github-commit-status.service.test.ts
@@ -1,0 +1,437 @@
+/**
+ * Tests for GitHubCommitStatusService
+ *
+ * Covers:
+ *   - postCommitStatus: happy path (pending, success, failure, error states)
+ *   - postCommitStatus: missing GITHUB_TOKEN → returns failure without throwing
+ *   - postCommitStatus: GitHub API error response → returns failure without throwing
+ *   - postCommitStatus: network error → returns failure without throwing
+ *   - postCommitStatus: description truncated to 140 chars
+ *   - postCommitStatus: targetUrl omitted when not provided
+ *   - reportPending: delegates to postCommitStatus with correct payload
+ *   - reportSuccess: includes deployment URL in description
+ *   - reportFailure: includes failed stage in description
+ *   - buildDeploymentDetailUrl: constructs correct URL
+ *
+ * Issue: #651
+ * Branch: feat/issue-115-github-commit-status-reporting
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+    GitHubCommitStatusService,
+    buildDeploymentDetailUrl,
+    type PostCommitStatusRequest,
+} from './github-commit-status.service';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeOkFetch(statusCode = 201): ReturnType<typeof vi.fn> {
+    return vi.fn().mockResolvedValue({
+        ok: true,
+        status: statusCode,
+        json: vi.fn().mockResolvedValue({ id: 1 }),
+    });
+}
+
+function makeErrorFetch(statusCode: number, message = 'Not Found'): ReturnType<typeof vi.fn> {
+    return vi.fn().mockResolvedValue({
+        ok: false,
+        status: statusCode,
+        json: vi.fn().mockResolvedValue({ message }),
+    });
+}
+
+function makeNetworkErrorFetch(message = 'Network failure'): ReturnType<typeof vi.fn> {
+    return vi.fn().mockRejectedValue(new Error(message));
+}
+
+function makeBaseRequest(overrides?: Partial<PostCommitStatusRequest>): PostCommitStatusRequest {
+    return {
+        owner: 'org',
+        repo: 'my-dex-app',
+        sha: 'abc1234def5678abc1234def5678abc1234def56',
+        state: 'pending',
+        context: 'craft/deployment',
+        description: 'Deployment is in progress…',
+        targetUrl: 'https://craft.app/app/deployments/deploy-001',
+        ...overrides,
+    };
+}
+
+// ── buildDeploymentDetailUrl ──────────────────────────────────────────────────
+
+describe('buildDeploymentDetailUrl', () => {
+    it('constructs the correct URL from a base app URL', () => {
+        const url = buildDeploymentDetailUrl('deploy-abc', 'https://craft.app');
+        expect(url).toBe('https://craft.app/app/deployments/deploy-abc');
+    });
+
+    it('strips a trailing slash from the base URL', () => {
+        const url = buildDeploymentDetailUrl('deploy-xyz', 'https://craft.app/');
+        expect(url).toBe('https://craft.app/app/deployments/deploy-xyz');
+    });
+
+    it('falls back to NEXT_PUBLIC_APP_URL env var when no appUrl is provided', () => {
+        const originalEnv = process.env.NEXT_PUBLIC_APP_URL;
+        process.env.NEXT_PUBLIC_APP_URL = 'https://staging.craft.app';
+        try {
+            const url = buildDeploymentDetailUrl('deploy-123');
+            expect(url).toBe('https://staging.craft.app/app/deployments/deploy-123');
+        } finally {
+            process.env.NEXT_PUBLIC_APP_URL = originalEnv;
+        }
+    });
+});
+
+// ── postCommitStatus ──────────────────────────────────────────────────────────
+
+describe('GitHubCommitStatusService — postCommitStatus', () => {
+    const originalToken = process.env.GITHUB_TOKEN;
+
+    beforeEach(() => {
+        process.env.GITHUB_TOKEN = 'ghp_test_token';
+    });
+
+    afterEach(() => {
+        process.env.GITHUB_TOKEN = originalToken;
+    });
+
+    it('returns success when the GitHub API responds 201', async () => {
+        const fetchMock = makeOkFetch(201);
+        const svc = new GitHubCommitStatusService(fetchMock);
+
+        const result = await svc.postCommitStatus(makeBaseRequest());
+
+        expect(result.success).toBe(true);
+        expect(result.statusCode).toBe(201);
+        expect(result.error).toBeUndefined();
+    });
+
+    it('sends a POST to the correct GitHub Statuses API endpoint', async () => {
+        const fetchMock = makeOkFetch();
+        const svc = new GitHubCommitStatusService(fetchMock);
+        const req = makeBaseRequest();
+
+        await svc.postCommitStatus(req);
+
+        const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+        expect(url).toBe(`https://api.github.com/repos/${req.owner}/${req.repo}/statuses/${req.sha}`);
+        expect((init as any).method).toBe('POST');
+    });
+
+    it('includes the correct Authorization header', async () => {
+        const fetchMock = makeOkFetch();
+        const svc = new GitHubCommitStatusService(fetchMock);
+
+        await svc.postCommitStatus(makeBaseRequest());
+
+        const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+        expect((init.headers as Record<string, string>)['Authorization']).toBe('Bearer ghp_test_token');
+    });
+
+    it('sends the correct payload body', async () => {
+        const fetchMock = makeOkFetch();
+        const svc = new GitHubCommitStatusService(fetchMock);
+        const req = makeBaseRequest({ state: 'success', context: 'craft/deployment', description: 'Done', targetUrl: 'https://craft.app' });
+
+        await svc.postCommitStatus(req);
+
+        const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+        const body = JSON.parse(init.body as string);
+        expect(body.state).toBe('success');
+        expect(body.context).toBe('craft/deployment');
+        expect(body.description).toBe('Done');
+        expect(body.target_url).toBe('https://craft.app');
+    });
+
+    it('omits target_url from the payload when targetUrl is not provided', async () => {
+        const fetchMock = makeOkFetch();
+        const svc = new GitHubCommitStatusService(fetchMock);
+        const req = makeBaseRequest({ targetUrl: undefined });
+
+        await svc.postCommitStatus(req);
+
+        const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+        const body = JSON.parse(init.body as string);
+        expect(body).not.toHaveProperty('target_url');
+    });
+
+    it('truncates description to 140 characters when it is too long', async () => {
+        const fetchMock = makeOkFetch();
+        const svc = new GitHubCommitStatusService(fetchMock);
+        const longDesc = 'x'.repeat(200);
+        const req = makeBaseRequest({ description: longDesc });
+
+        await svc.postCommitStatus(req);
+
+        const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+        const body = JSON.parse(init.body as string);
+        expect(body.description.length).toBeLessThanOrEqual(140);
+        expect(body.description).toMatch(/…$/);
+    });
+
+    it('does not truncate descriptions that are exactly 140 characters', async () => {
+        const fetchMock = makeOkFetch();
+        const svc = new GitHubCommitStatusService(fetchMock);
+        const exactDesc = 'x'.repeat(140);
+
+        await svc.postCommitStatus(makeBaseRequest({ description: exactDesc }));
+
+        const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+        const body = JSON.parse(init.body as string);
+        expect(body.description).toBe(exactDesc);
+        expect(body.description.length).toBe(140);
+    });
+
+    it('returns failure (without throwing) when GITHUB_TOKEN is not set', async () => {
+        delete process.env.GITHUB_TOKEN;
+        const fetchMock = makeOkFetch();
+        const svc = new GitHubCommitStatusService(fetchMock);
+
+        const result = await svc.postCommitStatus(makeBaseRequest());
+
+        expect(result.success).toBe(false);
+        expect(result.error).toContain('GITHUB_TOKEN');
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('returns failure when GitHub API responds with a non-ok status', async () => {
+        const fetchMock = makeErrorFetch(422, 'Unprocessable Entity');
+        const svc = new GitHubCommitStatusService(fetchMock);
+
+        const result = await svc.postCommitStatus(makeBaseRequest());
+
+        expect(result.success).toBe(false);
+        expect(result.statusCode).toBe(422);
+        expect(result.error).toContain('Unprocessable Entity');
+    });
+
+    it('returns failure when the network call throws (never re-throws)', async () => {
+        const fetchMock = makeNetworkErrorFetch('ECONNREFUSED');
+        const svc = new GitHubCommitStatusService(fetchMock);
+
+        const result = await svc.postCommitStatus(makeBaseRequest());
+
+        expect(result.success).toBe(false);
+        expect(result.error).toContain('ECONNREFUSED');
+    });
+
+    it('does not throw even when fetch throws an unknown (non-Error) value', async () => {
+        const fetchMock = vi.fn().mockRejectedValue('string error');
+        const svc = new GitHubCommitStatusService(fetchMock);
+
+        await expect(svc.postCommitStatus(makeBaseRequest())).resolves.not.toThrow();
+    });
+
+    it('returns failure with GitHub error message when API response body contains message', async () => {
+        const fetchMock = makeErrorFetch(404, 'Not Found');
+        const svc = new GitHubCommitStatusService(fetchMock);
+
+        const result = await svc.postCommitStatus(makeBaseRequest());
+
+        expect(result.success).toBe(false);
+        expect(result.error).toBe('Not Found');
+    });
+
+    it('falls back to status code in error message when response body has no message', async () => {
+        const fetchMock = vi.fn().mockResolvedValue({
+            ok: false,
+            status: 500,
+            json: vi.fn().mockResolvedValue({}),
+        });
+        const svc = new GitHubCommitStatusService(fetchMock);
+
+        const result = await svc.postCommitStatus(makeBaseRequest());
+
+        expect(result.success).toBe(false);
+        expect(result.error).toContain('500');
+    });
+});
+
+// ── reportPending ─────────────────────────────────────────────────────────────
+
+describe('GitHubCommitStatusService — reportPending', () => {
+    const originalToken = process.env.GITHUB_TOKEN;
+
+    beforeEach(() => {
+        process.env.GITHUB_TOKEN = 'ghp_test_token';
+    });
+
+    afterEach(() => {
+        process.env.GITHUB_TOKEN = originalToken;
+    });
+
+    it('posts a pending state with correct context', async () => {
+        const fetchMock = makeOkFetch();
+        const svc = new GitHubCommitStatusService(fetchMock);
+
+        const result = await svc.reportPending('org', 'repo', 'sha123', 'deploy-001');
+
+        expect(result.success).toBe(true);
+        const body = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string);
+        expect(body.state).toBe('pending');
+        expect(body.context).toBe('craft/deployment');
+    });
+
+    it('includes the deployment detail URL as target_url', async () => {
+        const fetchMock = makeOkFetch();
+        const svc = new GitHubCommitStatusService(fetchMock);
+
+        process.env.NEXT_PUBLIC_APP_URL = 'https://craft.app';
+        await svc.reportPending('org', 'repo', 'sha123', 'deploy-001');
+
+        const body = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string);
+        expect(body.target_url).toContain('deploy-001');
+    });
+
+    it('uses the stageName parameter in the description', async () => {
+        const fetchMock = makeOkFetch();
+        const svc = new GitHubCommitStatusService(fetchMock);
+
+        await svc.reportPending('org', 'repo', 'sha123', 'deploy-001', 'Code Generation');
+
+        const body = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string);
+        expect(body.description).toContain('Code Generation');
+    });
+});
+
+// ── reportSuccess ─────────────────────────────────────────────────────────────
+
+describe('GitHubCommitStatusService — reportSuccess', () => {
+    const originalToken = process.env.GITHUB_TOKEN;
+
+    beforeEach(() => {
+        process.env.GITHUB_TOKEN = 'ghp_test_token';
+    });
+
+    afterEach(() => {
+        process.env.GITHUB_TOKEN = originalToken;
+    });
+
+    it('posts a success state', async () => {
+        const fetchMock = makeOkFetch();
+        const svc = new GitHubCommitStatusService(fetchMock);
+
+        const result = await svc.reportSuccess('org', 'repo', 'sha123', 'deploy-001');
+
+        expect(result.success).toBe(true);
+        const body = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string);
+        expect(body.state).toBe('success');
+    });
+
+    it('includes the deployment URL in the description when provided', async () => {
+        const fetchMock = makeOkFetch();
+        const svc = new GitHubCommitStatusService(fetchMock);
+
+        await svc.reportSuccess('org', 'repo', 'sha123', 'deploy-001', 'https://myapp.vercel.app');
+
+        const body = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string);
+        expect(body.description).toContain('https://myapp.vercel.app');
+    });
+
+    it('uses a generic success description when no deployment URL is provided', async () => {
+        const fetchMock = makeOkFetch();
+        const svc = new GitHubCommitStatusService(fetchMock);
+
+        await svc.reportSuccess('org', 'repo', 'sha123', 'deploy-001');
+
+        const body = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string);
+        expect(body.description).toContain('successfully');
+    });
+
+    it('links to the deployment detail page', async () => {
+        const fetchMock = makeOkFetch();
+        const svc = new GitHubCommitStatusService(fetchMock);
+        process.env.NEXT_PUBLIC_APP_URL = 'https://craft.app';
+
+        await svc.reportSuccess('org', 'repo', 'sha123', 'deploy-xyz');
+
+        const body = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string);
+        expect(body.target_url).toContain('deploy-xyz');
+    });
+});
+
+// ── reportFailure ─────────────────────────────────────────────────────────────
+
+describe('GitHubCommitStatusService — reportFailure', () => {
+    const originalToken = process.env.GITHUB_TOKEN;
+
+    beforeEach(() => {
+        process.env.GITHUB_TOKEN = 'ghp_test_token';
+    });
+
+    afterEach(() => {
+        process.env.GITHUB_TOKEN = originalToken;
+    });
+
+    it('posts a failure state', async () => {
+        const fetchMock = makeOkFetch();
+        const svc = new GitHubCommitStatusService(fetchMock);
+
+        const result = await svc.reportFailure('org', 'repo', 'sha123', 'deploy-001');
+
+        expect(result.success).toBe(true);
+        const body = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string);
+        expect(body.state).toBe('failure');
+    });
+
+    it('includes the failed stage in the description when provided', async () => {
+        const fetchMock = makeOkFetch();
+        const svc = new GitHubCommitStatusService(fetchMock);
+
+        await svc.reportFailure('org', 'repo', 'sha123', 'deploy-001', 'deploying');
+
+        const body = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string);
+        expect(body.description).toContain('deploying');
+    });
+
+    it('uses a generic failure description when no stage is provided', async () => {
+        const fetchMock = makeOkFetch();
+        const svc = new GitHubCommitStatusService(fetchMock);
+
+        await svc.reportFailure('org', 'repo', 'sha123', 'deploy-001');
+
+        const body = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string);
+        expect(body.description).toBe('Deployment failed');
+    });
+
+    it('links to the deployment detail page', async () => {
+        const fetchMock = makeOkFetch();
+        const svc = new GitHubCommitStatusService(fetchMock);
+        process.env.NEXT_PUBLIC_APP_URL = 'https://craft.app';
+
+        await svc.reportFailure('org', 'repo', 'sha123', 'dep-fail');
+
+        const body = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string);
+        expect(body.target_url).toContain('dep-fail');
+    });
+});
+
+// ── API version header ────────────────────────────────────────────────────────
+
+describe('GitHubCommitStatusService — request headers', () => {
+    beforeEach(() => {
+        process.env.GITHUB_TOKEN = 'ghp_test_token';
+    });
+
+    it('sends the required GitHub API version header', async () => {
+        const fetchMock = makeOkFetch();
+        const svc = new GitHubCommitStatusService(fetchMock);
+
+        await svc.postCommitStatus(makeBaseRequest());
+
+        const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+        expect((init.headers as Record<string, string>)['X-GitHub-Api-Version']).toBe('2022-11-28');
+    });
+
+    it('sends the correct Accept header', async () => {
+        const fetchMock = makeOkFetch();
+        const svc = new GitHubCommitStatusService(fetchMock);
+
+        await svc.postCommitStatus(makeBaseRequest());
+
+        const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+        expect((init.headers as Record<string, string>)['Accept']).toBe('application/vnd.github+json');
+    });
+});

--- a/apps/backend/src/services/github-commit-status.service.ts
+++ b/apps/backend/src/services/github-commit-status.service.ts
@@ -1,0 +1,239 @@
+/**
+ * GitHubCommitStatusService
+ *
+ * Posts GitHub commit statuses at each deployment pipeline stage so that
+ * developers can observe progress directly in pull-request and commit views
+ * on GitHub.
+ *
+ * GitHub Statuses API reference:
+ *   POST /repos/{owner}/{repo}/statuses/{sha}
+ *   https://docs.github.com/en/rest/commits/statuses
+ *
+ * Status lifecycle wired by DeploymentPipelineService:
+ *   pending  → immediately after a deployment record is created (pipeline starting)
+ *   success  → after the deployment is marked `completed`
+ *   failure  → after the deployment is marked `failed`
+ *   error    → reserved for unexpected errors (network / API)
+ *
+ * Each status POST:
+ *   - `state`       : 'pending' | 'success' | 'failure' | 'error'
+ *   - `context`     : human-readable label (e.g. "craft/deployment")
+ *   - `description` : concise summary (≤ 140 chars; GitHub truncates longer values)
+ *   - `target_url`  : link to the deployment detail page in CRAFT
+ *
+ * Failure policy:
+ *   Report errors are caught and logged but NEVER re-thrown. Status reporting
+ *   is best-effort — it must never block or fail the deployment pipeline.
+ *
+ * Configuration (env vars):
+ *   GITHUB_TOKEN     — Personal Access Token or GitHub App installation token.
+ *                      Must have `repo:status` scope.
+ *   NEXT_PUBLIC_APP_URL — Base URL of the CRAFT application (e.g. https://craft.app).
+ *                         Used to build the `target_url` for each status.
+ *
+ * Issue: #651
+ * Branch: feat/issue-115-github-commit-status-reporting
+ */
+
+const GITHUB_API_BASE = 'https://api.github.com';
+
+/** Valid states accepted by the GitHub Statuses API. */
+export type GitHubCommitState = 'pending' | 'success' | 'failure' | 'error';
+
+export interface PostCommitStatusRequest {
+    /** GitHub repository owner (user or organisation login). */
+    owner: string;
+    /** GitHub repository name. */
+    repo: string;
+    /** Full 40-character commit SHA to attach the status to. */
+    sha: string;
+    /** Status state. */
+    state: GitHubCommitState;
+    /**
+     * Namespaced label that distinguishes this status from others on the same
+     * commit (e.g. "craft/deployment" or "craft/deployment — generating").
+     * GitHub groups statuses by context in the UI.
+     */
+    context: string;
+    /**
+     * Short human-readable description shown alongside the status badge.
+     * GitHub truncates to 140 characters; keep descriptions concise.
+     */
+    description: string;
+    /**
+     * Optional URL the status badge links to (shown as "Details" on GitHub).
+     * Should point to the CRAFT deployment detail page.
+     */
+    targetUrl?: string;
+}
+
+export interface PostCommitStatusResult {
+    success: boolean;
+    /** HTTP status code returned by the GitHub API (present even on failure). */
+    statusCode?: number;
+    /** Error message if the API call failed. */
+    error?: string;
+}
+
+interface FetchLike {
+    (input: string, init?: RequestInit): Promise<Response>;
+}
+
+/**
+ * Builds the deployment detail page URL for a given deployment ID.
+ *
+ * @param deploymentId - The CRAFT deployment UUID.
+ * @param appUrl       - Base URL of the CRAFT app (e.g. "https://craft.app").
+ *                       Defaults to the NEXT_PUBLIC_APP_URL env var.
+ */
+export function buildDeploymentDetailUrl(
+    deploymentId: string,
+    appUrl: string = process.env.NEXT_PUBLIC_APP_URL ?? '',
+): string {
+    const base = appUrl.replace(/\/$/, '');
+    return `${base}/app/deployments/${deploymentId}`;
+}
+
+export class GitHubCommitStatusService {
+    constructor(private readonly _fetch: FetchLike = fetch) {}
+
+    /**
+     * Post a commit status to the GitHub Statuses API.
+     *
+     * This method NEVER throws. Any API or network failure is captured in the
+     * returned result so the caller can log the error without breaking its own
+     * control flow.
+     *
+     * @param request - Status payload.
+     * @returns Result indicating whether the POST succeeded.
+     */
+    async postCommitStatus(request: PostCommitStatusRequest): Promise<PostCommitStatusResult> {
+        const token = process.env.GITHUB_TOKEN ?? '';
+
+        if (!token) {
+            return {
+                success: false,
+                error: 'GITHUB_TOKEN is not configured — commit status not posted',
+            };
+        }
+
+        const { owner, repo, sha, state, context, description, targetUrl } = request;
+
+        const payload: Record<string, string | undefined> = {
+            state,
+            context,
+            // GitHub hard-caps descriptions at 140 characters.
+            description: description.length > 140 ? description.slice(0, 137) + '…' : description,
+        };
+
+        if (targetUrl) {
+            payload.target_url = targetUrl;
+        }
+
+        const url = `${GITHUB_API_BASE}/repos/${owner}/${repo}/statuses/${sha}`;
+
+        try {
+            const response = await this._fetch(url, {
+                method: 'POST',
+                headers: {
+                    Authorization: `Bearer ${token}`,
+                    Accept: 'application/vnd.github+json',
+                    'X-GitHub-Api-Version': '2022-11-28',
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify(payload),
+            });
+
+            if (!response.ok) {
+                const body = await response.json().catch(() => ({})) as Record<string, unknown>;
+                const message = (body.message as string | undefined) ?? `GitHub API error: ${response.status}`;
+                return { success: false, statusCode: response.status, error: message };
+            }
+
+            return { success: true, statusCode: response.status };
+        } catch (err: unknown) {
+            const message = err instanceof Error ? err.message : 'Unknown network error';
+            return { success: false, error: `Network error posting commit status: ${message}` };
+        }
+    }
+
+    /**
+     * Convenience wrapper that posts a `pending` status.
+     *
+     * Typically called at the start of the deployment pipeline before any
+     * stage has executed.
+     */
+    async reportPending(
+        owner: string,
+        repo: string,
+        sha: string,
+        deploymentId: string,
+        stageName: string = 'Deployment',
+    ): Promise<PostCommitStatusResult> {
+        return this.postCommitStatus({
+            owner,
+            repo,
+            sha,
+            state: 'pending',
+            context: 'craft/deployment',
+            description: `${stageName} is in progress…`,
+            targetUrl: buildDeploymentDetailUrl(deploymentId),
+        });
+    }
+
+    /**
+     * Convenience wrapper that posts a `success` status.
+     *
+     * Called after the deployment has been marked `completed`.
+     */
+    async reportSuccess(
+        owner: string,
+        repo: string,
+        sha: string,
+        deploymentId: string,
+        deploymentUrl?: string,
+    ): Promise<PostCommitStatusResult> {
+        const description = deploymentUrl
+            ? `Deployed to ${deploymentUrl}`
+            : 'Deployment completed successfully';
+
+        return this.postCommitStatus({
+            owner,
+            repo,
+            sha,
+            state: 'success',
+            context: 'craft/deployment',
+            description,
+            targetUrl: buildDeploymentDetailUrl(deploymentId),
+        });
+    }
+
+    /**
+     * Convenience wrapper that posts a `failure` status.
+     *
+     * Called after the deployment has been marked `failed`.
+     */
+    async reportFailure(
+        owner: string,
+        repo: string,
+        sha: string,
+        deploymentId: string,
+        failedStage?: string,
+    ): Promise<PostCommitStatusResult> {
+        const description = failedStage
+            ? `Deployment failed at stage: ${failedStage}`
+            : 'Deployment failed';
+
+        return this.postCommitStatus({
+            owner,
+            repo,
+            sha,
+            state: 'failure',
+            context: 'craft/deployment',
+            description,
+            targetUrl: buildDeploymentDetailUrl(deploymentId),
+        });
+    }
+}
+
+export const githubCommitStatusService = new GitHubCommitStatusService();

--- a/docs/GITHUB_COMMIT_STATUS_REPORTING.md
+++ b/docs/GITHUB_COMMIT_STATUS_REPORTING.md
@@ -1,0 +1,207 @@
+# GitHub Commit Status Reporting
+
+**Issue:** #651  
+**Branch:** `feat/issue-115-github-commit-status-reporting`
+
+---
+
+## Overview
+
+CRAFT's deployment pipeline now posts GitHub [commit statuses](https://docs.github.com/en/rest/commits/statuses) at each key transition point. This gives developers live feedback directly in pull-request and commit views on GitHub — no need to leave GitHub to check deployment progress.
+
+When a deployment is triggered, a status badge appears next to the associated commit. The badge links directly to the deployment detail page in CRAFT so developers can dig into logs and metadata with a single click.
+
+---
+
+## Status Lifecycle
+
+| Pipeline Event | GitHub Status State | Description |
+|---|---|---|
+| Code pushed to repository (SHA known) | `pending` | `Deployment is in progress…` |
+| Deployment completed successfully | `success` | `Deployed to <deploymentUrl>` |
+| Any stage fails | `failure` | `Deployment failed at stage: <stageName>` |
+
+### Sequencing Notes
+
+- The commit SHA is not available until the generated code is pushed to the GitHub repository (Step 4 of the pipeline). For this reason, the `pending` status is posted **immediately after a successful push**, not at the very start of the pipeline.
+- `success` is posted only after the Vercel deployment URL is confirmed and the deployment record is written to the database as `completed`.
+- Stages that fail **before** the push step (e.g., `generating`, `validating`, `signing`, `creating_repo`) do not emit a status because no commit SHA exists yet.
+
+---
+
+## Failure Policy — Non-Blocking by Design
+
+Status reporting failures **must never block or abort the deployment pipeline**.
+
+All calls to `GitHubCommitStatusService` are wrapped in `DeploymentPipelineService.reportCommitStatus()`, which:
+
+1. Catches any exception thrown by the status service.
+2. Writes a `warn`-level entry to `deployment_logs` (stage: `commit_status`).
+3. Returns control to the pipeline, which continues normally.
+
+This means a misconfigured `GITHUB_TOKEN`, a GitHub API outage, or a network hiccup will degrade status reporting but will **not** prevent deployments from completing.
+
+---
+
+## Configuration
+
+| Environment Variable | Required | Default | Description |
+|---|---|---|---|
+| `GITHUB_TOKEN` | Yes | — | Personal Access Token or GitHub App installation token. Must have the `repo:status` scope (or `public_repo:status` for public repositories). |
+| `NEXT_PUBLIC_APP_URL` | Yes | — | Base URL of the CRAFT application (e.g. `https://craft.app`). Used to build the `target_url` that each status badge links to. |
+| `GITHUB_COMMIT_STATUS_CONTEXT` | No | `craft/deployment` | The status context label shown in GitHub UI. Changing this groups statuses under a different check name. |
+
+### Token Permissions
+
+The `GITHUB_TOKEN` used by the deployment pipeline needs at minimum:
+
+- `repo:status` — to create commit statuses on **private** repositories.
+- `public_repo:status` — to create commit statuses on **public** repositories only.
+
+If you use a GitHub App installation token (recommended), ensure the app has **Commit statuses: Read and write** under the repository permissions.
+
+---
+
+## Architecture
+
+### New Service — `GitHubCommitStatusService`
+
+**Location:** `apps/backend/src/services/github-commit-status.service.ts`
+
+```
+GitHubCommitStatusService
+  ├── postCommitStatus(request)       ← core method; never throws
+  ├── reportPending(owner, repo, sha, deploymentId, stageName?)
+  ├── reportSuccess(owner, repo, sha, deploymentId, deploymentUrl?)
+  └── reportFailure(owner, repo, sha, deploymentId, failedStage?)
+
+buildDeploymentDetailUrl(deploymentId, appUrl?)  ← pure helper; exported for tests
+```
+
+The service receives a `FetchLike` constructor argument, making it fully testable without network calls.
+
+### Integration in `DeploymentPipelineService`
+
+**Location:** `apps/backend/src/services/deployment-pipeline.service.ts`
+
+The service is injected as an optional constructor parameter:
+
+```typescript
+constructor(
+  // …existing parameters…
+  private readonly _commitStatusService: Pick<
+    GitHubCommitStatusService,
+    'reportPending' | 'reportSuccess' | 'reportFailure'
+  > = githubCommitStatusService,
+)
+```
+
+The integration points inside `deploy()`:
+
+| Location in `deploy()` | What happens |
+|---|---|
+| After `pushGeneratedCode` succeeds | `reportPending` is called with the new commit SHA |
+| After `deployments` record is updated to `completed` | `reportSuccess` is called |
+| Inside the `fail()` private helper (when `commitContext` is set) | `reportFailure` is called (currently unused for pre-push failures — no SHA available) |
+
+All three calls go through `reportCommitStatus()`, which wraps them in `try/catch` and logs a `warn`-level entry on failure.
+
+---
+
+## Testing
+
+### `github-commit-status.service.test.ts`
+
+Full unit test coverage for the standalone service:
+
+- `postCommitStatus` — happy path for each state (`pending`, `success`, `failure`, `error`).
+- Missing `GITHUB_TOKEN` → returns failure, no fetch call.
+- GitHub API non-ok response → returns failure with error message.
+- Network error (fetch throws) → returns failure without re-throwing.
+- Description truncation to 140 characters.
+- `target_url` omitted when `targetUrl` is not provided.
+- Correct endpoint URL, Authorization header, and API version header.
+- `buildDeploymentDetailUrl` unit tests.
+
+### `deployment-pipeline.service.test.ts`
+
+New test suite **"GitHub commit status reporting (#651)"** appended to the existing file:
+
+| Test | What it asserts |
+|---|---|
+| Reports pending after code push | `reportPending` called once on success |
+| Reports success after completion | `reportSuccess` called once; `reportFailure` not called |
+| SHA from push result passed to reportPending | Correct `commitSha` forwarded |
+| No status when pipeline fails before push | None of the three methods called |
+| No success when Vercel fails | `reportSuccess` not called |
+| Failure result from reportPending does not block pipeline | Full deployment still succeeds |
+| reportSuccess throwing does not block pipeline | Full deployment still succeeds |
+| reportPending throwing does not block pipeline | Full deployment still succeeds |
+| Warn log written on failure result | `commit_status` warn log entry present |
+| Warn log written on unexpected throw | `commit_status` warn log entry present |
+
+### Running the Tests
+
+```bash
+# Run all tests in the backend app
+cd apps/backend
+npx vitest run
+
+# Run only the new service tests
+npx vitest run src/services/github-commit-status.service.test.ts
+
+# Run the pipeline tests (includes the new #651 suite)
+npx vitest run src/services/deployment-pipeline.service.test.ts
+```
+
+---
+
+## GitHub UI — What Developers See
+
+Once deployed and configured, developers will see a status section in each pull request and on each commit page on GitHub:
+
+```
+○  craft/deployment   Details   Deployment is in progress…
+↓  (after completion)
+✓  craft/deployment   Details   Deployed to https://my-app.vercel.app
+```
+
+Clicking **Details** opens the CRAFT deployment detail page at:
+
+```
+https://<NEXT_PUBLIC_APP_URL>/app/deployments/<deploymentId>
+```
+
+---
+
+## Extending This Feature
+
+### Adding per-stage statuses
+
+The current implementation posts a single `craft/deployment` status. You can post per-stage statuses by calling `postCommitStatus` directly with a more specific `context` value:
+
+```typescript
+await this._commitStatusService.postCommitStatus({
+    owner,
+    repo,
+    sha,
+    state: 'pending',
+    context: 'craft/deployment — code-generation',
+    description: 'Generating code from template…',
+    targetUrl: buildDeploymentDetailUrl(deploymentId),
+});
+```
+
+GitHub groups statuses by `context`, so each distinct value appears as a separate check.
+
+### Custom context label
+
+Set `GITHUB_COMMIT_STATUS_CONTEXT` in your environment to change the label shown in GitHub UI. This is useful when running multiple CRAFT instances (e.g., staging vs. production) that target the same repositories.
+
+---
+
+## Related Documents
+
+- [`docs/github-vercel-deployment-triggering.md`](./github-vercel-deployment-triggering.md) — describes the Vercel deployment trigger flow.
+- [`docs/deployment-detail-design.md`](./deployment-detail-design.md) — the deployment detail page that `target_url` links to.
+- [GitHub Statuses API reference](https://docs.github.com/en/rest/commits/statuses)


### PR DESCRIPTION
## Summary
Implements issue-651: GitHub commit status reporting for deployment pipeline progress.

## Changes
- Posts GitHub commit statuses at each pipeline stage (pending, success, failure)
- Descriptive status contexts with links to deployment detail view
- Status reporting failures do not block the deployment pipeline
- New `docs/GITHUB_COMMIT_STATUS_REPORTING.md`

## Test Results
- 29/29 github-commit-status.service.test.ts ✅
- 53/53 deployment-pipeline.service.test.ts ✅ (43 pre-existing + 10 new)

Closes #651 