### PR TITLE
test: property and mutation tests for issues #731 #732 #733 #735

### DIFF
--- a/apps/backend/src/services/auth.service.mutation.test.ts
+++ b/apps/backend/src/services/auth.service.mutation.test.ts
@@ -699,4 +699,102 @@ describe('AuthService - Mutation Testing (Boundary Conditions)', () => {
             expect(result.user?.githubUsername).toBe('');
         });
     });
+
+    // ===== CREDENTIAL VALIDATION EDGE CASES (Issue #732) =====
+    // Kill surviving mutants in empty-string checks, error code mapping, and
+    // the INVALID_CREDENTIALS vs USER_NOT_FOUND distinction.
+    describe('Credential Validation Edge Cases', () => {
+        it('signIn with empty email returns an error, not a success (MUTATION: missing empty-string guard)', async () => {
+            mockSignInWithPassword.mockResolvedValue({
+                data: { user: null, session: null },
+                error: { code: 'validation_failed', message: 'email is required' },
+            });
+
+            const result = await service.signIn('', 'password123');
+
+            expect(result.user).toBeNull();
+            expect(result.session).toBeNull();
+            expect(result.error).not.toBeNull();
+            expect(result.error?.code).toBe('validation_failed');
+        });
+
+        it('signIn with empty email and no error code falls back to SIGNIN_ERROR (MUTATION: remove fallback)', async () => {
+            mockSignInWithPassword.mockResolvedValue({
+                data: { user: null, session: null },
+                error: { message: 'Invalid input' },
+            });
+
+            const result = await service.signIn('', 'password');
+
+            expect(result.error?.code).toBe('SIGNIN_ERROR');
+            expect(result.user).toBeNull();
+        });
+
+        it('signUp with password under minimum length returns error with exact code (MUTATION: swallow short-password error)', async () => {
+            mockSignUp.mockResolvedValue({
+                data: { user: null, session: null },
+                error: { code: 'weak_password', message: 'Password should be at least 6 characters.' },
+            });
+
+            const result = await service.signUp('user@example.com', 'abc');
+
+            expect(result.user).toBeNull();
+            expect(result.session).toBeNull();
+            expect(result.error).not.toBeNull();
+            expect(result.error?.code).toBe('weak_password');
+            expect(result.error?.message).toContain('6 characters');
+        });
+
+        it('signUp error message is passed through verbatim, not transformed (MUTATION: apply getReadableErrorMessage to signUp)', async () => {
+            const rawMessage = 'Password should be at least 6 characters.';
+            mockSignUp.mockResolvedValue({
+                data: { user: null, session: null },
+                error: { code: 'weak_password', message: rawMessage },
+            });
+
+            const result = await service.signUp('user@example.com', 'abc');
+
+            // signUp must NOT apply getReadableErrorMessage — message is unchanged
+            expect(result.error?.message).toBe(rawMessage);
+            expect(result.error?.message).not.toBe('Invalid email or password. Please try again.');
+        });
+
+        it('non-existent user returns INVALID_CREDENTIALS, not USER_NOT_FOUND (MUTATION: wrong error code)', async () => {
+            mockSignInWithPassword.mockResolvedValue({
+                data: { user: null, session: null },
+                error: { code: 'invalid_credentials', message: 'Invalid login credentials' },
+            });
+
+            const result = await service.signIn('valid-but-missing@example.com', 'somepassword');
+
+            expect(result.error?.code).toBe('invalid_credentials');
+            expect(result.error?.code).not.toBe('USER_NOT_FOUND');
+            expect(result.error?.code).not.toBe('user_not_found');
+            expect(result.error?.message).toBe('Invalid email or password. Please try again.');
+        });
+
+        it('non-existent user error message is transformed to friendly text (MUTATION: skip getReadableErrorMessage)', async () => {
+            mockSignInWithPassword.mockResolvedValue({
+                data: { user: null, session: null },
+                error: { code: 'invalid_credentials', message: 'Invalid login credentials' },
+            });
+
+            const result = await service.signIn('ghost@example.com', 'pass');
+
+            expect(result.error?.message).not.toBe('Invalid login credentials');
+            expect(result.error?.message).toBe('Invalid email or password. Please try again.');
+        });
+
+        it('signUp with empty password falls back to SIGNUP_ERROR when code is absent (MUTATION: remove fallback)', async () => {
+            mockSignUp.mockResolvedValue({
+                data: { user: null, session: null },
+                error: { message: 'Password is required' },
+            });
+
+            const result = await service.signUp('test@example.com', '');
+
+            expect(result.error?.code).toBe('SIGNUP_ERROR');
+            expect(result.user).toBeNull();
+        });
+    });
 });

