### PR TITLE
feat(notifications): email delivery service with template rendering and tracking

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -19,6 +19,7 @@
         "@supabase/supabase-js": "^2.39.1",
         "client-only": "^0.0.1",
         "for-each": "^0.3.5",
+        "handlebars": "^4.7.8",
         "next": "14.0.4",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",

--- a/apps/backend/src/app/api/webhooks/email/route.ts
+++ b/apps/backend/src/app/api/webhooks/email/route.ts
@@ -1,0 +1,109 @@
+/**
+ * POST /api/webhooks/email
+ *
+ * Receives delivery-status events from the transactional email provider and
+ * advances the matching email_deliveries row (sent → delivered / bounced /
+ * opened). Provider events are normalised to {@link DeliveryWebhookEvent}.
+ *
+ * Authentication: optional shared secret via the EMAIL_WEBHOOK_SECRET env var,
+ * checked against the `authorization: Bearer <secret>` header when configured.
+ *
+ * Supported provider event names are mapped to internal statuses:
+ *   delivered            → delivered
+ *   bounced / bounce / complained → bounced
+ *   opened / open        → opened
+ *   sent / delivery_sent → sent
+ *
+ * Always returns 200 for recognised-but-unmapped events so the provider does
+ * not retry unnecessarily.
+ *
+ * Issue: #769 — Email Notification Delivery Service with Template Rendering
+ *               and Delivery Tracking
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import {
+    emailDeliveryService,
+    type DeliveryStatus,
+    type DeliveryWebhookEvent,
+} from '@/services/email-delivery.service';
+
+const STATUS_MAP: Record<string, DeliveryStatus> = {
+    sent: 'sent',
+    delivery_sent: 'sent',
+    delivered: 'delivered',
+    delivery: 'delivered',
+    bounced: 'bounced',
+    bounce: 'bounced',
+    complained: 'bounced',
+    complaint: 'bounced',
+    opened: 'opened',
+    open: 'opened',
+};
+
+/** Pull the provider message id from the common field names across providers. */
+function extractMessageId(payload: Record<string, any>): string | null {
+    return (
+        payload.message_id ??
+        payload.messageId ??
+        payload.id ??
+        payload.data?.message_id ??
+        payload.data?.id ??
+        null
+    );
+}
+
+/** Pull the event/type name from the common field names across providers. */
+function extractEventName(payload: Record<string, any>): string | null {
+    const raw = payload.type ?? payload.event ?? payload.record_type ?? payload.RecordType;
+    return typeof raw === 'string' ? raw.toLowerCase() : null;
+}
+
+function normalise(payload: Record<string, any>): DeliveryWebhookEvent | null {
+    const messageId = extractMessageId(payload);
+    const eventName = extractEventName(payload);
+    if (!messageId || !eventName) return null;
+
+    const status = STATUS_MAP[eventName];
+    if (!status) return null;
+
+    const error =
+        payload.error ??
+        payload.reason ??
+        payload.data?.reason ??
+        (status === 'bounced' ? 'bounced' : undefined);
+
+    return { providerMessageId: messageId, status, error };
+}
+
+export async function POST(req: NextRequest) {
+    const secret = process.env.EMAIL_WEBHOOK_SECRET;
+    if (secret && req.headers.get('authorization') !== `Bearer ${secret}`) {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    let payload: Record<string, any>;
+    try {
+        payload = await req.json();
+    } catch {
+        return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+    }
+
+    // Providers may batch events into an array or send a single object.
+    const events = Array.isArray(payload) ? payload : [payload];
+
+    let updated = 0;
+    let ignored = 0;
+    for (const raw of events) {
+        const event = normalise(raw);
+        if (!event) {
+            ignored++;
+            continue;
+        }
+        const applied = await emailDeliveryService.handleWebhook(event);
+        if (applied) updated++;
+        else ignored++;
+    }
+
+    return NextResponse.json({ received: events.length, updated, ignored });
+}

--- a/apps/backend/src/services/email-delivery.service.test.ts
+++ b/apps/backend/src/services/email-delivery.service.test.ts
@@ -1,0 +1,301 @@
+/**
+ * Tests for EmailDeliveryService (#769)
+ *
+ * Covers Handlebars template rendering (layout inheritance + every supported
+ * type), delivery recording, provider dispatch, and bounce / webhook status
+ * handling. Templates are rendered from the real files under
+ * src/templates/email (cwd is apps/backend under vitest).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import {
+    EmailDeliveryService,
+    EMAIL_TYPES,
+    type EmailType,
+} from './email-delivery.service';
+
+// ── Supabase mock ─────────────────────────────────────────────────────────────
+//
+// Records inserts/updates so tests can assert on the persisted delivery rows.
+
+function makeSupabaseMock() {
+    const inserts: Record<string, unknown>[] = [];
+    const updates: Array<{ values: Record<string, unknown>; messageId: string }> = [];
+    let insertShouldFail = false;
+    let updateMatchCount = 1;
+
+    const client = {
+        from(_table: string) {
+            return {
+                insert(values: Record<string, unknown>) {
+                    inserts.push(values);
+                    return {
+                        select() {
+                            return {
+                                single() {
+                                    return insertShouldFail
+                                        ? Promise.resolve({ data: null, error: { message: 'insert failed' } })
+                                        : Promise.resolve({ data: { id: 'delivery-1' }, error: null });
+                                },
+                            };
+                        },
+                    };
+                },
+                update(values: Record<string, unknown>) {
+                    return {
+                        eq(_col: string, messageId: string) {
+                            updates.push({ values, messageId });
+                            return {
+                                select() {
+                                    const rows = Array.from({ length: updateMatchCount }, (_, i) => ({
+                                        id: `row-${i}`,
+                                    }));
+                                    return Promise.resolve({ data: rows, error: null });
+                                },
+                            };
+                        },
+                    };
+                },
+            };
+        },
+    } as unknown as SupabaseClient;
+
+    return {
+        client,
+        inserts,
+        updates,
+        setInsertFail: (v: boolean) => (insertShouldFail = v),
+        setUpdateMatchCount: (n: number) => (updateMatchCount = n),
+    };
+}
+
+const SAMPLE_DATA: Record<EmailType, Record<string, unknown>> = {
+    deployment_complete: {
+        name: 'Ada',
+        projectName: 'stellar-app',
+        environment: 'production',
+        region: 'us-east-1',
+        durationSeconds: 42,
+        deploymentUrl: 'https://craft.app/d/1',
+    },
+    subscription_changed: {
+        name: 'Ada',
+        previousPlan: 'Free',
+        newPlan: 'Pro',
+        effectiveDate: '2026-07-01',
+        billingUrl: 'https://craft.app/billing',
+    },
+    security_alert: {
+        name: 'Ada',
+        event: 'New sign-in from an unknown device',
+        occurredAt: '2026-06-26T10:00:00Z',
+        ipAddress: '203.0.113.7',
+        location: 'Lagos, NG',
+        secureAccountUrl: 'https://craft.app/security',
+    },
+    invoice_ready: {
+        name: 'Ada',
+        invoiceNumber: 'INV-001',
+        amountDue: '$20.00',
+        periodStart: '2026-06-01',
+        periodEnd: '2026-06-30',
+        dueDate: '2026-07-05',
+        invoiceUrl: 'https://craft.app/invoice.pdf',
+    },
+};
+
+describe('EmailDeliveryService', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.unstubAllEnvs();
+        vi.unstubAllGlobals();
+    });
+
+    describe('template rendering', () => {
+        it('renders every supported type inside the shared layout (layout inheritance)', () => {
+            const svc = new EmailDeliveryService();
+            for (const type of EMAIL_TYPES) {
+                const { subject, html } = svc.render(type, SAMPLE_DATA[type]);
+                expect(subject).toBeTruthy();
+                // Layout chrome is present...
+                expect(html).toContain('<!doctype html>');
+                expect(html).toContain('CRAFT');
+                expect(html).toContain('Email preferences');
+                // ...and the body slot was filled with type-specific content.
+                expect(html).toContain('Ada');
+            }
+        });
+
+        it('injects type-specific body content into the layout body slot', () => {
+            const svc = new EmailDeliveryService();
+            const html = svc.render('deployment_complete', SAMPLE_DATA.deployment_complete).html;
+            expect(html).toContain('stellar-app');
+            expect(html).toContain('us-east-1');
+            expect(html).toContain('View deployment');
+        });
+
+        it('uses the default subject per type but allows an override', () => {
+            const svc = new EmailDeliveryService();
+            expect(svc.render('security_alert', SAMPLE_DATA.security_alert).subject).toBe(
+                'Security alert on your account',
+            );
+            expect(
+                svc.render('invoice_ready', SAMPLE_DATA.invoice_ready, 'Custom subject').subject,
+            ).toBe('Custom subject');
+        });
+
+        it('throws on an unsupported email type', () => {
+            const svc = new EmailDeliveryService();
+            expect(() => svc.render('nope' as EmailType, {})).toThrow(/Unsupported email type/);
+        });
+    });
+
+    describe('sending + delivery recording', () => {
+        it('records a sent delivery in dev mode (no EMAIL_API_URL)', async () => {
+            const mock = makeSupabaseMock();
+            const svc = new EmailDeliveryService(mock.client);
+
+            const result = await svc.send({
+                type: 'deployment_complete',
+                to: 'ada@example.com',
+                userId: 'user-1',
+                data: SAMPLE_DATA.deployment_complete,
+            });
+
+            expect(result.status).toBe('sent');
+            expect(result.delivered).toBe(true);
+            expect(result.deliveryId).toBe('delivery-1');
+            expect(mock.inserts).toHaveLength(1);
+            expect(mock.inserts[0]).toMatchObject({
+                user_id: 'user-1',
+                email_type: 'deployment_complete',
+                recipient: 'ada@example.com',
+                status: 'sent',
+            });
+            expect(mock.inserts[0].provider_message_id).toBeTruthy();
+        });
+
+        it('dispatches via the provider API when EMAIL_API_URL is set', async () => {
+            vi.stubEnv('EMAIL_API_URL', 'https://api.email.test');
+            vi.stubEnv('EMAIL_API_KEY', 'key_test');
+            const fetchMock = vi.fn().mockResolvedValue({
+                ok: true,
+                json: () => Promise.resolve({ id: 'provider-msg-9' }),
+            });
+            vi.stubGlobal('fetch', fetchMock);
+
+            const mock = makeSupabaseMock();
+            const svc = new EmailDeliveryService(mock.client);
+
+            const result = await svc.send({
+                type: 'invoice_ready',
+                to: 'ada@example.com',
+                data: SAMPLE_DATA.invoice_ready,
+            });
+
+            expect(fetchMock).toHaveBeenCalledOnce();
+            expect(result.providerMessageId).toBe('provider-msg-9');
+            expect(result.status).toBe('sent');
+            expect(mock.inserts[0].provider_message_id).toBe('provider-msg-9');
+        });
+
+        it('records a bounce when the provider rejects the send', async () => {
+            vi.stubEnv('EMAIL_API_URL', 'https://api.email.test');
+            const fetchMock = vi.fn().mockResolvedValue({
+                ok: false,
+                status: 422,
+                text: () => Promise.resolve('invalid recipient'),
+            });
+            vi.stubGlobal('fetch', fetchMock);
+
+            const mock = makeSupabaseMock();
+            const svc = new EmailDeliveryService(mock.client);
+
+            const result = await svc.send({
+                type: 'security_alert',
+                to: 'bad@example.com',
+                data: SAMPLE_DATA.security_alert,
+            });
+
+            expect(result.status).toBe('bounced');
+            expect(result.delivered).toBe(false);
+            expect(mock.inserts[0]).toMatchObject({ status: 'bounced' });
+            expect(mock.inserts[0].error).toContain('422');
+        });
+
+        it('returns a null deliveryId but still succeeds if the audit insert fails', async () => {
+            const mock = makeSupabaseMock();
+            mock.setInsertFail(true);
+            const svc = new EmailDeliveryService(mock.client);
+
+            const result = await svc.send({
+                type: 'deployment_complete',
+                to: 'ada@example.com',
+                data: SAMPLE_DATA.deployment_complete,
+            });
+
+            expect(result.status).toBe('sent');
+            expect(result.deliveryId).toBeNull();
+        });
+    });
+
+    describe('webhook status handling', () => {
+        it('advances a delivery to delivered', async () => {
+            const mock = makeSupabaseMock();
+            const svc = new EmailDeliveryService(mock.client);
+
+            const applied = await svc.handleWebhook({
+                providerMessageId: 'provider-msg-9',
+                status: 'delivered',
+            });
+
+            expect(applied).toBe(true);
+            expect(mock.updates[0]).toMatchObject({
+                messageId: 'provider-msg-9',
+                values: { status: 'delivered' },
+            });
+        });
+
+        it('records a bounce reason on a bounce webhook', async () => {
+            const mock = makeSupabaseMock();
+            const svc = new EmailDeliveryService(mock.client);
+
+            await svc.handleWebhook({
+                providerMessageId: 'provider-msg-9',
+                status: 'bounced',
+                error: 'mailbox full',
+            });
+
+            expect(mock.updates[0].values).toMatchObject({
+                status: 'bounced',
+                error: 'mailbox full',
+            });
+        });
+
+        it('returns false when no delivery row matches the message id', async () => {
+            const mock = makeSupabaseMock();
+            mock.setUpdateMatchCount(0);
+            const svc = new EmailDeliveryService(mock.client);
+
+            const applied = await svc.handleWebhook({
+                providerMessageId: 'unknown',
+                status: 'opened',
+            });
+
+            expect(applied).toBe(false);
+        });
+
+        it('ignores an event with no provider message id', async () => {
+            const mock = makeSupabaseMock();
+            const svc = new EmailDeliveryService(mock.client);
+
+            const applied = await svc.handleWebhook({
+                providerMessageId: '',
+                status: 'opened',
+            });
+
+            expect(applied).toBe(false);
+            expect(mock.updates).toHaveLength(0);
+        });
+    });
+});

--- a/apps/backend/src/services/email-delivery.service.ts
+++ b/apps/backend/src/services/email-delivery.service.ts
@@ -1,0 +1,296 @@
+/**
+ * EmailDeliveryService
+ *
+ * Renders transactional emails with Handlebars (layout inheritance), dispatches
+ * them through the configured transactional email provider, and records a
+ * delivery audit trail in Supabase. Delivery status is later advanced by the
+ * provider's webhook (sent → delivered / bounced / opened).
+ *
+ * Supported email types:
+ *   - deployment_complete   Deployment finished successfully
+ *   - subscription_changed  Billing plan changed
+ *   - security_alert        Suspicious account activity
+ *   - invoice_ready         New invoice available
+ *
+ * Template rendering:
+ *   Each type has its own partial in templates/email/<type>.hbs. The partial is
+ *   rendered first, then injected into the shared layout.hbs via its {{{body}}}
+ *   slot — a simple form of layout inheritance. Compiled templates are cached.
+ *
+ * Email provider (mirrors invoice-delivery.service.ts):
+ *   EMAIL_API_URL   — Base URL of the email API (e.g. https://api.resend.com)
+ *   EMAIL_API_KEY   — API key for the provider
+ *   EMAIL_FROM      — Sender address (e.g. notifications@craft.app)
+ *   When EMAIL_API_URL is unset, the message is logged instead of sent (dev mode).
+ *
+ * Issue: #769 — Email Notification Delivery Service with Template Rendering
+ *               and Delivery Tracking
+ */
+
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import Handlebars from 'handlebars';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { createClient } from '@/lib/supabase/server';
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export type EmailType =
+    | 'deployment_complete'
+    | 'subscription_changed'
+    | 'security_alert'
+    | 'invoice_ready';
+
+export type DeliveryStatus = 'sent' | 'delivered' | 'bounced' | 'opened';
+
+/** The four supported email types, exported for validation/iteration. */
+export const EMAIL_TYPES: readonly EmailType[] = [
+    'deployment_complete',
+    'subscription_changed',
+    'security_alert',
+    'invoice_ready',
+];
+
+/** Default subject lines per type (overridable via SendEmailInput.subject). */
+const DEFAULT_SUBJECTS: Record<EmailType, string> = {
+    deployment_complete: 'Your deployment is live',
+    subscription_changed: 'Your subscription was updated',
+    security_alert: 'Security alert on your account',
+    invoice_ready: 'Your invoice is ready',
+};
+
+export interface SendEmailInput {
+    type: EmailType;
+    to: string;
+    /** Template variables consumed by the Handlebars template + layout. */
+    data: Record<string, unknown>;
+    /** Recipient user id, persisted on the delivery record. */
+    userId?: string;
+    /** Overrides the default subject for the type. */
+    subject?: string;
+}
+
+export interface RenderedEmail {
+    subject: string;
+    html: string;
+}
+
+export interface EmailDeliveryResult {
+    deliveryId: string | null;
+    providerMessageId: string | null;
+    recipient: string;
+    type: EmailType;
+    status: DeliveryStatus;
+    delivered: boolean;
+}
+
+/** Normalised provider webhook event. */
+export interface DeliveryWebhookEvent {
+    /** Provider message id; joins back to email_deliveries.provider_message_id. */
+    providerMessageId: string;
+    /** New status to record. */
+    status: DeliveryStatus;
+    /** Bounce / failure reason, if any. */
+    error?: string;
+}
+
+// ── Service ───────────────────────────────────────────────────────────────────
+
+export class EmailDeliveryService {
+    private readonly templateDir: string;
+    private layoutCache: HandlebarsTemplateDelegate | null = null;
+    private readonly templateCache = new Map<EmailType, HandlebarsTemplateDelegate>();
+
+    constructor(
+        private readonly supabase?: SupabaseClient,
+        templateDir?: string,
+    ) {
+        this.templateDir = templateDir ?? join(process.cwd(), 'src/templates/email');
+    }
+
+    private db(): SupabaseClient {
+        return this.supabase ?? (createClient() as unknown as SupabaseClient);
+    }
+
+    // ── Template rendering ────────────────────────────────────────────────────
+
+    private compileLayout(): HandlebarsTemplateDelegate {
+        if (!this.layoutCache) {
+            const src = readFileSync(join(this.templateDir, 'layout.hbs'), 'utf8');
+            this.layoutCache = Handlebars.compile(src);
+        }
+        return this.layoutCache;
+    }
+
+    private compileTemplate(type: EmailType): HandlebarsTemplateDelegate {
+        const cached = this.templateCache.get(type);
+        if (cached) return cached;
+
+        const file = `${type.replace(/_/g, '-')}.hbs`;
+        const src = readFileSync(join(this.templateDir, file), 'utf8');
+        const compiled = Handlebars.compile(src);
+        this.templateCache.set(type, compiled);
+        return compiled;
+    }
+
+    /**
+     * Render the email for a type: render the type's template, then inject it
+     * into the shared layout (layout inheritance via the {{{body}}} slot).
+     */
+    render(type: EmailType, data: Record<string, unknown>, subject?: string): RenderedEmail {
+        if (!EMAIL_TYPES.includes(type)) {
+            throw new Error(`Unsupported email type: ${type}`);
+        }
+
+        const resolvedSubject = subject ?? DEFAULT_SUBJECTS[type];
+        const body = this.compileTemplate(type)(data);
+        const html = this.compileLayout()({
+            ...data,
+            subject: resolvedSubject,
+            body,
+        });
+
+        return { subject: resolvedSubject, html };
+    }
+
+    // ── Sending ───────────────────────────────────────────────────────────────
+
+    /**
+     * Render, dispatch, and record an email. Always writes a delivery row
+     * (status 'sent', or 'bounced' if the provider rejects the send) so the
+     * audit trail is complete even on failure.
+     */
+    async send(input: SendEmailInput): Promise<EmailDeliveryResult> {
+        const { subject, html } = this.render(input.type, input.data, input.subject);
+
+        let providerMessageId: string | null = null;
+        let status: DeliveryStatus = 'sent';
+        let error: string | undefined;
+
+        try {
+            providerMessageId = await this.dispatch(input.to, subject, html);
+        } catch (err: unknown) {
+            status = 'bounced';
+            error = err instanceof Error ? err.message : 'Email dispatch failed';
+        }
+
+        const deliveryId = await this.recordDelivery({
+            userId: input.userId,
+            type: input.type,
+            recipient: input.to,
+            subject,
+            providerMessageId,
+            status,
+            error,
+        });
+
+        return {
+            deliveryId,
+            providerMessageId,
+            recipient: input.to,
+            type: input.type,
+            status,
+            delivered: status === 'sent',
+        };
+    }
+
+    /**
+     * Hand the rendered message to the email provider. Returns the provider
+     * message id (used to correlate webhook status updates), or a synthetic id
+     * in dev mode. Throws on provider error so send() can record a bounce.
+     */
+    private async dispatch(to: string, subject: string, html: string): Promise<string> {
+        const apiUrl = process.env.EMAIL_API_URL;
+
+        if (!apiUrl) {
+            // Dev / test mode — log instead of sending.
+            console.log(`[EmailDelivery] Would send "${subject}" to ${to}`);
+            return `dev-${to}-${subject}`;
+        }
+
+        const from = process.env.EMAIL_FROM ?? 'notifications@craft.app';
+        const apiKey = process.env.EMAIL_API_KEY ?? '';
+
+        const res = await fetch(`${apiUrl}/emails`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                Authorization: `Bearer ${apiKey}`,
+            },
+            body: JSON.stringify({ from, to, subject, html }),
+        });
+
+        if (!res.ok) {
+            const text = await res.text().catch(() => res.statusText);
+            throw new Error(`Email API error ${res.status}: ${text}`);
+        }
+
+        const payload = (await res.json().catch(() => ({}))) as { id?: string };
+        return payload.id ?? `sent-${to}`;
+    }
+
+    // ── Delivery tracking ─────────────────────────────────────────────────────
+
+    /**
+     * Insert a delivery audit record. Returns the new row id, or null if the
+     * insert fails (logged, never throws — a failed audit write must not mask
+     * a successful send).
+     */
+    async recordDelivery(record: {
+        userId?: string;
+        type: EmailType;
+        recipient: string;
+        subject: string;
+        providerMessageId: string | null;
+        status: DeliveryStatus;
+        error?: string;
+    }): Promise<string | null> {
+        const { data, error } = await this.db()
+            .from('email_deliveries')
+            .insert({
+                user_id: record.userId ?? null,
+                email_type: record.type,
+                recipient: record.recipient,
+                subject: record.subject,
+                provider_message_id: record.providerMessageId,
+                status: record.status,
+                error: record.error ?? null,
+            })
+            .select('id')
+            .single();
+
+        if (error) {
+            console.error('[EmailDelivery] failed to record delivery:', error.message);
+            return null;
+        }
+
+        return (data as { id: string } | null)?.id ?? null;
+    }
+
+    /**
+     * Apply a provider delivery-status webhook event to the matching delivery
+     * record (joined by provider_message_id). Returns true if a row was updated.
+     */
+    async handleWebhook(event: DeliveryWebhookEvent): Promise<boolean> {
+        if (!event.providerMessageId) return false;
+
+        const update: Record<string, unknown> = { status: event.status };
+        if (event.error !== undefined) update.error = event.error;
+
+        const { data, error } = await this.db()
+            .from('email_deliveries')
+            .update(update)
+            .eq('provider_message_id', event.providerMessageId)
+            .select('id');
+
+        if (error) {
+            console.error('[EmailDelivery] failed to apply webhook:', error.message);
+            return false;
+        }
+
+        return Array.isArray(data) && data.length > 0;
+    }
+}
+
+/** Shared singleton using the request-scoped Supabase server client. */
+export const emailDeliveryService = new EmailDeliveryService();

