### PR TITLE
feat(cleanup): orphaned artifact detection with retention policy

### DIFF
--- a/apps/backend/src/app/api/cron/purge-tombstoned-deployments/route.ts
+++ b/apps/backend/src/app/api/cron/purge-tombstoned-deployments/route.ts
@@ -1,13 +1,19 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
+import { cleanupService } from '@/services/cleanup.service';
 
 /**
- * Cron: permanently purge tombstoned deployments past the retention window.
+ * Cron: permanently purge tombstoned deployments past the retention window,
+ * and remove orphaned Supabase Storage artifacts left by deployments that
+ * failed before their artifact was registered.
  *
  * Soft-deleted (tombstoned) deployments are archived with a deleted_at timestamp.
  * After DEPLOYMENT_TOMBSTONE_RETENTION_DAYS (default: 30) they are permanently
  * removed by this job, along with their cascaded deployment_logs and
  * deployment_analytics rows.
+ *
+ * Orphaned artifacts are kept for a 24h debugging window and deleted in batches
+ * of up to 100 per run (see CleanupService.purgeOrphanedArtifacts).
  *
  * Scheduled daily via vercel.json.  Protected by CRON_SECRET.
  */
@@ -18,23 +24,38 @@ export async function GET(req: NextRequest) {
     }
 
     const retentionDays = parseInt(process.env.DEPLOYMENT_TOMBSTONE_RETENTION_DAYS ?? '30', 10);
