### PR TITLE
feat(webhooks/logs): DLQ auto-recovery with circuit breaker + deployment log batching

### DIFF
--- a/apps/backend/src/lib/webhook-dlq/dead-letter-queue.test.ts
+++ b/apps/backend/src/lib/webhook-dlq/dead-letter-queue.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Tests for DLQ auto-recovery: scheduleRetry() with exponential backoff,
+ * jitter, and circuit-breaker behaviour.
+ *
+ * Uses vi.useFakeTimers() to control time and avoid real waits.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { webhookDLQ } from '@/lib/webhook-dlq/dead-letter-queue';
+
+// Mock exponential-backoff so sleep() resolves immediately
+vi.mock('@/lib/retry/exponential-backoff', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('@/lib/retry/exponential-backoff')>();
+    return {
+        ...actual,
+        sleep: vi.fn().mockResolvedValue(undefined),
+    };
+});
+
+beforeEach(() => {
+    webhookDLQ._reset();
+});
+
+afterEach(() => {
+    webhookDLQ._reset();
+    vi.restoreAllMocks();
+});
+
+describe('webhookDLQ.scheduleRetry()', () => {
+    it('succeeds on first retry attempt', async () => {
+        const processor = vi.fn().mockResolvedValue(undefined);
+        webhookDLQ.registerProcessor('stripe', processor);
+
+        const entry = webhookDLQ.capture('stripe', 'invoice.paid', '{}', 'timeout', 1);
+
+        await webhookDLQ.scheduleRetry(entry.id);
+
+        expect(processor).toHaveBeenCalledTimes(1);
+        const updated = webhookDLQ.get(entry.id)!;
+        expect(updated.reprocessStatus).toBe('succeeded');
+    });
+
+    it('retries all 6 scheduled intervals on repeated failure then marks permanent failure', async () => {
+        const processor = vi.fn().mockRejectedValue(new Error('delivery failed'));
+        webhookDLQ.registerProcessor('github', processor);
+
+        const entry = webhookDLQ.capture('github', 'push', '{}', 'net error', 0);
+
+        await webhookDLQ.scheduleRetry(entry.id);
+
+        expect(processor).toHaveBeenCalledTimes(6);
+        const updated = webhookDLQ.get(entry.id)!;
+        expect(updated.reprocessStatus).toBe('failed');
+    });
+
+    it('succeeds on the 3rd attempt after two failures', async () => {
+        let callCount = 0;
+        const processor = vi.fn().mockImplementation(() => {
+            callCount++;
+            if (callCount < 3) return Promise.reject(new Error('transient'));
+            return Promise.resolve();
+        });
+        webhookDLQ.registerProcessor('stripe', processor);
+
+        const entry = webhookDLQ.capture('stripe', 'checkout.completed', '{}', 'timeout', 0);
+
+        await webhookDLQ.scheduleRetry(entry.id);
+
+        expect(processor).toHaveBeenCalledTimes(3);
+        const updated = webhookDLQ.get(entry.id)!;
+        expect(updated.reprocessStatus).toBe('succeeded');
+    });
+
+    it('does nothing if entry does not exist', async () => {
+        // Should not throw
+        await expect(webhookDLQ.scheduleRetry('nonexistent-id')).resolves.toBeUndefined();
+    });
+
+    it('does nothing if entry already succeeded', async () => {
+        const processor = vi.fn().mockResolvedValue(undefined);
+        webhookDLQ.registerProcessor('stripe', processor);
+
+        const entry = webhookDLQ.capture('stripe', 'invoice.paid', '{}', 'err', 0);
+        await webhookDLQ.scheduleRetry(entry.id);
+        processor.mockClear();
+
+        // Should skip - already succeeded
+        await webhookDLQ.scheduleRetry(entry.id);
+        expect(processor).not.toHaveBeenCalled();
+    });
+
+    it('does nothing if no processor registered', async () => {
+        const entry = webhookDLQ.capture('stripe', 'invoice.paid', '{}', 'err', 0);
+        // No processor registered
+        await expect(webhookDLQ.scheduleRetry(entry.id)).resolves.toBeUndefined();
+        expect(webhookDLQ.get(entry.id)?.reprocessStatus).toBe('pending');
+    });
+});
+
+describe('Circuit breaker', () => {
+    it('trips after 5 consecutive failures and blocks subsequent retries', async () => {
+        const processor = vi.fn().mockRejectedValue(new Error('endpoint down'));
+        webhookDLQ.registerProcessor('stripe', processor);
+
+        const endpoint = 'https://example.com/webhook';
+
+        // Create 5 entries with the same endpoint and schedule retries to trip the breaker
+        // Each scheduleRetry makes up to 6 attempts, so trip happens fast
+        for (let i = 0; i < 5; i++) {
+            const entry = webhookDLQ.capture('stripe', 'test', '{}', 'err', 0, endpoint);
+            // Run only one retry each to track consecutive failures
+            // We need to trip the circuit; simulate by calling recordFailure via the scheduleRetry path
+        }
+
+        // Schedule retry for one entry; it will fail multiple times and trip the circuit
+        const entries = webhookDLQ.list();
+        await webhookDLQ.scheduleRetry(entries[entries.length - 1].id);
+
+        // After 5 failures the circuit should be open
+        const cb = webhookDLQ._getCircuitBreaker(endpoint);
+        expect(cb.consecutiveFailures).toBeGreaterThanOrEqual(5);
+        expect(cb.openedAt).not.toBeNull();
+    });
+
+    it('circuit opens and blocks retry for subsequent entries on same endpoint', async () => {
+        const processor = vi.fn().mockRejectedValue(new Error('down'));
+        webhookDLQ.registerProcessor('github', processor);
+
+        const endpoint = 'https://delivery.example.com/hook';
+
+        // Trip the circuit manually via 5 failures from a first entry
+        const first = webhookDLQ.capture('github', 'push', '{}', 'err', 0, endpoint);
+        await webhookDLQ.scheduleRetry(first.id); // 6 failures → trips at 5
+
+        const cb = webhookDLQ._getCircuitBreaker(endpoint);
+        expect(cb.openedAt).not.toBeNull();
+
+        // A new entry on the same endpoint should be blocked immediately
+        processor.mockClear();
+        const second = webhookDLQ.capture('github', 'push', '{}', 'err', 0, endpoint);
+        await webhookDLQ.scheduleRetry(second.id);
+
+        // processor should not be called since circuit is open on first attempt check
+        expect(processor).not.toHaveBeenCalled();
+    });
+
+    it('circuit resets after 1 hour', async () => {
+        const processor = vi.fn().mockRejectedValue(new Error('down'));
+        webhookDLQ.registerProcessor('stripe', processor);
+        const endpoint = 'https://reset.example.com/hook';
+
+        // Trip the circuit
+        const entry = webhookDLQ.capture('stripe', 'ev', '{}', 'err', 0, endpoint);
+        await webhookDLQ.scheduleRetry(entry.id);
+
+        const cb = webhookDLQ._getCircuitBreaker(endpoint);
+        expect(cb.openedAt).not.toBeNull();
+
+        // Advance time by 1 hour + 1ms
+        cb.openedAt = Date.now() - (60 * 60 * 1000 + 1);
+
+        // Now the circuit should auto-reset
+        processor.mockClear().mockResolvedValue(undefined);
+        const entry2 = webhookDLQ.capture('stripe', 'ev2', '{}', 'err', 0, endpoint);
+        await webhookDLQ.scheduleRetry(entry2.id);
+
+        expect(processor).toHaveBeenCalled();
+        const updated = webhookDLQ.get(entry2.id)!;
+        expect(updated.reprocessStatus).toBe('succeeded');
+    });
+
+    it('records consecutive failures correctly via _getCircuitBreaker', async () => {
+        const processor = vi.fn().mockRejectedValue(new Error('fail'));
+        webhookDLQ.registerProcessor('stripe', processor);
+        const endpoint = 'https://track.example.com';
+
+        const entry = webhookDLQ.capture('stripe', 'ev', '{}', 'err', 0, endpoint);
+        await webhookDLQ.scheduleRetry(entry.id);
+
+        const cb = webhookDLQ._getCircuitBreaker(endpoint);
+        // At least 5 failures before circuit tripped
+        expect(cb.consecutiveFailures).toBeGreaterThanOrEqual(5);
+    });
+});
+
+describe('webhookDLQ.capture()', () => {
+    it('captures entry and stores it', () => {
+        const entry = webhookDLQ.capture('stripe', 'invoice.paid', '{"id":"x"}', 'timeout', 3);
+        expect(entry.id).toMatch(/^dlq_/);
+        expect(webhookDLQ.get(entry.id)).toEqual(entry);
+    });
+
+    it('capture stores optional endpointUrl', () => {
+        const entry = webhookDLQ.capture('github', 'push', '{}', 'err', 1, 'https://ep.example.com');
+        expect(webhookDLQ.get(entry.id)?.endpointUrl).toBe('https://ep.example.com');
+    });
+});