--- a/apps/backend/src/templates/email/deployment-complete.hbs
+++ b/apps/backend/src/templates/email/deployment-complete.hbs
@@ -1,0 +1,10 @@
+<h1 style="margin:0 0 16px;font-size:22px;">Your deployment is live 🚀</h1>
+<p style="margin:0 0 16px;font-size:15px;line-height:1.5;">
+  Hi {{name}}, your project <strong>{{projectName}}</strong> finished deploying successfully.
+</p>
+<table role="presentation" cellpadding="0" cellspacing="0" style="margin:0 0 24px;font-size:14px;">
+  <tr><td style="padding:4px 16px 4px 0;color:#6a737d;">Environment</td><td style="padding:4px 0;">{{environment}}</td></tr>
+  <tr><td style="padding:4px 16px 4px 0;color:#6a737d;">Region</td><td style="padding:4px 0;">{{region}}</td></tr>
+  <tr><td style="padding:4px 16px 4px 0;color:#6a737d;">Duration</td><td style="padding:4px 0;">{{durationSeconds}}s</td></tr>
+</table>
+<a href="{{deploymentUrl}}" style="display:inline-block;background:#0969da;color:#ffffff;text-decoration:none;padding:12px 24px;border-radius:6px;font-size:15px;font-weight:600;">View deployment</a>