-    if (retentionDays === 0) {
-        return NextResponse.json({ purged: 0, message: 'Retention disabled' });
+
+    let purged = 0;
+    if (retentionDays > 0) {
+        const cutoff = new Date(Date.now() - retentionDays * 24 * 60 * 60 * 1000).toISOString();
+        const supabase = createClient();
+
+        const { error, count } = await supabase
+            .from('deployments')
+            .delete({ count: 'exact' })
+            .not('deleted_at', 'is', null)
+            .lt('deleted_at', cutoff);
+
+        if (error) {
+            console.error('Tombstone purge failed:', error);
+            return NextResponse.json({ error: error.message }, { status: 500 });
+        }
+        purged = count ?? 0;
     }
 
-    const cutoff = new Date(Date.now() - retentionDays * 24 * 60 * 60 * 1000).toISOString();
-    const supabase = createClient();
-
-    const { error, count } = await supabase
-        .from('deployments')
-        .delete({ count: 'exact' })
-        .not('deleted_at', 'is', null)
-        .lt('deleted_at', cutoff);
-
-    if (error) {
-        console.error('Tombstone purge failed:', error);
-        return NextResponse.json({ error: error.message }, { status: 500 });
+    // Remove orphaned storage artifacts (24h retention, 100/run batch limit).
+    let orphanedArtifactsPurged = 0;
+    try {
+        const orphanResult = await cleanupService.purgeOrphanedArtifacts();
+        orphanedArtifactsPurged = orphanResult.recordsDeleted;
+    } catch (err: unknown) {
+        // Orphan cleanup failure should not fail the whole cron; log and continue.
+        console.error('Orphaned artifact purge failed:', err);
     }
 
-    return NextResponse.json({ purged: count ?? 0 });
+    return NextResponse.json({
+        purged,
+        orphanedArtifactsPurged,
+        retentionDisabled: retentionDays === 0,
+    });
 }

--- a/apps/backend/src/services/cleanup.orphaned-artifacts.test.ts
+++ b/apps/backend/src/services/cleanup.orphaned-artifacts.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Unit tests for CleanupService.purgeOrphanedArtifacts (#758)
+ *
+ * Coverage:
+ *   - orphan detection (artifact with no deployments row)
+ *   - 24h retention window (recent orphans are kept)
+ *   - 100-per-run batch limit
+ *   - audit log emission with size and age
+ *   - deployment-id derivation from artifact path
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { CleanupService, deploymentIdFromArtifactPath } from './cleanup.service';
+
+// ── Mock Supabase client (storage + deployments cross-reference + audit) ───────
+
+const mockList = vi.fn();
+const mockRemove = vi.fn();
+const mockIn = vi.fn();
+const mockAuditInsert = vi.fn();
+
+function buildClient() {
+    return {
+        storage: {
+            from: vi.fn(() => ({
+                list: mockList,
+                remove: mockRemove,
+            })),
+        },
+        from: vi.fn((table: string) => {
+            if (table === 'deployments') {
+                return {
+                    select: vi.fn(() => ({ in: mockIn })),
+                };
+            }
+            if (table === 'orphaned_artifact_cleanup_log') {
+                return { insert: mockAuditInsert };
+            }
+            throw new Error(`unexpected table ${table}`);
+        }),
+    };
+}
+
+vi.mock('@/lib/supabase/server', () => ({
+    createClient: vi.fn(() => buildClient()),
+}));
+
+const NOW = new Date('2026-06-26T12:00:00Z');
+const hoursAgo = (h: number) => new Date(NOW.getTime() - h * 60 * 60 * 1000).toISOString();
+
+function artifact(name: string, ageHours: number, size = 1024) {
+    return { name, created_at: hoursAgo(ageHours), metadata: { size } };
+}
+
+describe('CleanupService.purgeOrphanedArtifacts', () => {
+    let service: CleanupService;
+
+    beforeEach(() => {
+        service = new CleanupService();
+        vi.clearAllMocks();
+        mockRemove.mockResolvedValue({ error: null });
+        mockAuditInsert.mockResolvedValue({ error: null });
+        mockIn.mockResolvedValue({ data: [], error: null });
+    });
+
+    it('derives the deployment id from both folder and flat artifact paths', () => {
+        expect(deploymentIdFromArtifactPath('dep-1/bundle.zip')).toBe('dep-1');
+        expect(deploymentIdFromArtifactPath('dep-2.zip')).toBe('dep-2');
+        expect(deploymentIdFromArtifactPath('dep-3')).toBe('dep-3');
+    });
+
+    it('deletes an artifact with no corresponding deployments record', async () => {
+        mockList.mockResolvedValue({
+            data: [artifact('orphan-1/bundle.zip', 48)],
+            error: null,
+        });
+        // No matching deployment rows → orphan.
+        mockIn.mockResolvedValue({ data: [], error: null });
+
+        const result = await service.purgeOrphanedArtifacts({ now: NOW });
+
+        expect(result.recordsDeleted).toBe(1);
+        expect(mockRemove).toHaveBeenCalledWith(['orphan-1/bundle.zip']);
+        expect(result.orphansDeleted[0]).toMatchObject({
+            path: 'orphan-1/bundle.zip',
+            sizeBytes: 1024,
+        });
+        expect(result.orphansDeleted[0].ageSeconds).toBe(48 * 3600);
+    });
+
+    it('keeps artifacts that DO have a deployments record', async () => {
+        mockList.mockResolvedValue({
+            data: [artifact('live-1/bundle.zip', 48)],
+            error: null,
+        });
+        mockIn.mockResolvedValue({ data: [{ id: 'live-1' }], error: null });
+
+        const result = await service.purgeOrphanedArtifacts({ now: NOW });
+
+        expect(result.recordsDeleted).toBe(0);
+        expect(mockRemove).not.toHaveBeenCalled();
+    });
+
+    it('respects the 24h retention window (keeps recent orphans)', async () => {
+        mockList.mockResolvedValue({
+            data: [
+                artifact('recent/bundle.zip', 5), // < 24h → retained
+                artifact('old/bundle.zip', 30), // > 24h → deleted
+            ],
+            error: null,
+        });
+        mockIn.mockResolvedValue({ data: [], error: null });
+
+        const result = await service.purgeOrphanedArtifacts({ now: NOW });
+
+        expect(result.recordsDeleted).toBe(1);
+        expect(result.skippedWithinRetention).toBe(1);
+        expect(mockRemove).toHaveBeenCalledWith(['old/bundle.zip']);
+    });
+
+    it('treats the retention boundary as exclusive (exactly 24h old is deleted)', async () => {
+        mockList.mockResolvedValue({
+            data: [artifact('boundary/bundle.zip', 24)],
+            error: null,
+        });
+        mockIn.mockResolvedValue({ data: [], error: null });
+
+        const result = await service.purgeOrphanedArtifacts({ now: NOW });
+        expect(result.recordsDeleted).toBe(1);
+    });
+
+    it('enforces the 100-per-run batch limit', async () => {
+        const many = Array.from({ length: 150 }, (_, i) => artifact(`orphan-${i}/b.zip`, 48));
+        mockList.mockResolvedValue({ data: many, error: null });
+        mockIn.mockResolvedValue({ data: [], error: null });
+
+        const result = await service.purgeOrphanedArtifacts({ now: NOW });
+
+        expect(result.recordsDeleted).toBe(100);
+        expect(result.batchLimitReached).toBe(true);
+        expect(mockRemove.mock.calls[0][0]).toHaveLength(100);
+    });
+
+    it('emits an audit log entry per deleted orphan with size and age', async () => {
+        mockList.mockResolvedValue({
+            data: [artifact('orphan-1/b.zip', 48, 2048)],
+            error: null,
+        });
+        mockIn.mockResolvedValue({ data: [], error: null });
+
+        await service.purgeOrphanedArtifacts({ now: NOW });
+
+        expect(mockAuditInsert).toHaveBeenCalledTimes(1);
+        const rows = mockAuditInsert.mock.calls[0][0];
+        expect(rows[0]).toMatchObject({
+            artifact_path: 'orphan-1/b.zip',
+            size_bytes: 2048,
+            age_seconds: 48 * 3600,
+        });
+    });
+
+    it('does nothing when the bucket is empty', async () => {
+        mockList.mockResolvedValue({ data: [], error: null });
+
+        const result = await service.purgeOrphanedArtifacts({ now: NOW });
+
+        expect(result.recordsDeleted).toBe(0);
+        expect(result.scanned).toBe(0);
+        expect(mockRemove).not.toHaveBeenCalled();
+    });
+
+    it('throws when listing storage fails', async () => {
+        mockList.mockResolvedValue({ data: null, error: { message: 'bucket missing' } });
+
+        await expect(service.purgeOrphanedArtifacts({ now: NOW })).rejects.toThrow(
+            /Failed to list storage artifacts/,
+        );
+    });
+
+    it('honours a custom retention window and batch limit', async () => {
+        mockList.mockResolvedValue({
+            data: [artifact('a/b.zip', 2), artifact('c/d.zip', 2), artifact('e/f.zip', 2)],
+            error: null,
+        });
+        mockIn.mockResolvedValue({ data: [], error: null });
+
+        const result = await service.purgeOrphanedArtifacts({
+            now: NOW,
+            retentionHours: 1, // all 2h-old orphans are now eligible
+            batchLimit: 2,
+        });
+
+        expect(result.recordsDeleted).toBe(2);
+        expect(result.batchLimitReached).toBe(true);
+    });
+});

--- a/apps/backend/src/services/cleanup.service.ts
+++ b/apps/backend/src/services/cleanup.service.ts
@@ -48,6 +48,52 @@ export interface CleanupJobHealth {
     maxRecordsDeleted: number | null;
 }
 
+/** A storage artifact with no corresponding deployments record. */
+export interface OrphanedArtifact {
+    /** Object path within the storage bucket. */
+    path: string;
+    /** Object size in bytes (0 when the provider does not report it). */
+    sizeBytes: number;
+    /** Age of the object in seconds at the time of cleanup. */
+    ageSeconds: number;
+}
+
+export interface OrphanCleanupResult extends CleanupResult {
+    /** Artifacts that were deleted this run. */
+    orphansDeleted: OrphanedArtifact[];
+    /** Total artifacts scanned in the bucket. */
+    scanned: number;
+    /** Orphans skipped because they were still inside the retention window. */
+    skippedWithinRetention: number;
+    /** Whether the batch limit was hit (more orphans may remain). */
+    batchLimitReached: boolean;
+}
+
+export interface PurgeOrphanedArtifactsOptions {
+    /** Storage bucket to scan (default: env DEPLOYMENT_ARTIFACT_BUCKET or 'deployment-artifacts'). */
+    bucket?: string;
+    /** Hours an orphan must survive before deletion (default: 24, debugging window). */
+    retentionHours?: number;
+    /** Maximum orphans to delete per run (default: 100). */
+    batchLimit?: number;
+    /** Override the current time (testing only). */
+    now?: Date;
+}
+
+const DEFAULT_ARTIFACT_BUCKET = 'deployment-artifacts';
+const ORPHAN_RETENTION_HOURS = 24;
+const ORPHAN_BATCH_LIMIT = 100;
+
+/**
+ * Derive the deployment id an artifact belongs to from its object path.
+ * Supports both `<deploymentId>/bundle.zip` (folder) and `<deploymentId>.zip`
+ * (flat) layouts: take the first path segment, then strip any file extension.
+ */
+export function deploymentIdFromArtifactPath(path: string): string {
+    const firstSegment = path.split('/')[0] ?? path;
+    return firstSegment.replace(/\.[^.]+$/, '');
+}
+
 // ── Service ───────────────────────────────────────────────────────────────────
 
 export class CleanupService {
@@ -157,6 +203,126 @@ export class CleanupService {
             recordsDeleted: data ?? 0,
             description: 'Old usage records purged',
             executedAt: new Date(),
+        };
+    }
+
+    /**
+     * Detect and remove orphaned Supabase Storage artifacts.
+     *
+     * An orphan is a storage object (generated code bundle) that has no
+     * corresponding row in the deployments table — typically left behind by a
+     * deployment that failed before its artifact was registered.
+     *
+     * Safety rules:
+     *   - Retention: orphans younger than `retentionHours` (default 24h) are
+     *     kept to preserve a debugging window.
+     *   - Batch limit: at most `batchLimit` orphans (default 100) are deleted
+     *     per run to bound cron work.
+     *   - Audit: every deleted orphan is logged to orphaned_artifact_cleanup_log
+     *     with its size and age.
+     */
+    async purgeOrphanedArtifacts(
+        options: PurgeOrphanedArtifactsOptions = {},
+    ): Promise<OrphanCleanupResult> {
+        const bucket =
+            options.bucket ?? process.env.DEPLOYMENT_ARTIFACT_BUCKET ?? DEFAULT_ARTIFACT_BUCKET;
+        const retentionHours = options.retentionHours ?? ORPHAN_RETENTION_HOURS;
+        const batchLimit = options.batchLimit ?? ORPHAN_BATCH_LIMIT;
+        const now = options.now ?? new Date();
+        const retentionMs = retentionHours * 60 * 60 * 1000;
+
+        const supabase = createClient();
+
+        // 1. Enumerate artifacts in the bucket.
+        const { data: objects, error: listError } = await supabase.storage
+            .from(bucket)
+            .list('', { limit: 1000, sortBy: { column: 'created_at', order: 'asc' } });
+
+        if (listError) {
+            throw new Error(`Failed to list storage artifacts: ${listError.message}`);
+        }
+
+        const artifacts = objects ?? [];
+
+        // 2. Cross-reference derived deployment ids against the deployments table.
+        const candidateIds = Array.from(
+            new Set(artifacts.map((o) => deploymentIdFromArtifactPath(o.name))),
+        );
+
+        const existingIds = new Set<string>();
+        if (candidateIds.length > 0) {
+            const { data: rows, error: depError } = await supabase
+                .from('deployments')
+                .select('id')
+                .in('id', candidateIds);
+
+            if (depError) {
+                throw new Error(`Failed to cross-reference deployments: ${depError.message}`);
+            }
+            for (const row of rows ?? []) existingIds.add((row as { id: string }).id);
+        }
+
+        // 3. Identify orphans, applying the retention window.
+        let skippedWithinRetention = 0;
+        const orphans: OrphanedArtifact[] = [];
+
+        for (const obj of artifacts) {
+            const deploymentId = deploymentIdFromArtifactPath(obj.name);
+            if (existingIds.has(deploymentId)) continue; // has a deployment record → not orphan
+
+            const createdAt = obj.created_at ? new Date(obj.created_at) : now;
+            const ageMs = now.getTime() - createdAt.getTime();
+            if (ageMs < retentionMs) {
+                skippedWithinRetention++;
+                continue; // still inside the debugging window
+            }
+
+            orphans.push({
+                path: obj.name,
+                sizeBytes: (obj.metadata as { size?: number } | null)?.size ?? 0,
+                ageSeconds: Math.floor(ageMs / 1000),
+            });
+        }
+
+        // 4. Apply the batch limit (oldest first, since the list is asc by age).
+        const batchLimitReached = orphans.length > batchLimit;
+        const toDelete = orphans.slice(0, batchLimit);
+
+        // 5. Delete and audit each orphan.
+        if (toDelete.length > 0) {
+            const { error: removeError } = await supabase.storage
+                .from(bucket)
+                .remove(toDelete.map((o) => o.path));
+
+            if (removeError) {
+                throw new Error(`Failed to delete orphaned artifacts: ${removeError.message}`);
+            }
+
+            const auditRows = toDelete.map((o) => ({
+                artifact_path: o.path,
+                bucket,
+                size_bytes: o.sizeBytes,
+                age_seconds: o.ageSeconds,
+            }));
+
+            const { error: auditError } = await supabase
+                .from('orphaned_artifact_cleanup_log')
+                .insert(auditRows);
+
+            if (auditError) {
+                // Audit failures are logged but must not mask a successful purge.
+                console.error('Orphan cleanup audit insert failed:', auditError.message);
+            }
+        }
+
+        return {
+            recordsDeleted: toDelete.length,
+            description: `Orphaned deployment artifacts purged from ${bucket}`,
+            executedAt: now,
+            orphansDeleted: toDelete,
+            scanned: artifacts.length,
+            skippedWithinRetention,
+            batchLimitReached,
         };
     }
 

--- a/supabase/migrations/014_orphaned_artifact_cleanup_audit.sql
+++ b/supabase/migrations/014_orphaned_artifact_cleanup_audit.sql
@@ -1,0 +1,33 @@
+-- Migration 014: Orphaned Artifact Cleanup Audit Log
+--
+-- Records every orphaned deployment-artifact (storage object with no
+-- corresponding deployments row) deleted by
+-- CleanupService.purgeOrphanedArtifacts(), capturing the artifact size and age
+-- at deletion time for an audit trail / debugging window accounting.
+--
+-- Issue: #758 — Automated Cleanup Service for Orphaned Deployment Artifacts
+--               with Retention Policy Enforcement
+
+CREATE TABLE IF NOT EXISTS orphaned_artifact_cleanup_log (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    -- Object path within the storage bucket.
+    artifact_path TEXT NOT NULL,
+    -- Bucket the artifact was removed from.
+    bucket TEXT NOT NULL,
+    -- Size of the deleted object in bytes (0 when unreported).
+    size_bytes BIGINT NOT NULL DEFAULT 0,
+    -- Age of the object in seconds at deletion time.
+    age_seconds BIGINT NOT NULL DEFAULT 0,
+    -- When the orphan was deleted.
+    deleted_at TIMESTAMPTZ DEFAULT NOW() NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT NOW() NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_orphaned_artifact_cleanup_log_deleted_at
+    ON orphaned_artifact_cleanup_log(deleted_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_orphaned_artifact_cleanup_log_artifact_path
+    ON orphaned_artifact_cleanup_log(artifact_path);
+
+-- Append-only audit table written by the service role only.
+ALTER TABLE orphaned_artifact_cleanup_log ENABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
## Summary
Extends the cleanup service to detect and remove orphaned Supabase Storage artifacts (generated code bundles) left behind by deployments that failed before their artifact was registered.

- **`CleanupService.purgeOrphanedArtifacts()`** (`apps/backend/src/services/cleanup.service.ts`):
  - Lists objects in the deployment-artifact bucket and cross-references each against the `deployments` table — an **orphan** is an object with no corresponding deployments row.
  - **Retention:** orphans younger than **24h** are kept (debugging window).
  - **Batch limit:** at most **100** orphans deleted per run.
  - **Audit:** every deletion is logged with the artifact's **size and age**.
- New `orphaned_artifact_cleanup_log` audit table (`supabase/migrations/014_orphaned_artifact_cleanup_audit.sql`).
- Wired into the existing **`purge-tombstoned-deployments`** cron route (no new cron entry needed); orphan-cleanup failures are logged and do not fail the tombstone purge.
- `deploymentIdFromArtifactPath()` helper supports both `<id>/bundle.zip` and `<id>.zip` layouts.

## Tests
`apps/backend/src/services/cleanup.orphaned-artifacts.test.ts` covers orphan detection, the 24h retention window (incl. boundary), the 100-per-run batch limit, audit emission, and id derivation.

Run: `pnpm --filter @craft/backend test -- cleanup`

Closes #758