--- a/apps/backend/src/lib/webhook-dlq/dead-letter-queue.ts
+++ b/apps/backend/src/lib/webhook-dlq/dead-letter-queue.ts
@@ -8,7 +8,15 @@
  *
  * Reprocessing is guarded by a single-attempt-per-entry flag so the same
  * entry cannot be requeued in an infinite loop.
+ *
+ * Auto-recovery: scheduleRetry() drives automatic retry with exponential
+ * backoff (1m, 2m, 4m, 8m, 16m, 32m → permanent failure) and ±10% jitter.
+ *
+ * Circuit breaker: after 5 consecutive failures to an endpoint, all retries
+ * to that endpoint are paused for 1 hour.
  */
+
+import { calculateBackoffDelay, sleep } from '../retry/exponential-backoff';
 
 export type WebhookSource = 'stripe' | 'github';
 
@@ -22,17 +30,72 @@ export interface DLQEntry {
     createdAt: Date;
     reprocessedAt?: Date;
     reprocessStatus?: 'pending' | 'succeeded' | 'failed';
+    /** Endpoint URL used for delivery (required for circuit-breaker tracking). */
+    endpointUrl?: string;
 }
 
 type ProcessorFn = (entry: DLQEntry) => Promise<void>;
 
+// Retry schedule in milliseconds: 1m, 2m, 4m, 8m, 16m, 32m
+const RETRY_INTERVALS_MS = [
+    1 * 60 * 1000,
+    2 * 60 * 1000,
+    4 * 60 * 1000,
+    8 * 60 * 1000,
+    16 * 60 * 1000,
+    32 * 60 * 1000,
+];
+
+const CIRCUIT_BREAKER_THRESHOLD = 5;
+const CIRCUIT_BREAKER_RESET_MS = 60 * 60 * 1000; // 1 hour
+
+interface CircuitBreakerState {
+    consecutiveFailures: number;
+    openedAt: number | null; // timestamp when tripped, null = closed
+}
+
 const store = new Map<string, DLQEntry>();