--- a/apps/backend/src/templates/email/invoice-ready.hbs
+++ b/apps/backend/src/templates/email/invoice-ready.hbs
@@ -1,0 +1,10 @@
+<h1 style="margin:0 0 16px;font-size:22px;">Your invoice is ready</h1>
+<p style="margin:0 0 16px;font-size:15px;line-height:1.5;">
+  Hi {{name}}, invoice <strong>{{invoiceNumber}}</strong> for
+  <strong>{{amountDue}}</strong> is now available.
+</p>
+<table role="presentation" cellpadding="0" cellspacing="0" style="margin:0 0 24px;font-size:14px;">
+  <tr><td style="padding:4px 16px 4px 0;color:#6a737d;">Period</td><td style="padding:4px 0;">{{periodStart}} – {{periodEnd}}</td></tr>
+  <tr><td style="padding:4px 16px 4px 0;color:#6a737d;">Due</td><td style="padding:4px 0;">{{dueDate}}</td></tr>
+</table>
+<a href="{{invoiceUrl}}" style="display:inline-block;background:#0969da;color:#ffffff;text-decoration:none;padding:12px 24px;border-radius:6px;font-size:15px;font-weight:600;">Download invoice PDF</a>

--- a/apps/backend/src/templates/email/layout.hbs
+++ b/apps/backend/src/templates/email/layout.hbs
@@ -1,0 +1,35 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>{{subject}}</title>
+  </head>
+  <body style="margin:0;padding:0;background:#f4f5f7;font-family:-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;color:#1a1a1a;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#f4f5f7;padding:24px 0;">
+      <tr>
+        <td align="center">
+          <table role="presentation" width="600" cellpadding="0" cellspacing="0" style="background:#ffffff;border-radius:8px;overflow:hidden;">
+            <tr>
+              <td style="background:#0d1117;padding:20px 32px;">
+                <span style="color:#ffffff;font-size:18px;font-weight:600;">CRAFT</span>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:32px;">
+                {{{body}}}
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:20px 32px;background:#fafbfc;border-top:1px solid #eaecef;color:#6a737d;font-size:12px;">
+                You are receiving this email because you have an account on CRAFT.
+                <br />
+                &copy; CRAFT &middot; <a href="{{preferencesUrl}}" style="color:#0969da;">Email preferences</a>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/apps/backend/src/templates/email/security-alert.hbs
+++ b/apps/backend/src/templates/email/security-alert.hbs
@@ -1,0 +1,16 @@
+<h1 style="margin:0 0 16px;font-size:22px;color:#cf222e;">Security alert</h1>
+<p style="margin:0 0 16px;font-size:15px;line-height:1.5;">
+  Hi {{name}}, we detected the following activity on your account:
+</p>
+<p style="margin:0 0 16px;padding:12px 16px;background:#fff8f0;border-left:3px solid #cf222e;font-size:15px;">
+  <strong>{{event}}</strong>
+</p>
+<table role="presentation" cellpadding="0" cellspacing="0" style="margin:0 0 24px;font-size:14px;">
+  <tr><td style="padding:4px 16px 4px 0;color:#6a737d;">When</td><td style="padding:4px 0;">{{occurredAt}}</td></tr>
+  <tr><td style="padding:4px 16px 4px 0;color:#6a737d;">IP address</td><td style="padding:4px 0;">{{ipAddress}}</td></tr>
+  <tr><td style="padding:4px 16px 4px 0;color:#6a737d;">Location</td><td style="padding:4px 0;">{{location}}</td></tr>
+</table>
+<p style="margin:0 0 24px;font-size:14px;line-height:1.5;color:#6a737d;">
+  If this was you, no action is needed. Otherwise, secure your account immediately.
+</p>
+<a href="{{secureAccountUrl}}" style="display:inline-block;background:#cf222e;color:#ffffff;text-decoration:none;padding:12px 24px;border-radius:6px;font-size:15px;font-weight:600;">Secure my account</a>