--- a/apps/backend/src/services/metered-billing.property.test.ts
+++ b/apps/backend/src/services/metered-billing.property.test.ts
@@ -1,0 +1,400 @@
+/**
+ * Property-based tests for MeteringService usage accumulation
+ *
+ * Invariants under test:
+ *   1. Usage total after N deployments equals N × unit cost
+ *   2. Concurrent increments (same-second idempotency) accumulate correctly
+ *   3. Reset-at-period-end: after reset, aggregateUsage returns empty
+ *   4. Total usage is never negative for non-negative inputs
+ *
+ * Issue: #731
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as fc from 'fast-check';
+import { MeteringService } from './metered-billing.service';
+
+// ─── In-memory Supabase mock ─────────────────────────────────────────────────
+
+interface UsageRecord {
+  id: string;
+  user_id: string;
+  operation_type: string;
+  quantity: number;
+  metadata: Record<string, unknown>;
+  billing_period_start: string;
+  billing_period_end: string;
+  idempotency_key: string;
+  reported_to_stripe: boolean;
+  created_at: string;
+}
+
+const store: UsageRecord[] = [];
+let idCounter = 0;
+
+function createQueryBuilder(records: UsageRecord[]) {
+  const conditions: Array<(r: UsageRecord) => boolean> = [];
+  let isDelete = false;
+
+  const builder: any = {
+    select(_cols?: string, _opts?: unknown) {
+      return builder;
+    },
+    eq(col: string, val: unknown) {
+      conditions.push((r: any) => r[col] === val);
+      return builder;
+    },
+    gte(col: string, val: unknown) {
+      conditions.push((r: any) => r[col] >= val);
+      return builder;
+    },
+    lte(col: string, val: unknown) {
+      conditions.push((r: any) => r[col] <= val);
+      return builder;
+    },
+    is(col: string, _val: null) {
+      conditions.push((r: any) => r[col] == null);
+      return builder;
+    },
+    async single() {
+      const matching = records.filter(r => conditions.every(c => c(r)));
+      if (matching.length === 0) {
+        return { data: null, error: { code: 'PGRST116', message: 'No rows found' } };
+      }
+      return { data: matching[0], error: null };
+    },
+    insert(data: unknown) {
+      const record = {
+        id: `id-${++idCounter}`,
+        created_at: new Date().toISOString(),
+        ...(data as object),
+      } as UsageRecord;
+      records.push(record);
+      return {
+        select(_cols?: string) {
+          return {
+            async single() {
+              return { data: record, error: null };
+            },
+          };
+        },
+      };
+    },
+    update(data: unknown) {
+      return {
+        eq(col: string, val: unknown) {
+          const idx = records.findIndex((r: any) => r[col] === val);
+          if (idx >= 0) {
+            Object.assign(records[idx], data);
+          }
+          const found = idx >= 0 ? records[idx] : null;
+          return {
+            select(_cols?: string) {
+              return {
+                async single() {
+                  return { data: found, error: null };
+                },
+              };
+            },
+          };
+        },
+      };
+    },
+    delete() {
+      isDelete = true;
+      return builder;
+    },
+    then(resolve: (val: unknown) => void, reject: (err: unknown) => void) {
+      try {
+        const matching = records.filter(r => conditions.every(c => c(r)));
+        if (isDelete) {
+          matching.forEach(r => {
+            const idx = records.indexOf(r);
+            if (idx >= 0) records.splice(idx, 1);
+          });
+          resolve({ data: matching, error: null });
+        } else {
+          resolve({ data: matching, error: null });
+        }
+      } catch (e) {
+        reject(e);
+      }
+    },
+  };
+
+  return builder;
+}
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: () => ({
+    from: (_table: string) => createQueryBuilder(store),
+  }),
+}));
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function getBillingPeriodStart(): Date {
+  const now = new Date();
+  return new Date(now.getFullYear(), now.getMonth(), 1);
+}
+
+function getBillingPeriodEnd(): Date {
+  const now = new Date();
+  return new Date(now.getFullYear(), now.getMonth() + 1, 0, 23, 59, 59);
+}
+
+function seedRecord(
+  userId: string,
+  operationType: string,
+  quantity: number,
+  index: number
+): void {
+  store.push({
+    id: `id-${++idCounter}`,
+    user_id: userId,
+    operation_type: operationType,
+    quantity,
+    metadata: {},
+    billing_period_start: getBillingPeriodStart().toISOString(),
+    billing_period_end: getBillingPeriodEnd().toISOString(),
+    idempotency_key: `${operationType}-${userId}-${index}`,
+    reported_to_stripe: false,
+    created_at: new Date().toISOString(),
+  });
+}
+
+// ─── Property tests ───────────────────────────────────────────────────────────
+
+describe('MeteringService – property-based invariants', () => {
+  beforeEach(() => {
+    store.length = 0;
+    idCounter = 0;
+  });
+
+  describe('Property 1 — accumulation: N deployments with unit cost q totals N × q', () => {
+    it('total_quantity equals N when each record has quantity 1', async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          fc.string({ minLength: 1, maxLength: 20 }),
+          fc.string({ minLength: 1, maxLength: 20 }),
+          fc.integer({ min: 1, max: 20 }),
+          async (userId, operationType, n) => {
+            store.length = 0;
+            idCounter = 0;
+
+            for (let i = 0; i < n; i++) {
+              seedRecord(userId, operationType, 1, i);
+            }
+
+            const svc = new MeteringService();
+            const aggregations = await svc.aggregateUsage(userId);
+            const opAgg = aggregations.find(a => a.operation_type === operationType);
+
+            expect(opAgg?.total_quantity).toBe(n);
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('total_quantity equals N × q for any positive unit cost q', async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          fc.string({ minLength: 1, maxLength: 20 }),
+          fc.string({ minLength: 1, maxLength: 20 }),
+          fc.integer({ min: 1, max: 10 }),
+          fc.integer({ min: 1, max: 100 }),
+          async (userId, operationType, n, q) => {
+            store.length = 0;
+            idCounter = 0;
+
+            for (let i = 0; i < n; i++) {
+              seedRecord(userId, operationType, q, i);
+            }
+
+            const svc = new MeteringService();
+            const aggregations = await svc.aggregateUsage(userId);
+            const opAgg = aggregations.find(a => a.operation_type === operationType);
+
+            expect(opAgg?.total_quantity).toBe(n * q);
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('record_count equals N regardless of quantity value', async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          fc.string({ minLength: 1, maxLength: 20 }),
+          fc.string({ minLength: 1, maxLength: 20 }),
+          fc.integer({ min: 1, max: 15 }),
+          fc.integer({ min: 1, max: 50 }),
+          async (userId, operationType, n, q) => {
+            store.length = 0;
+            idCounter = 0;
+
+            for (let i = 0; i < n; i++) {
+              seedRecord(userId, operationType, q, i);
+            }
+
+            const svc = new MeteringService();
+            const aggregations = await svc.aggregateUsage(userId);
+            const opAgg = aggregations.find(a => a.operation_type === operationType);
+
+            expect(opAgg?.record_count).toBe(n);
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+  });
+
+  describe('Property 2 — concurrent increment: same-second calls accumulate into one record', () => {
+    it('two recordUsage calls in the same second yield combined quantity', async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          fc.string({ minLength: 1, maxLength: 20 }),
+          fc.string({ minLength: 1, maxLength: 20 }),
+          fc.integer({ min: 1, max: 50 }),
+          fc.integer({ min: 1, max: 50 }),
+          async (userId, operationType, q1, q2) => {
+            store.length = 0;
+            idCounter = 0;
+
+            const svc = new MeteringService();
+            await svc.recordUsage(userId, operationType, q1);
+            await svc.recordUsage(userId, operationType, q2);
+
+            const aggregations = await svc.aggregateUsage(userId);
+            const opAgg = aggregations.find(a => a.operation_type === operationType);
+
+            expect(opAgg?.total_quantity).toBeGreaterThan(0);
+            expect(opAgg?.total_quantity).toBeLessThanOrEqual(q1 + q2);
+          }
+        ),
+        { numRuns: 50 }
+      );
+    });
+  });
+
+  describe('Property 3 — reset-at-period-end: after reset, usage returns to zero', () => {
+    it('aggregateUsage returns empty after resetUsageForPeriod clears all records', async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          fc.string({ minLength: 1, maxLength: 20 }),
+          fc.string({ minLength: 1, maxLength: 20 }),
+          fc.integer({ min: 1, max: 15 }),
+          async (userId, operationType, n) => {
+            store.length = 0;
+            idCounter = 0;
+
+            const periodStart = getBillingPeriodStart();
+            const periodEnd = getBillingPeriodEnd();
+
+            for (let i = 0; i < n; i++) {
+              seedRecord(userId, operationType, 1, i);
+            }
+
+            const svc = new MeteringService();
+            await svc.resetUsageForPeriod({ start: periodStart, end: periodEnd });
+
+            const aggregations = await svc.aggregateUsage(userId);
+            expect(aggregations).toHaveLength(0);
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('reset does not affect subsequent usage recorded after reset', async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          fc.string({ minLength: 1, maxLength: 20 }),
+          fc.string({ minLength: 1, maxLength: 20 }),
+          fc.integer({ min: 1, max: 10 }),
+          fc.integer({ min: 1, max: 10 }),
+          async (userId, operationType, beforeN, afterN) => {
+            store.length = 0;
+            idCounter = 0;
+
+            const periodStart = getBillingPeriodStart();
+            const periodEnd = getBillingPeriodEnd();
+
+            for (let i = 0; i < beforeN; i++) {
+              seedRecord(userId, operationType, 1, i);
+            }
+
+            const svc = new MeteringService();
+            await svc.resetUsageForPeriod({ start: periodStart, end: periodEnd });
+
+            for (let i = 0; i < afterN; i++) {
+              seedRecord(userId, operationType, 1, beforeN + i);
+            }
+
+            const aggregations = await svc.aggregateUsage(userId);
+            const opAgg = aggregations.find(a => a.operation_type === operationType);
+            expect(opAgg?.total_quantity).toBe(afterN);
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+  });
+
+  describe('Property 4 — non-negative invariant: total usage is never negative', () => {
+    it('aggregate total_quantity is always >= 0 for non-negative inputs', async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          fc.string({ minLength: 1, maxLength: 20 }),
+          fc.array(
+            fc.record({
+              operationType: fc.string({ minLength: 1, maxLength: 20 }),
+              quantity: fc.integer({ min: 0, max: 100 }),
+            }),
+            { minLength: 0, maxLength: 20 }
+          ),
+          async (userId, calls) => {
+            store.length = 0;
+            idCounter = 0;
+
+            calls.forEach((c, i) => seedRecord(userId, c.operationType, c.quantity, i));
+
+            const svc = new MeteringService();
+            const aggregations = await svc.aggregateUsage(userId);
+
+            for (const agg of aggregations) {
+              expect(agg.total_quantity).toBeGreaterThanOrEqual(0);
+            }
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('billing unit rounding: integer quantity sums are exact (no floating-point drift)', async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          fc.string({ minLength: 1, maxLength: 20 }),
+          fc.string({ minLength: 1, maxLength: 20 }),
+          fc.array(fc.integer({ min: 1, max: 1000 }), { minLength: 1, maxLength: 50 }),
+          async (userId, operationType, quantities) => {
+            store.length = 0;
+            idCounter = 0;
+
+            quantities.forEach((q, i) => seedRecord(userId, operationType, q, i));
+
+            const expected = quantities.reduce((sum, q) => sum + q, 0);
+
+            const svc = new MeteringService();
+            const aggregations = await svc.aggregateUsage(userId);
+            const opAgg = aggregations.find(a => a.operation_type === operationType);
+
+            expect(opAgg?.total_quantity).toBe(expected);
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+  });
+});

--- a/apps/backend/src/services/syntax-validator.property.test.ts
+++ b/apps/backend/src/services/syntax-validator.property.test.ts
@@ -21,6 +21,7 @@ import * as fc from 'fast-check';
 import { CodeGeneratorService, type TemplateFamilyId } from './code-generator.service';
 import { SyntaxValidator } from './syntax-validator';
 import type { CustomizationConfig } from '@craft/types';
+import type { GeneratedFile } from '@craft/types';
 
 // ── Arbitraries (shared with code-generator property tests) ──────────────────
 
@@ -171,4 +172,178 @@ describe('Property 49 – Generated Code Syntax Validity', () => {
             );
         }
     );
+});
+
+// ── Direct SyntaxValidator property tests (Issue #735) ───────────────────────
+
+const safeIdentifier = fc
+    .stringOf(
+        fc.constantFrom(...'abcdefghijklmnopqrstuvwxyz'.split('')),
+        { minLength: 1, maxLength: 12 }
+    )
+    .filter(s => !['if', 'else', 'for', 'let', 'const', 'var', 'return', 'function', 'class'].includes(s));
+
+const arbLiteral = fc.oneof(
+    fc.integer({ min: 0, max: 9999 }).map(n => String(n)),
+    fc.constantFrom('"hello"', '"world"', 'true', 'false', 'null'),
+);
+
+function makeFile(path: string, content: string): GeneratedFile {
+    return { path, content };
+}
+
+describe('SyntaxValidator – direct property-based classification (Issue #735)', () => {
+    const validator = new SyntaxValidator();
+
+    // Property A: valid TypeScript snippets always classify as valid
+    describe('Property A — valid TS snippets return { valid: true }', () => {
+        it('A1: const declarations with safe identifiers are always valid', () => {
+            fc.assert(
+                fc.property(safeIdentifier, arbLiteral, (name, value) => {
+                    const content = `const ${name} = ${value};\n`;
+                    const result = validator.validate(makeFile('test.ts', content));
+                    expect(result.valid).toBe(true);
+                    expect(result.errors).toHaveLength(0);
+                }),
+                { numRuns: 500 }
+            );
+        });
+
+        it('A2: function declarations with a body are always valid', () => {
+            fc.assert(
+                fc.property(safeIdentifier, arbLiteral, (name, value) => {
+                    const content = `function ${name}(): number { return ${value}; }\n`;
+                    const result = validator.validate(makeFile('fn.ts', content));
+                    expect(result.valid).toBe(true);
+                    expect(result.errors).toHaveLength(0);
+                }),
+                { numRuns: 500 }
+            );
+        });
+
+        it('A3: arrow functions assigned to const are always valid', () => {
+            fc.assert(
+                fc.property(safeIdentifier, arbLiteral, (fn, value) => {
+                    const content = `const ${fn} = (): number => ${value};\n`;
+                    const result = validator.validate(makeFile('arrow.ts', content));
+                    expect(result.valid).toBe(true);
+                    expect(result.errors).toHaveLength(0);
+                }),
+                { numRuns: 500 }
+            );
+        });
+
+        it('A4: interface declarations with one typed field are always valid', () => {
+            fc.assert(
+                fc.property(safeIdentifier, safeIdentifier, (iface, field) => {
+                    const content = `interface ${iface} { ${field}: string; }\n`;
+                    const result = validator.validate(makeFile('iface.ts', content));
+                    expect(result.valid).toBe(true);
+                    expect(result.errors).toHaveLength(0);
+                }),
+                { numRuns: 500 }
+            );
+        });
+    });
+
+    // Property B: snippets with mismatched braces always classify as invalid
+    describe('Property B — mismatched braces return { valid: false }', () => {
+        it('B1: unclosed function body (missing closing brace) is always invalid', () => {
+            fc.assert(
+                fc.property(safeIdentifier, arbLiteral, (name, value) => {
+                    const content = `function ${name}() { return ${value};\n`;
+                    const result = validator.validate(makeFile('bad.ts', content));
+                    expect(result.valid).toBe(false);
+                    expect(result.errors.length).toBeGreaterThan(0);
+                }),
+                { numRuns: 500 }
+            );
+        });
+
+        it('B2: stray closing brace with no matching open is always invalid', () => {
+            fc.assert(
+                fc.property(safeIdentifier, arbLiteral, (name, value) => {
+                    const content = `const ${name} = ${value}; }`;
+                    const result = validator.validate(makeFile('extra.ts', content));
+                    expect(result.valid).toBe(false);
+                    expect(result.errors.length).toBeGreaterThan(0);
+                }),
+                { numRuns: 500 }
+            );
+        });
+
+        it('B3: unclosed object literal assigned to const is always invalid', () => {
+            fc.assert(
+                fc.property(safeIdentifier, (name) => {
+                    const content = `const ${name} = {`;
+                    const result = validator.validate(makeFile('obj.ts', content));
+                    expect(result.valid).toBe(false);
+                }),
+                { numRuns: 500 }
+            );
+        });
+    });
+
+    // Property C: JSON validation – valid vs invalid
+    describe('Property C — JSON validation classification', () => {
+        it('C1: well-formed JSON objects always validate as valid', () => {
+            fc.assert(
+                fc.property(
+                    fc.dictionary(
+                        fc.string({ minLength: 1, maxLength: 10 }),
+                        fc.oneof(fc.string(), fc.integer(), fc.boolean()),
+                    ),
+                    (obj) => {
+                        const content = JSON.stringify(obj);
+                        const result = validator.validate(makeFile('data.json', content));
+                        expect(result.valid).toBe(true);
+                        expect(result.errors).toHaveLength(0);
+                    }
+                ),
+                { numRuns: 500 }
+            );
+        });
+
+        it('C2: truncated JSON always fails validation', () => {
+            fc.assert(
+                fc.property(
+                    fc.dictionary(
+                        fc.string({ minLength: 1, maxLength: 10 }),
+                        fc.string({ minLength: 1, maxLength: 10 }),
+                        { minKeys: 1 }
+                    ),
+                    fc.integer({ min: 1, max: 5 }),
+                    (obj, cutFrom) => {
+                        const full = JSON.stringify(obj);
+                        const truncated = full.slice(0, full.length - cutFrom);
+                        const result = validator.validate(makeFile('data.json', truncated));
+                        expect(result.valid).toBe(false);
+                        expect(result.errors.length).toBeGreaterThan(0);
+                    }
+                ),
+                { numRuns: 500 }
+            );
+        });
+    });
+
+    // Performance: 1MB TypeScript file must validate in < 500ms
+    describe('Performance — 1MB TypeScript file validates in under 500ms', () => {
+        it('validates a 1MB TypeScript file in < 500ms', () => {
+            const lineTemplate = (i: number) =>
+                `const variable_${i.toString().padStart(8, '0')} = ${i}; // auto-generated line\n`;
+            let code = '';
+            let i = 0;
+            while (code.length < 1024 * 1024) {
+                code += lineTemplate(i++);
+            }
+
+            const file = makeFile('large.ts', code);
+            const start = Date.now();
+            const result = validator.validate(file);
+            const elapsed = Date.now() - start;
+
+            expect(result.valid).toBe(true);
+            expect(elapsed).toBeLessThan(500);
+        });
+    });
 });

--- a/apps/backend/src/services/template-cloning.property.test.ts
+++ b/apps/backend/src/services/template-cloning.property.test.ts
@@ -1,0 +1,312 @@
+/**
+ * Property-based tests for TemplateCloningService file tree integrity
+ *
+ * Invariants under test:
+ *   1. Cloned tree has same file count as source (no files silently dropped)
+ *   2. All cloned file paths preserve relative structure (no absolute path leakage)
+ *   3. Dot-files (.gitignore, .env.example, etc.) are cloned correctly
+ *   4. Zero-file source yields an empty but valid result
+ *   5. Source entries containing ../ traversal segments are skipped with a
+ *      warning; the rest of the clone still succeeds
+ *
+ * Feature: template-cloning-logic
+ * Issue: #733
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as fc from 'fast-check';
+import * as nodePath from 'path';
+import {
+  TemplateCloningService,
+  type FileSystemAdapter,
+  type CloningConfig,
+  type CloneRequest,
+} from './template-cloning.service';
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+const ALLOWED_SOURCE = '/allowed/templates';
+const ALLOWED_WORKSPACE = '/allowed/workspaces';
+
+const testConfig: CloningConfig = {
+  allowedSourceRoots: [ALLOWED_SOURCE],
+  allowedWorkspaceRoots: [ALLOWED_WORKSPACE],
+};
+
+const SRC_BASE = `${ALLOWED_SOURCE}/my-template`;
+
+// ── Mock helpers ──────────────────────────────────────────────────────────────
+
+interface MockFsState {
+  dirs: Set<string>;
+  files: Map<string, string>;
+}
+
+function makeMockFs(state: MockFsState): FileSystemAdapter {
+  return {
+    async mkdir(path) {
+      state.dirs.add(path);
+    },
+    async readdir(path) {
+      const prefix = path.endsWith(nodePath.sep) ? path : path + nodePath.sep;
+      return Array.from(state.files.keys())
+        .filter((f) => f.startsWith(prefix))
+        .map((f) => nodePath.relative(path, f));
+    },
+    async copyFile(src, dest) {
+      state.files.set(dest, state.files.get(src) ?? '');
+    },
+    async exists(path) {
+      return state.dirs.has(path) || state.files.has(path);
+    },
+    async readFile(path) {
+      const content = state.files.get(path);
+      if (content === undefined) throw new Error(`File not found: ${path}`);
+      return content;
+    },
+    async writeFile(path, content) {
+      state.files.set(path, content);
+    },
+  };
+}
+
+function makeState(relativePaths: string[]): MockFsState {
+  const files = new Map<string, string>();
+  for (const rel of relativePaths) {
+    files.set(`${SRC_BASE}/${rel}`, 'content');
+  }
+  return { dirs: new Set(), files };
+}
+
+function makeRequest(overrides: Partial<CloneRequest> = {}): CloneRequest {
+  return {
+    source: { type: 'local', path: SRC_BASE },
+    workspaceRoot: ALLOWED_WORKSPACE,
+    runId: 'run-prop-test',
+    ...overrides,
+  };
+}
+
+function makeService(state: MockFsState): TemplateCloningService {
+  return new TemplateCloningService(makeMockFs(state), testConfig);
+}
+
+// ── Arbitraries ───────────────────────────────────────────────────────────────
+
+const safeSegment = fc
+  .stringOf(fc.constantFrom(...'abcdefghijklmnopqrstuvwxyz0123456789_-'.split('')), {
+    minLength: 1,
+    maxLength: 12,
+  })
+  .filter((s) => s !== '..' && s !== '.');
+
+const dotFileName = fc.constantFrom(
+  '.gitignore',
+  '.env.example',
+  '.eslintrc',
+  '.prettierrc',
+  '.editorconfig',
+  '.npmrc',
+  '.nvmrc',
+);
+
+const regularFileName = safeSegment.chain((name) =>
+  fc.constantFrom('.ts', '.js', '.json', '.md', '.yml', '.css').map((ext) => `${name}${ext}`)
+);
+
+const relativeFilePath = fc.oneof(
+  regularFileName,
+  fc.tuple(safeSegment, regularFileName).map(([dir, file]) => `${dir}/${file}`),
+  fc.tuple(safeSegment, safeSegment, regularFileName).map(
+    ([d1, d2, file]) => `${d1}/${d2}/${file}`
+  ),
+  dotFileName,
+);
+
+/** Non-empty array of unique relative file paths */
+const fileTreeArb = fc
+  .array(relativeFilePath, { minLength: 1, maxLength: 30 })
+  .map((paths) => [...new Set(paths)])
+  .filter((paths) => paths.length > 0);
+
+// ── Property 1: File count invariant ─────────────────────────────────────────
+
+describe('Property 1 — file count invariant', () => {
+  it('cloned tree always has the same number of files as the source tree', async () => {
+    await fc.assert(
+      fc.asyncProperty(fileTreeArb, async (relativePaths) => {
+        const state = makeState(relativePaths);
+        const svc = makeService(state);
+        const result = await svc.clone(makeRequest());
+
+        expect(result.success).toBe(true);
+
+        const ws = result.workspacePath!;
+        const clonedCount = Array.from(state.files.keys()).filter((p) =>
+          p.startsWith(ws + '/')
+        ).length;
+
+        expect(clonedCount).toBe(relativePaths.length);
+      }),
+      { numRuns: 200 }
+    );
+  });
+});
+
+// ── Property 2: Relative path structure preserved (no absolute path leakage) ─
+
+describe('Property 2 — relative path structure preserved', () => {
+  it('every file in the clone exists at the same relative path as in the source', async () => {
+    await fc.assert(
+      fc.asyncProperty(fileTreeArb, async (relativePaths) => {
+        const state = makeState(relativePaths);
+        const svc = makeService(state);
+        const result = await svc.clone(makeRequest());
+
+        expect(result.success).toBe(true);
+
+        const ws = result.workspacePath!;
+
+        for (const rel of relativePaths) {
+          const destPath = `${ws}/${rel}`;
+          expect(state.files.has(destPath)).toBe(true);
+        }
+      }),
+      { numRuns: 200 }
+    );
+  });
+});
+
+// ── Property 3: Dot-file handling ────────────────────────────────────────────
+
+describe('Property 3 — dot-file handling', () => {
+  it('dot-files are cloned alongside regular files without being dropped', async () => {
+    const treeWithDotFiles = fc
+      .tuple(
+        fc.array(regularFileName, { minLength: 0, maxLength: 10 }),
+        fc.array(dotFileName, { minLength: 1, maxLength: 5 }),
+      )
+      .map(([regular, dots]) => [...new Set([...regular, ...dots])]);
+
+    await fc.assert(
+      fc.asyncProperty(treeWithDotFiles, async (relativePaths) => {
+        const state = makeState(relativePaths);
+        const svc = makeService(state);
+        const result = await svc.clone(makeRequest());
+
+        expect(result.success).toBe(true);
+
+        const ws = result.workspacePath!;
+        const dotFiles = relativePaths.filter((p) => nodePath.basename(p).startsWith('.'));
+
+        for (const dotFile of dotFiles) {
+          expect(state.files.has(`${ws}/${dotFile}`)).toBe(true);
+        }
+      }),
+      { numRuns: 200 }
+    );
+  });
+});
+
+// ── Property 4: Zero files ────────────────────────────────────────────────────
+
+describe('Property 4 — zero-file source', () => {
+  it('empty source tree returns success with no files in workspace', async () => {
+    const state: MockFsState = { dirs: new Set(), files: new Map() };
+    const svc = makeService(state);
+    const result = await svc.clone(makeRequest());
+
+    expect(result.success).toBe(true);
+    expect(result.workspacePath).toBeDefined();
+    expect(result.errors).toHaveLength(0);
+
+    const ws = result.workspacePath!;
+    const clonedFiles = Array.from(state.files.keys()).filter((p) =>
+      p.startsWith(ws + '/')
+    );
+    expect(clonedFiles).toHaveLength(0);
+  });
+});
+
+// ── Property 5: Path traversal entries are rejected ───────────────────────────
+
+describe('Property 5 — path traversal protection', () => {
+  it('readdir entries containing ../ are skipped with a warning; safe files are still cloned', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.array(regularFileName, { minLength: 1, maxLength: 10 }),
+        fc.array(
+          fc.constantFrom(
+            '../../../etc/passwd',
+            '../../secret.key',
+            '../outside.ts',
+            './../sneaky.json',
+          ),
+          { minLength: 1, maxLength: 3 }
+        ),
+        async (safeFiles, traversalEntries) => {
+          const safeFileSet = [...new Set(safeFiles)];
+          const files = new Map<string, string>();
+          for (const rel of safeFileSet) {
+            files.set(`${SRC_BASE}/${rel}`, 'safe-content');
+          }
+
+          const allEntries = [...safeFileSet, ...traversalEntries];
+
+          const mockFs: FileSystemAdapter = {
+            async mkdir(_p) {
+              /* no-op */
+            },
+            async readdir() {
+              return allEntries;
+            },
+            async copyFile(src, dest) {
+              files.set(dest, files.get(src) ?? '');
+            },
+            async exists() {
+              return false;
+            },
+            async readFile(path) {
+              const c = files.get(path);
+              if (c === undefined) throw new Error(`not found: ${path}`);
+              return c;
+            },
+            async writeFile(path, content) {
+              files.set(path, content);
+            },
+          };
+
+          const svc = new TemplateCloningService(mockFs, testConfig);
+          const result = await svc.clone(makeRequest());
+
+          expect(result.success).toBe(true);
+          expect(result.errors.some((e) => e.severity === 'warning')).toBe(true);
+
+          const ws = result.workspacePath!;
+          for (const safe of safeFileSet) {
+            expect(files.has(`${ws}/${safe}`)).toBe(true);
+          }
+        }
+      ),
+      { numRuns: 200 }
+    );
+  });
+
+  it('runId containing ../ is always rejected', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.constantFrom('../escape', 'a/../b', '../../root', 'x/..'),
+        async (maliciousRunId) => {
+          const state: MockFsState = { dirs: new Set(), files: new Map() };
+          const svc = makeService(state);
+          const result = await svc.clone(makeRequest({ runId: maliciousRunId }));
+
+          expect(result.success).toBe(false);
+          expect(result.errors[0].severity).toBe('error');
+          expect(result.workspacePath).toBeUndefined();
+        }
+      ),
+      { numRuns: 50 }
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- **#731** — Add `metered-billing.property.test.ts`: fast-check property tests for `MeteringService` covering usage accumulation (N×q), same-second idempotency, period reset, and non-negative invariant using an in-memory Supabase mock
- **#732** — Extend `auth.service.mutation.test.ts`: 6 new mutation-killing tests targeting empty-email `signIn`, short-password `signUp`, signUp message passthrough, and the `INVALID_CREDENTIALS` vs `USER_NOT_FOUND` distinction
- **#733** — Add `template-cloning.property.test.ts`: 5 property invariants (file count, relative paths, dot-files, empty tree, path traversal protection)
- **#735** — Extend `syntax-validator.property.test.ts`: direct property tests for valid TS/JSON → `valid:true`, mismatched-brace detection → `valid:false`, and a 1MB performance assertion (<500ms)

## Test plan

- [ ] `FC_NUM_RUNS=500 pnpm test -- metered-billing.property` — all 4 property groups pass
- [ ] `pnpm test -- auth.service.mutation` — all new credential edge-case tests pass
- [ ] `FC_NUM_RUNS=500 pnpm test -- template-cloning.property` — all 5 properties pass
- [ ] `FC_NUM_RUNS=500 pnpm test -- syntax-validator.property` — valid/invalid classification and perf test pass
- [ ] `pnpm lint && pnpm typecheck` — no new errors

Closes #731
Closes #732
Closes #733
Closes #735

🤖 Generated with [Claude Code](https://claude.com/claude-code)