### PR TITLE
feat(shutdown): implemented graceful deployment drain on SIGTERM with…

### DIFF
--- a/apps/backend/src/app/api/health/drain/route.ts
+++ b/apps/backend/src/app/api/health/drain/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from 'next/server';
+import { inFlightCount, isDraining } from '@/lib/shutdown-manager';
+
+/**
+ * GET /api/health/drain
+ *
+ * Returns the current drain status of the server, including the number
+ * of in-flight deployment operations and whether the server is actively
+ * draining.
+ */
+export async function GET(): Promise<NextResponse> {
+    return NextResponse.json({
+        inFlightCount: inFlightCount(),
+        draining: isDraining(),
+    });
+}

--- a/apps/backend/src/instrumentation.ts
+++ b/apps/backend/src/instrumentation.ts
@@ -10,7 +10,9 @@
  *  1. Signal received → draining flag set via shutdown-manager.
  *  2. New deployment POST requests receive 503 Service Unavailable.
  *  3. Manager polls in-flight set until empty or timeout expires.
- *  4. Process exits with code 0 (or 1 on timeout).
+ *  4. On timeout, remaining deployments are force-failed with reason shutdown.
+ *  5. All Supabase realtime subscriptions are unsubscribed.
+ *  6. Process exits with code 0 (or 1 on timeout).
  */
 export async function register() {
     if (process.env.NEXT_RUNTIME !== 'nodejs') return;

--- a/apps/backend/src/lib/shutdown-manager.test.ts
+++ b/apps/backend/src/lib/shutdown-manager.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Tests for shutdown-manager.ts — graceful deployment drain.
+ *
+ * Uses fake timers to control the drain timeout window and dynamic imports
+ * so each describe block gets a fresh module instance with clean state.
+ *
+ * Issue: #XXX — Graceful Shutdown Drain
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// ── Supabase mock ─────────────────────────────────────────────────────────────
+
+const mockUpdate = vi.fn().mockReturnValue({ eq: vi.fn().mockResolvedValue({ error: null }) });
+
+vi.mock('@/lib/supabase/server', () => ({
+    createClient: () => ({
+        from: () => ({
+            update: mockUpdate,
+        }),
+    }),
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+async function importModule() {
+    return await import('./shutdown-manager');
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('shutdown-manager — core functions', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('isDraining returns false initially', async () => {
+        const mod = await importModule();
+        expect(mod.isDraining()).toBe(false);
+    });
+
+    it('trackOperation adds to inFlight and returns a done callback', async () => {
+        const mod = await importModule();
+        expect(mod.inFlightCount()).toBe(0);
+
+        const done = mod.trackOperation('deploy-1');
+        expect(mod.inFlightCount()).toBe(1);
+
+        done();
+        expect(mod.inFlightCount()).toBe(0);
+    });
+
+    it('inFlightCount returns correct count for multiple operations', async () => {
+        const mod = await importModule();
+
+        const done1 = mod.trackOperation('a');
+        const done2 = mod.trackOperation('b');
+        const done3 = mod.trackOperation('c');
+        expect(mod.inFlightCount()).toBe(3);
+
+        done2();
+        expect(mod.inFlightCount()).toBe(2);
+
+        done1();
+        done3();
+        expect(mod.inFlightCount()).toBe(0);
+    });
+
+    it('registerRealtimeCleanup stores callbacks invoked by unsubscribeAll', async () => {
+        const mod = await importModule();
+
+        const cleanup1 = vi.fn().mockResolvedValue(undefined);
+        const cleanup2 = vi.fn().mockResolvedValue(undefined);
+
+        mod.registerRealtimeCleanup(cleanup1);
+        mod.registerRealtimeCleanup(cleanup2);
+
+        await mod.unsubscribeAll();
+
+        expect(cleanup1).toHaveBeenCalledOnce();
+        expect(cleanup2).toHaveBeenCalledOnce();
+    });
+
+    it('unsubscribeAll swallows errors from individual cleanups', async () => {
+        const mod = await importModule();
+
+        const good = vi.fn().mockResolvedValue(undefined);
+        const bad = vi.fn().mockRejectedValue(new Error('cleanup failed'));
+
+        mod.registerRealtimeCleanup(good);
+        mod.registerRealtimeCleanup(bad);
+        mod.registerRealtimeCleanup(good);
+
+        await expect(mod.unsubscribeAll()).resolves.toBeUndefined();
+        expect(good).toHaveBeenCalledTimes(2);
+        expect(bad).toHaveBeenCalledOnce();
+    });
+});
+
+describe('shutdown-manager — drain', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('drain completes immediately when no operations are in-flight', async () => {
+        const mod = await importModule();
+
+        expect(mod.isDraining()).toBe(false);
+        await mod.drain();
+        // After drain completes, draining flag is set
+    });
+
+    it('drain sets draining flag and waits for in-flight operations to complete', async () => {
+        const mod = await importModule();
+
+        const done = mod.trackOperation('deploy-1');
+
+        const drainPromise = mod.drain();
+
+        // Before timers advance, drain is waiting
+        expect(mod.isDraining()).toBe(true);
+
+        // Complete the in-flight operation
+        done();
+
+        // Advance past one poll cycle so drain re-checks inFlight.size
+        await vi.advanceTimersByTimeAsync(200);
+
+        await drainPromise;
+    });
+
+    it('forceFailStuckDeployments updates stuck deployments to failed', async () => {
+        const mod = await importModule();
+
+        mod.trackOperation('stuck-deploy-1');
+        mod.trackOperation('stuck-deploy-2');
+
+        await mod.forceFailStuckDeployments();
+
+        expect(mockUpdate).toHaveBeenCalled();
+        const updateArg = mockUpdate.mock.calls[0][0];
+        expect(updateArg.status).toBe('failed');
+        expect(updateArg.error_message).toBe('Shutdown: drain timeout');
+    });
+
+    it('drain calls forceFailStuckDeployments when timeout expires with in-flight ops', async () => {
+        const mod = await importModule();
+
+        // Register an operation that never completes
+        mod.trackOperation('stuck-deploy');
+
+        const drainPromise = mod.drain();
+
+        // Fast forward past the 30s drain timeout
+        await vi.advanceTimersByTimeAsync(31_000);
+
+        await drainPromise;
+
+        // The stuck deployment should have been force-failed
+        expect(mod.inFlightCount()).toBe(0);
+        expect(mockUpdate).toHaveBeenCalled();
+        const updateArg = mockUpdate.mock.calls[0][0];
+        expect(updateArg.status).toBe('failed');
+        expect(updateArg.error_message).toBe('Shutdown: drain timeout');
+    });
+
+    it('drain calls unsubscribeAll after force-failing stuck deployments', async () => {
+        const mod = await importModule();
+
+        const cleanup = vi.fn().mockResolvedValue(undefined);
+        mod.registerRealtimeCleanup(cleanup);
+
+        mod.trackOperation('stuck-deploy');
+
+        const drainPromise = mod.drain();
+        await vi.advanceTimersByTimeAsync(31_000);
+        await drainPromise;
+
+        expect(cleanup).toHaveBeenCalledOnce();
+    });
+});

--- a/apps/backend/src/lib/shutdown-manager.ts
+++ b/apps/backend/src/lib/shutdown-manager.ts
@@ -5,13 +5,20 @@
  * isDraining() and respond with 503.  Existing operations call
  * trackOperation() so the process can wait for them to finish before exiting.
  *
+ * After the drain timeout, forceFailStuckDeployments() transitions any
+ * remaining in-flight deployments to `failed` with reason `shutdown`.
+ *
  * Drain timeout: SHUTDOWN_DRAIN_TIMEOUT_MS (default 30 000 ms).
  */
+
+import { createClient } from '@/lib/supabase/server';
 
 const DRAIN_TIMEOUT_MS = parseInt(process.env.SHUTDOWN_DRAIN_TIMEOUT_MS ?? '30000', 10);
 
 let draining = false;
 const inFlight = new Set<string>();
+
+const realtimeCleanups: Array<() => Promise<void>> = [];
 
 export function isDraining(): boolean {
     return draining;
@@ -31,13 +38,63 @@ export function inFlightCount(): number {
 }
 
 /**
+ * Register a cleanup function to be called during shutdown to unsubscribe
+ * from Supabase realtime channels.
+ */
+export function registerRealtimeCleanup(fn: () => Promise<void>): void {
+    realtimeCleanups.push(fn);
+}
+
+/**
+ * Invoke all registered realtime cleanup callbacks.  Each is run and
+ * errors are swallowed so one failing unsubscribe does not block the rest.
+ */
+export async function unsubscribeAll(): Promise<void> {
+    await Promise.allSettled(realtimeCleanups.map((fn) => fn()));
+    realtimeCleanups.length = 0;
+}
+
+/**
+ * Force-fail any in-flight deployments that did not complete during the
+ * drain window.  Each stuck deployment is transitioned to `failed` with
+ * `error_message` set to `Shutdown: drain timeout`.
+ */
+export async function forceFailStuckDeployments(): Promise<void> {
+    if (inFlight.size === 0) return;
+
+    const supabase = createClient();
+    const stuck = [...inFlight];
+
+    await Promise.allSettled(
+        stuck.map((id) =>
+            supabase
+                .from('deployments')
+                .update({
+                    status: 'failed',
+                    error_message: 'Shutdown: drain timeout',
+                    updated_at: new Date().toISOString(),
+                })
+                .eq('id', id),
+        ),
+    );
+
+    stuck.forEach((id) => inFlight.delete(id));
+}
+
+/**
  * Initiate graceful drain.  Sets the draining flag and waits up to
  * DRAIN_TIMEOUT_MS for in-flight operations to finish before resolving.
+ *
+ * After the timeout any remaining deployments are force-failed and all
+ * realtime channels are unsubscribed.
  */
 export async function drain(): Promise<void> {
     draining = true;
 
-    if (inFlight.size === 0) return;
+    if (inFlight.size === 0) {
+        await unsubscribeAll();
+        return;
+    }
 
     const deadline = Date.now() + DRAIN_TIMEOUT_MS;
     while (inFlight.size > 0 && Date.now() < deadline) {
@@ -45,14 +102,17 @@ export async function drain(): Promise<void> {
     }
 
     if (inFlight.size > 0) {
-        // Log remaining operations that could not be checkpointed.
         console.warn(
             JSON.stringify({
                 level: 'warn',
-                message: 'Drain timeout: forcing exit with in-flight operations',
+                message: 'Drain timeout: force-failing stuck deployments',
                 inFlight: [...inFlight],
                 timestamp: new Date().toISOString(),
-            })
+            }),
         );
+
+        await forceFailStuckDeployments();
     }
+
+    await unsubscribeAll();
 }

--- a/apps/backend/src/services/deployment-pipeline.artifact-signing.test.ts
+++ b/apps/backend/src/services/deployment-pipeline.artifact-signing.test.ts
@@ -20,6 +20,27 @@ vi.mock('./template-generator.service', () => ({
     mapCategoryToFamily: vi.fn().mockReturnValue('stellar-dex'),
 }));
 
+vi.mock('./github-commit-status.service', () => ({
+    GitHubCommitStatusService: vi.fn(),
+    githubCommitStatusService: {
+        reportPending: vi.fn().mockResolvedValue({ success: true }),
+        reportSuccess: vi.fn().mockResolvedValue({ success: true }),
+        reportFailure: vi.fn().mockResolvedValue({ success: true }),
+    },
+}));
+
+vi.mock('./build-cache.service', () => ({
+    BuildCacheService: vi.fn(),
+    buildCacheService: {
+        checkCache: vi.fn().mockResolvedValue({
+            status: 'miss',
+            contentHash: 'hash-abc',
+            filesToBuild: [],
+        }),
+        storeHash: vi.fn().mockResolvedValue(undefined),
+    },
+}));
+
 import { DeploymentPipelineService } from './deployment-pipeline.service';
 import type { DeploymentPipelineRequest } from './deployment-pipeline.service';
 import type { CustomizationConfig } from '@craft/types';

--- a/apps/backend/src/services/deployment-pipeline.service.test.ts
+++ b/apps/backend/src/services/deployment-pipeline.service.test.ts
@@ -20,6 +20,27 @@ vi.mock('./template-generator.service', () => ({
     mapCategoryToFamily: vi.fn().mockReturnValue('stellar-dex'),
 }));
 
+vi.mock('./github-commit-status.service', () => ({
+    GitHubCommitStatusService: vi.fn(),
+    githubCommitStatusService: {
+        reportPending: vi.fn().mockResolvedValue({ success: true }),
+        reportSuccess: vi.fn().mockResolvedValue({ success: true }),
+        reportFailure: vi.fn().mockResolvedValue({ success: true }),
+    },
+}));
+
+vi.mock('./build-cache.service', () => ({
+    BuildCacheService: vi.fn(),
+    buildCacheService: {
+        checkCache: vi.fn().mockResolvedValue({
+            status: 'miss',
+            contentHash: 'hash-abc',
+            filesToBuild: [],
+        }),
+        storeHash: vi.fn().mockResolvedValue(undefined),
+    },
+}));
+
 import { DeploymentPipelineService } from './deployment-pipeline.service';
 import type { DeploymentPipelineRequest } from './deployment-pipeline.service';
 import type { CustomizationConfig } from '@craft/types';

--- a/apps/backend/src/services/deployment-pipeline.service.ts
+++ b/apps/backend/src/services/deployment-pipeline.service.ts
@@ -65,6 +65,8 @@ import { syntaxValidator, type SyntaxValidator } from './syntax-validator';
 import { artifactSigningService, ArtifactSigningService } from './artifact-signing.service';
 import { deploymentUpdateService, DeploymentUpdateService } from './deployment-update.service';
 import { buildCacheService, BuildCacheService } from './build-cache.service';
+import { githubCommitStatusService, GitHubCommitStatusService } from './github-commit-status.service';
+import { isDraining, trackOperation } from '@/lib/shutdown-manager';
 // ── Request / result types ────────────────────────────────────────────────────
 
 export interface DeploymentPipelineRequest {
@@ -119,6 +121,7 @@ export class DeploymentPipelineService {
         private readonly _artifactSigningService: ArtifactSigningService = artifactSigningService,
         private readonly _deploymentUpdateService: Pick<DeploymentUpdateService, 'rollbackUpdate'> | null = null,
         private readonly _commitStatusService: Pick<GitHubCommitStatusService, 'reportPending' | 'reportSuccess' | 'reportFailure'> = githubCommitStatusService,
+        private readonly _buildCacheService: Pick<BuildCacheService, 'checkCache' | 'storeHash'> = buildCacheService,
     ) {}
 
     /**
@@ -130,6 +133,19 @@ export class DeploymentPipelineService {
         const deploymentId = crypto.randomUUID();
         const { userId, templateId, customization, name, updateContext } = request;
 
+        if (isDraining()) {
+            return {
+                success: false,
+                deploymentId,
+                correlationId: '',
+                failedStage: 'pending' as DeploymentStatusType,
+                errorMessage: 'Server is shutting down',
+            };
+        }
+
+        const done = trackOperation(deploymentId);
+
+        try {
         // ── Step 0: Validate Dependency Graph ─────────────────────────────────
         // Build graph from customization config or template defaults
         const nodes = ((customization as any).nodes || []) as DeploymentNode[];
@@ -521,6 +537,9 @@ export class DeploymentPipelineService {
             repositoryUrl,
             deploymentUrl,
         };
+        } finally {
+            done();
+        }
     }
 
     // ── Private helpers ───────────────────────────────────────────────────────
@@ -675,4 +694,5 @@ export const deploymentPipelineService = new DeploymentPipelineService(
     artifactSigningService,
     deploymentUpdateService,
     githubCommitStatusService,
+    buildCacheService,
 );


### PR DESCRIPTION

Changes Made

1. apps/backend/src/lib/shutdown-manager.ts
- Added registerRealtimeCleanup(fn) — stores cleanup callbacks for realtime channels
- Added unsubscribeAll() — invokes all registered cleanup callbacks, errors swallowed
- Added forceFailStuckDeployments() — transitions stuck in-flight deployments to failed with error_message: 'Shutdown: drain timeout'
- Updated drain() to call forceFailStuckDeployments() after timeout, then unsubscribeAll()

2. apps/backend/src/services/deployment-pipeline.service.ts
- Added import { isDraining, trackOperation } from '@/lib/shutdown-manager'
- Added isDraining() check at deploy start — returns 503 result if draining
- Calls trackOperation(deploymentId) — registers in-flight deployment
- Wrapped deploy body in try/finally to call done() on every exit path
- Added missing import for githubCommitStatusService
- Added _buildCacheService constructor parameter (was missing)

3. apps/backend/src/app/api/health/drain/route.ts (new)
- GET /api/health/drain returns { inFlightCount, draining }

4. apps/backend/src/instrumentation.ts
- Updated doc comment to describe the full shutdown sequence including force-fail and realtime unsubscribe

5. apps/backend/src/lib/shutdown-manager.test.ts (new)
- 10 tests covering: core functions, drain with no in-flight, drain with clean completion, drain timeout with force-fail, forceFailStuckDeployments DB update, unsubscribeAll, error swallowing

6. Pre-existing bug fixes (test mocks)
- Added ./github-commit-status.service mock to deployment-pipeline.artifact-signing.test.ts and deployment-pipeline.service.test.ts
- Added ./build-cache.service mock to both test files
Test results: 10/10 shutdown-manager tests, 6/6 artifact-signing tests, 53/53 deployment-pipeline tests all pass.

Closes #751 