--- a/apps/backend/src/templates/email/subscription-changed.hbs
+++ b/apps/backend/src/templates/email/subscription-changed.hbs
@@ -1,0 +1,9 @@
+<h1 style="margin:0 0 16px;font-size:22px;">Your subscription was updated</h1>
+<p style="margin:0 0 16px;font-size:15px;line-height:1.5;">
+  Hi {{name}}, your CRAFT subscription changed from
+  <strong>{{previousPlan}}</strong> to <strong>{{newPlan}}</strong>.
+</p>
+<p style="margin:0 0 24px;font-size:15px;line-height:1.5;">
+  {{#if effectiveDate}}This change takes effect on {{effectiveDate}}.{{/if}}
+</p>
+<a href="{{billingUrl}}" style="display:inline-block;background:#0969da;color:#ffffff;text-decoration:none;padding:12px 24px;border-radius:6px;font-size:15px;font-weight:600;">Manage billing</a>

--- a/supabase/migrations/014_email_deliveries.sql
+++ b/supabase/migrations/014_email_deliveries.sql
@@ -1,0 +1,80 @@
+-- Migration 014: Email Notification Delivery Tracking
+--
+-- Stores an audit trail of every transactional email dispatched by the
+-- EmailDeliveryService, plus the latest delivery status reported by the
+-- email provider via webhook (sent → delivered / bounced / opened).
+--
+-- Issue: #769 — Email Notification Delivery Service with Template Rendering
+--               and Delivery Tracking
+
+-- ── Email Deliveries Table ───────────────────────────────────────────────────
+
+/**
+ * One row per dispatched email.
+ *
+ * user_id:             Recipient user (nullable for system/unauthenticated sends)
+ * email_type:          One of the supported notification types
+ * recipient:           Destination email address
+ * subject:             Rendered subject line
+ * provider_message_id: ID returned by the email provider; the join key used by
+ *                      the delivery-status webhook to update this row
+ * status:              Lifecycle status, advanced by the provider webhook
+ * error:               Provider error / bounce reason, if any
+ * sent_at:             When the message was handed to the provider
+ */
+CREATE TABLE IF NOT EXISTS email_deliveries (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+    email_type TEXT NOT NULL CHECK (
+        email_type IN (
+            'deployment_complete',
+            'subscription_changed',
+            'security_alert',
+            'invoice_ready'
+        )
+    ),
+    recipient TEXT NOT NULL,
+    subject TEXT NOT NULL,
+    provider_message_id TEXT UNIQUE,
+    status TEXT NOT NULL DEFAULT 'sent' CHECK (
+        status IN ('sent', 'delivered', 'bounced', 'opened')
+    ),
+    error TEXT,
+    sent_at TIMESTAMPTZ DEFAULT NOW() NOT NULL,
+    updated_at TIMESTAMPTZ DEFAULT NOW() NOT NULL
+);
+
+-- Indexes
+CREATE INDEX IF NOT EXISTS idx_email_deliveries_user_id
+    ON email_deliveries(user_id);
+
+CREATE INDEX IF NOT EXISTS idx_email_deliveries_provider_message_id
+    ON email_deliveries(provider_message_id);
+
+CREATE INDEX IF NOT EXISTS idx_email_deliveries_status
+    ON email_deliveries(status);
+
+CREATE INDEX IF NOT EXISTS idx_email_deliveries_email_type
+    ON email_deliveries(email_type);
+
+CREATE INDEX IF NOT EXISTS idx_email_deliveries_sent_at
+    ON email_deliveries(sent_at DESC);
+
+-- Keep updated_at fresh on status transitions (function defined in migration 001)
+CREATE TRIGGER update_email_deliveries_updated_at
+    BEFORE UPDATE ON email_deliveries
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
+
+-- ── Row Level Security ───────────────────────────────────────────────────────
+
+ALTER TABLE email_deliveries ENABLE ROW LEVEL SECURITY;
+
+-- Users may read their own delivery records (audit trail visibility).
+CREATE POLICY email_deliveries_select_own
+    ON email_deliveries
+    FOR SELECT
+    USING (auth.uid() = user_id);
+
+-- Inserts/updates are performed by the service role only (server-side service
+-- and provider webhook); no client-side write policy is granted.


### PR DESCRIPTION
## Summary
Implements a transactional email notification delivery service with Handlebars template rendering and delivery status tracking.

- **`EmailDeliveryService`** (`apps/backend/src/services/email-delivery.service.ts`) — renders, dispatches, and records emails for the four supported types: `deployment_complete`, `subscription_changed`, `security_alert`, `invoice_ready`.
- **Handlebars templates with layout inheritance** (`apps/backend/src/templates/email/`) — a shared `layout.hbs` with a `{{{body}}}` slot, plus one partial per email type. Compiled templates are cached.
- **Delivery tracking** — new `email_deliveries` Supabase table (`supabase/migrations/014_email_deliveries.sql`) records an audit trail; status advances `sent → delivered / bounced / opened`.
- **Provider webhook** (`apps/backend/src/app/api/webhooks/email/route.ts`) — normalises provider delivery events and updates the matching delivery row by `provider_message_id`.
- Reuses the existing `EMAIL_API_URL` / `EMAIL_API_KEY` / `EMAIL_FROM` provider pattern from `invoice-delivery.service.ts`, with a dev-mode console fallback.

## Tests
`apps/backend/src/services/email-delivery.service.test.ts` covers template rendering (layout inheritance + every type), delivery recording, provider dispatch, and bounce / webhook status handling.

Run: `pnpm --filter @craft/backend test -- email-delivery`

Closes #769