+const circuitBreakers = new Map<string, CircuitBreakerState>();
 
 let _stripeProcessor: ProcessorFn | null = null;
 let _githubProcessor: ProcessorFn | null = null;
 
 function generateId(): string {
     return `dlq_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`;
+}
+
+function getCircuitBreaker(endpoint: string): CircuitBreakerState {
+    if (!circuitBreakers.has(endpoint)) {
+        circuitBreakers.set(endpoint, { consecutiveFailures: 0, openedAt: null });
+    }
+    return circuitBreakers.get(endpoint)!;
+}
+
+function isCircuitOpen(endpoint: string): boolean {
+    const cb = getCircuitBreaker(endpoint);
+    if (cb.openedAt === null) return false;
+    if (Date.now() - cb.openedAt >= CIRCUIT_BREAKER_RESET_MS) {
+        // Auto-reset after 1 hour
+        cb.consecutiveFailures = 0;
+        cb.openedAt = null;
+        return false;
+    }
+    return true;
+}
+
+function recordSuccess(endpoint: string): void {
+    const cb = getCircuitBreaker(endpoint);
+    cb.consecutiveFailures = 0;
+    cb.openedAt = null;
+}
+
+function recordFailure(endpoint: string): void {
+    const cb = getCircuitBreaker(endpoint);
+    cb.consecutiveFailures += 1;
+    if (cb.consecutiveFailures >= CIRCUIT_BREAKER_THRESHOLD && cb.openedAt === null) {
+        cb.openedAt = Date.now();
+        console.error('[DLQ] Circuit breaker tripped', { endpoint, consecutiveFailures: cb.consecutiveFailures });
+    }
 }
 
 export const webhookDLQ = {
@@ -46,7 +109,8 @@ export const webhookDLQ = {
         eventType: string,
         payload: string,
         failureReason: string,
-        attempts: number
+        attempts: number,
+        endpointUrl?: string,
     ): DLQEntry {
         const entry: DLQEntry = {
             id: generateId(),
@@ -57,6 +121,7 @@ export const webhookDLQ = {
             attempts,
             createdAt: new Date(),
             reprocessStatus: 'pending',
+            endpointUrl,
         };
         store.set(entry.id, entry);
         console.error('[DLQ] Event captured', {
@@ -107,7 +172,117 @@ export const webhookDLQ = {
         }
     },
 
+    /**
+     * Schedule automatic retry for a DLQ entry with exponential backoff,
+     * ±10% jitter, and circuit-breaker protection per endpoint.
+     *
+     * Retry schedule: 1m → 2m → 4m → 8m → 16m → 32m → permanent failure.
+     * Circuit breaker: 5 consecutive endpoint failures → pause 1 hour.
+     */
+    async scheduleRetry(id: string): Promise<void> {
+        const entry = store.get(id);
+        if (!entry) return;
+        if (entry.reprocessStatus === 'succeeded') return;
+
+        const processor = entry.source === 'stripe' ? _stripeProcessor : _githubProcessor;
+        if (!processor) return;
+
+        // Circuit breaker only applies when an explicit endpoint URL is provided
+        const endpoint = entry.endpointUrl ?? null;
+
+        for (let attempt = 0; attempt < RETRY_INTERVALS_MS.length; attempt++) {
+            // Re-read entry in case it was mutated
+            const current = store.get(id);
+            if (!current || current.reprocessStatus === 'succeeded') return;
+
+            // Check circuit breaker before each attempt (only when endpoint URL is known)
+            if (endpoint !== null && isCircuitOpen(endpoint)) {
+                console.warn('[DLQ] Circuit open, skipping retry', { id, endpoint, attempt });
+                console.log('[DLQ] Retry audit', {
+                    id,
+                    source: current.source,
+                    eventType: current.eventType,
+                    attempt,
+                    outcome: 'circuit_open',
+                    timestamp: new Date().toISOString(),
+                });
+                return;
+            }
+
+            const baseDelay = RETRY_INTERVALS_MS[attempt];
+            const delay = calculateBackoffDelay(0, baseDelay, baseDelay * 2, 1);
+            await sleep(delay);
+
+            // Re-check after sleep
+            const afterSleep = store.get(id);
+            if (!afterSleep || afterSleep.reprocessStatus === 'succeeded') return;
+            if (endpoint !== null && isCircuitOpen(endpoint)) {
+                console.warn('[DLQ] Circuit opened during wait, skipping retry', { id, endpoint });
+                return;
+            }
+
+            try {
+                await processor(afterSleep);
+                afterSleep.reprocessedAt = new Date();
+                afterSleep.reprocessStatus = 'succeeded';
+                afterSleep.attempts += 1;
+                store.set(id, afterSleep);
+                if (endpoint !== null) recordSuccess(endpoint);
+                console.log('[DLQ] Retry audit', {
+                    id,
+                    source: afterSleep.source,
+                    eventType: afterSleep.eventType,
+                    attempt,
+                    outcome: 'succeeded',
+                    timestamp: new Date().toISOString(),
+                });
+                return;
+            } catch (err: any) {
+                afterSleep.attempts += 1;
+                afterSleep.failureReason = err?.message ?? 'Retry failed';
+                store.set(id, afterSleep);
+                if (endpoint !== null) recordFailure(endpoint);
+                console.log('[DLQ] Retry audit', {
+                    id,
+                    source: afterSleep.source,
+                    eventType: afterSleep.eventType,
+                    attempt,
+                    outcome: 'failed',
+                    error: afterSleep.failureReason,
+                    timestamp: new Date().toISOString(),
+                });
+            }
+        }
+
+        // All retries exhausted → permanent failure
+        const final = store.get(id);
+        if (final) {
+            final.reprocessStatus = 'failed';
+            store.set(id, final);
+            console.error('[DLQ] Permanent failure after all retries', {
+                id,
+                source: final.source,
+                eventType: final.eventType,
+                attempts: final.attempts,
+                timestamp: new Date().toISOString(),
+            });
+        }
+    },
+
     size(): number {
         return store.size;
+    },
+
+    /** Exposed for testing only. */
+    _getCircuitBreaker(endpoint: string): CircuitBreakerState {
+        return getCircuitBreaker(endpoint);
+    },
+
+    /** Exposed for testing only – resets all state. */
+    _reset(): void {
+        store.clear();
+        circuitBreakers.clear();
+        _stripeProcessor = null;
+        _githubProcessor = null;
     },
 };

--- a/apps/backend/src/services/deployment-logs.service.test.ts
+++ b/apps/backend/src/services/deployment-logs.service.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Tests for deploymentLogsService.writeLog() batching behaviour:
+ * - batch accumulation up to BATCH_SIZE
+ * - timer-based flush after 500ms
+ * - ordering by timestamp
+ * - backpressure when MAX_QUEUED_BATCHES exceeded
+ * - graceful shutdown via flushAll()
+ *
+ * Uses vi.useFakeTimers() to control the flush interval.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { deploymentLogsService } from '@/services/deployment-logs.service';
+
+// Mock shutdown-manager so trackOperation is a no-op
+vi.mock('@/lib/shutdown-manager', () => ({
+    trackOperation: vi.fn().mockReturnValue(() => {}),
+    isDraining: vi.fn().mockReturnValue(false),
+    drain: vi.fn().mockResolvedValue(undefined),
+    inFlightCount: vi.fn().mockReturnValue(0),
+}));
+
+function makeSupabase(insertMock?: ReturnType<typeof vi.fn>) {
+    const insert = insertMock ?? vi.fn().mockResolvedValue({ error: null });
+    return {
+        from: vi.fn().mockReturnValue({ insert }),
+        _insert: insert,
+    } as any;
+}
+
+beforeEach(() => {
+    deploymentLogsService._resetBatch();
+    vi.useFakeTimers();
+});
+
+afterEach(() => {
+    deploymentLogsService._resetBatch();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+});
+
+describe('deploymentLogsService.writeLog() batching', () => {
+    it('buffers entries and does not flush before BATCH_SIZE or timer fires', () => {
+        const supabase = makeSupabase();
+
+        deploymentLogsService.writeLog(
+            { deploymentId: 'dep-1', level: 'info', message: 'msg1' },
+            supabase,
+        );
+
+        // No flush yet
+        expect(supabase._insert).not.toHaveBeenCalled();
+    });
+
+    it('flushes automatically when batch reaches default size (50)', async () => {
+        const insert = vi.fn().mockResolvedValue({ error: null });
+        const supabase = {
+            from: vi.fn().mockReturnValue({ insert }),
+        } as any;
+
+        for (let i = 0; i < 50; i++) {
+            deploymentLogsService.writeLog(
+                { deploymentId: 'dep-1', level: 'info', message: `msg${i}`, timestamp: new Date(i).toISOString() },
+                supabase,
+            );
+        }
+
+        // Flush is triggered synchronously at BATCH_SIZE; advance timers to let async writeBatch settle
+        await vi.advanceTimersByTimeAsync(0);
+
+        expect(insert).toHaveBeenCalledTimes(1);
+        const rows = insert.mock.calls[0][0];
+        expect(rows).toHaveLength(50);
+    });
+
+    it('flushes after 500ms timer fires even with fewer than batch-size entries', async () => {
+        const insert = vi.fn().mockResolvedValue({ error: null });
+        const supabase = {
+            from: vi.fn().mockReturnValue({ insert }),
+        } as any;
+
+        deploymentLogsService.writeLog(
+            { deploymentId: 'dep-2', level: 'warn', message: 'partial batch' },
+            supabase,
+        );
+
+        expect(insert).not.toHaveBeenCalled();
+
+        // Advance timer past flush interval and await async callbacks
+        await vi.advanceTimersByTimeAsync(500);
+
+        expect(insert).toHaveBeenCalledTimes(1);
+    });
+
+    it('orders batch entries by timestamp ascending', async () => {
+        const insert = vi.fn().mockResolvedValue({ error: null });
+        const supabase = {
+            from: vi.fn().mockReturnValue({ insert }),
+        } as any;
+
+        const timestamps = [
+            '2024-01-01T00:00:03.000Z',
+            '2024-01-01T00:00:01.000Z',
+            '2024-01-01T00:00:02.000Z',
+        ];
+
+        for (const ts of timestamps) {
+            deploymentLogsService.writeLog(
+                { deploymentId: 'dep-3', level: 'info', message: `msg at ${ts}`, timestamp: ts },
+                supabase,
+            );
+        }
+
+        await vi.advanceTimersByTimeAsync(500);
+
+        const rows: Array<{ created_at: string }> = insert.mock.calls[0][0];
+        const sorted = [...rows].sort((a, b) =>
+            new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
+        );
+        expect(rows).toEqual(sorted);
+    });
+
+    it('flushAll() flushes buffered entries immediately', async () => {
+        const insert = vi.fn().mockResolvedValue({ error: null });
+        const supabase = {
+            from: vi.fn().mockReturnValue({ insert }),
+        } as any;
+
+        deploymentLogsService.writeLog(
+            { deploymentId: 'dep-4', level: 'error', message: 'shutdown flush' },
+            supabase,
+        );
+
+        const flushPromise = deploymentLogsService.flushAll();
+        // flushAll uses setTimeout(resolve, 0) — advance past it
+        await vi.advanceTimersByTimeAsync(1);
+        await flushPromise;
+
+        expect(insert).toHaveBeenCalledTimes(1);
+    });
+
+    it('applies backpressure when MAX_QUEUED_BATCHES (10) is exceeded', async () => {
+        const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const insert = vi
+            .fn()
+            .mockImplementation(() => new Promise((res) => setTimeout(() => res({ error: null }), 10000)));
+        const supabase = {
+            from: vi.fn().mockReturnValue({ insert }),
+        } as any;
+
+        // Fill up 11 batches (each 50 entries) — 11th triggers backpressure
+        for (let batch = 0; batch < 11; batch++) {
+            for (let i = 0; i < 50; i++) {
+                deploymentLogsService.writeLog(
+                    { deploymentId: 'dep-5', level: 'info', message: `b${batch}-m${i}`, timestamp: new Date(i).toISOString() },
+                    supabase,
+                );
+            }
+            await vi.advanceTimersByTimeAsync(0);
+        }
+
+        expect(consoleSpy).toHaveBeenCalledWith(
+            expect.stringContaining('Backpressure'),
+        );
+    });
+
+    it('sets default timestamp when not provided', async () => {
+        const insert = vi.fn().mockResolvedValue({ error: null });
+        const supabase = {
+            from: vi.fn().mockReturnValue({ insert }),
+        } as any;
+
+        const before = new Date().toISOString();
+        deploymentLogsService.writeLog(
+            { deploymentId: 'dep-6', level: 'info', message: 'no-ts' },
+            supabase,
+        );
+
+        await vi.advanceTimersByTimeAsync(500);
+
+        const rows: Array<{ created_at: string }> = insert.mock.calls[0][0];
+        expect(rows[0].created_at >= before).toBe(true);
+    });
+
+    it('uses default stage "build" when stage is not provided', async () => {
+        const insert = vi.fn().mockResolvedValue({ error: null });
+        const supabase = {
+            from: vi.fn().mockReturnValue({ insert }),
+        } as any;
+
+        deploymentLogsService.writeLog(
+            { deploymentId: 'dep-7', level: 'info', message: 'no-stage' },
+            supabase,
+        );
+
+        await vi.advanceTimersByTimeAsync(500);
+
+        const rows: Array<{ stage: string }> = insert.mock.calls[0][0];
+        expect(rows[0].stage).toBe('build');
+    });
+});

--- a/apps/backend/src/services/deployment-logs.service.ts
+++ b/apps/backend/src/services/deployment-logs.service.ts
@@ -5,6 +5,99 @@ import type {
     DeploymentLogResponse,
     PaginatedLogsResponse,
 } from '@craft/types';
+import { trackOperation } from '@/lib/shutdown-manager';
+
+// ── Write batching (issue #747) ───────────────────────────────────────────────
+
+const BATCH_SIZE = parseInt(process.env.LOG_BATCH_SIZE ?? '50', 10);
+const FLUSH_INTERVAL_MS = 500;
+const MAX_QUEUED_BATCHES = 10;
+
+export interface LogWriteEntry {
+    deploymentId: string;
+    level: LogLevel;
+    message: string;
+    stage?: string;
+    metadata?: Record<string, unknown>;
+    /** ISO timestamp; defaults to now if omitted. */
+    timestamp?: string;
+}
+
+interface PendingBatch {
+    entries: LogWriteEntry[];
+    supabase: SupabaseClient;
+}
+
+const pendingBatches: PendingBatch[] = [];
+let inFlightWrites = 0;
+let currentBatch: { entries: LogWriteEntry[]; supabase: SupabaseClient | null } = {
+    entries: [],
+    supabase: null,
+};
+let flushTimer: ReturnType<typeof setInterval> | null = null;
+
+function startFlushTimer(): void {
+    if (flushTimer !== null) return;
+    flushTimer = setInterval(() => {
+        flushCurrentBatch();
+    }, FLUSH_INTERVAL_MS);
+}
+
+function flushCurrentBatch(): void {
+    if (currentBatch.entries.length === 0 || currentBatch.supabase === null) return;
+
+    // Apply backpressure: if too many in-flight writes, drop oldest queued batch
+    if (inFlightWrites >= MAX_QUEUED_BATCHES) {
+        console.warn('[deployment-logs] Backpressure: dropping oldest pending batch');
+        pendingBatches.shift();
+    }
+
+    pendingBatches.push({ entries: [...currentBatch.entries], supabase: currentBatch.supabase });
+    currentBatch.entries = [];
+    currentBatch.supabase = null;
+
+    processPendingBatches();
+}
+
+function processPendingBatches(): void {
+    while (pendingBatches.length > 0) {
+        const batch = pendingBatches.shift()!;
+        writeBatch(batch).catch((err) => {
+            console.error('[deployment-logs] Batch write failed', err);
+        });
+    }
+}
+
+async function writeBatch(batch: PendingBatch): Promise<void> {
+    inFlightWrites++;
+    const done = trackOperation(`log-batch-${Date.now()}`);
+    try {
+        // Sort by timestamp to guarantee ordering
+        const rows = batch.entries
+            .slice()
+            .sort((a, b) => {
+                const ta = a.timestamp ? new Date(a.timestamp).getTime() : 0;
+                const tb = b.timestamp ? new Date(b.timestamp).getTime() : 0;
+                return ta - tb;
+            })
+            .map((e) => ({
+                deployment_id: e.deploymentId,
+                level: e.level,
+                message: e.message,
+                stage: e.stage ?? 'build',
+                metadata: e.metadata ?? null,
+                created_at: e.timestamp ?? new Date().toISOString(),
+            }));
+
+        const { error } = await batch.supabase.from('deployment_logs').insert(rows);
+        if (error) {
+            console.error('[deployment-logs] Batch insert error', error.message);
+        }
+    } finally {
+        inFlightWrites--;
+        done();
+    }
+}
 
 const MAX_LIMIT = 200;
 const DEFAULT_PAGE = 1;
@@ -105,6 +198,61 @@ export function parseLogsQueryParams(searchParams: URLSearchParams): ParseResult
 }
 
 export const deploymentLogsService = {
+    /**
+     * Buffer a single log entry for batched write.
+     * Entries are flushed every 500ms or when the batch reaches BATCH_SIZE.
+     * Uses the provided supabase client for the flush of this batch.
+     */
+    writeLog(entry: LogWriteEntry, supabase: SupabaseClient): void {
+        startFlushTimer();
+
+        if (currentBatch.supabase === null) {
+            currentBatch.supabase = supabase;
+        }
+
+        currentBatch.entries.push({
+            ...entry,
+            timestamp: entry.timestamp ?? new Date().toISOString(),
+        });
+
+        if (currentBatch.entries.length >= BATCH_SIZE) {
+            flushCurrentBatch();
+        }
+    },
+
+    /**
+     * Immediately flush all buffered entries.
+     * Should be called during graceful shutdown (integrates with shutdown-manager).
+     */
+    async flushAll(): Promise<void> {
+        flushCurrentBatch();
+        // Wait for any in-flight writes (processPendingBatches is sync-dispatch)
+        await new Promise((resolve) => setTimeout(resolve, 0));
+    },
+
+    /**
+     * Stop the flush timer (for testing / shutdown).
+     */
+    stopFlushTimer(): void {
+        if (flushTimer !== null) {
+            clearInterval(flushTimer);
+            flushTimer = null;
+        }
+    },
+
+    /**
+     * Exposed for testing only – resets batch state.
+     */
+    _resetBatch(): void {
+        currentBatch.entries = [];
+        currentBatch.supabase = null;
+        pendingBatches.length = 0;
+        inFlightWrites = 0;
+        if (flushTimer !== null) {
+            clearInterval(flushTimer);
+            flushTimer = null;
+        }
+    },
     /**
      * Get logs for a deployment with filtering support.
      *


### PR DESCRIPTION
## Summary

Resolves #748 and
Closes #747.

### #748 — Webhook DLQ Auto-Recovery with Exponential Backoff

- `scheduleRetry()` in `dead-letter-queue.ts`: 6-interval exponential backoff (1m → 2m → 4m → 8m → 16m → 32m → permanent failure)
- Jitter: ±10% per retry interval via `calculateBackoffDelay()`
- Circuit breaker: 5 consecutive failures to an explicit endpoint URL → 1hr pause, auto-resets
- Audit log entry emitted for every retry attempt with outcome, timestamp, source, eventType

### #747 — Deployment Log Write Batching

- Batch buffer up to `BATCH_SIZE` (default 50, env: `LOG_BATCH_SIZE`)
- Flush timer via `setInterval` every 500ms
- Timestamp-ascending ordering within each batch
- Backpressure via `inFlightWrites` counter (drops oldest when ≥10 concurrent writes)
- `flushAll()` for graceful shutdown via `shutdown-manager.ts`

## Tests

```
Test Files  2 passed (2)
Tests       20 passed (20)
```