### PR TITLE
feat(deployment): latency-based multi-region routing for deployment orchestration

### DIFF
--- a/apps/backend/src/services/region-selector.service.test.ts
+++ b/apps/backend/src/services/region-selector.service.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Unit tests for RegionSelectorService (#757)
+ *
+ * Coverage:
+ *   - weighted selection algorithm (0.7·user + 0.3·horizon) across latency combos
+ *   - fallback to us-east-1 when measurement fails
+ *   - 5-minute cache: hit within TTL (no measurement), miss when expired
+ *   - cache write on a fresh selection
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import {
+    RegionSelectorService,
+    scoreRegion,
+    selectOptimalRegion,
+    regionHealthUrl,
+    DEFAULT_REGION,
+    type Region,
+    type RegionMeasurement,
+} from './region-selector.service';
+
+// ── Supabase mock (cache read/write) ──────────────────────────────────────────
+
+function makeSupabaseMock() {
+    let cacheRow: { selected_region: string; expires_at: string } | null = null;
+    const upserts: Record<string, unknown>[] = [];
+
+    const client = {
+        from(_table: string) {
+            return {
+                select() {
+                    return {
+                        eq() {
+                            return {
+                                maybeSingle() {
+                                    return Promise.resolve({ data: cacheRow, error: null });
+                                },
+                            };
+                        },
+                    };
+                },
+                upsert(values: Record<string, unknown>) {
+                    upserts.push(values);
+                    return Promise.resolve({ error: null });
+                },
+            };
+        },
+    } as unknown as SupabaseClient;
+
+    return {
+        client,
+        upserts,
+        setCacheRow: (row: typeof cacheRow) => (cacheRow = row),
+    };
+}
+
+/** Build a probe that returns per-URL latencies; defaults to Infinity. */
+function probeFrom(latencies: Record<string, number>) {
+    return (url: string) => Promise.resolve(latencies[url] ?? Infinity);
+}
+
+const NOW = 1_000_000_000_000;
+const horizonTestnet = 'https://horizon-testnet.stellar.org';
+
+describe('scoring helpers', () => {
+    it('weights user latency at 0.7 and horizon at 0.3', () => {
+        expect(scoreRegion(100, 200)).toBeCloseTo(0.7 * 100 + 0.3 * 200);
+    });
+
+    it('selects the region with the lowest weighted score', () => {
+        const measurements: RegionMeasurement[] = [
+            { region: 'us-east-1', userLatencyMs: 100, horizonLatencyMs: 50 }, // 85
+            { region: 'eu-west-1', userLatencyMs: 40, horizonLatencyMs: 200 }, // 88
+            { region: 'ap-southeast-1', userLatencyMs: 30, horizonLatencyMs: 90 }, // 48
+        ];
+        const result = selectOptimalRegion(measurements);
+        expect(result.region).toBe('ap-southeast-1');
+        expect(result.fallback).toBe(false);
+    });
+
+    it('lets a low horizon latency tip the choice between close user latencies', () => {
+        const measurements: RegionMeasurement[] = [
+            { region: 'us-east-1', userLatencyMs: 50, horizonLatencyMs: 300 }, // 125
+            { region: 'eu-west-1', userLatencyMs: 55, horizonLatencyMs: 20 }, // 44.5
+        ];
+        expect(selectOptimalRegion(measurements).region).toBe('eu-west-1');
+    });
+
+    it('ignores unreachable regions (Infinity score)', () => {
+        const measurements: RegionMeasurement[] = [
+            { region: 'us-east-1', userLatencyMs: Infinity, horizonLatencyMs: Infinity },
+            { region: 'eu-west-1', userLatencyMs: 70, horizonLatencyMs: 70 },
+        ];
+        expect(selectOptimalRegion(measurements).region).toBe('eu-west-1');
+    });
+
+    it('falls back to the default region when every measurement failed', () => {
+        const measurements: RegionMeasurement[] = [
+            { region: 'us-east-1', userLatencyMs: Infinity, horizonLatencyMs: Infinity },
+            { region: 'eu-west-1', userLatencyMs: Infinity, horizonLatencyMs: Infinity },
+            { region: 'ap-southeast-1', userLatencyMs: Infinity, horizonLatencyMs: Infinity },
+        ];
+        const result = selectOptimalRegion(measurements);
+        expect(result.region).toBe(DEFAULT_REGION);
+        expect(result.fallback).toBe(true);
+        expect(result.score).toBeNull();
+    });
+});
+
+describe('RegionSelectorService.selectRegion', () => {
+    let mock: ReturnType<typeof makeSupabaseMock>;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.unstubAllEnvs();
+        mock = makeSupabaseMock();
+    });
+
+    it('measures, selects the optimal region, and caches it on a cache miss', async () => {
+        const probe = probeFrom({
+            [regionHealthUrl('us-east-1')]: 120,
+            [regionHealthUrl('eu-west-1')]: 30,
+            [regionHealthUrl('ap-southeast-1')]: 200,
+            [horizonTestnet]: 40,
+        });
+        const svc = new RegionSelectorService(mock.client, { probe, now: () => NOW });
+
+        const result = await svc.selectRegion({ cacheKey: 'user-1:testnet', network: 'testnet' });
+
+        // eu-west-1 has the lowest user latency; horizon is equal across regions.
+        expect(result.region).toBe('eu-west-1');
+        expect(result.cached).toBe(false);
+        expect(result.fallback).toBe(false);
+
+        // Cached with a 5-minute expiry.
+        expect(mock.upserts).toHaveLength(1);
+        expect(mock.upserts[0]).toMatchObject({
+            cache_key: 'user-1:testnet',
+            selected_region: 'eu-west-1',
+        });
+        expect(new Date(mock.upserts[0].expires_at as string).getTime()).toBe(
+            NOW + 5 * 60 * 1000,
+        );
+    });
+
+    it('returns the cached region without measuring when still within TTL', async () => {
+        mock.setCacheRow({
+            selected_region: 'ap-southeast-1',
+            expires_at: new Date(NOW + 60_000).toISOString(), // not yet expired
+        });
+        const probe = vi.fn(() => Promise.resolve(10));
+        const svc = new RegionSelectorService(mock.client, { probe, now: () => NOW });
+
+        const result = await svc.selectRegion({ cacheKey: 'user-1:testnet', network: 'testnet' });
+
+        expect(result.region).toBe('ap-southeast-1');
+        expect(result.cached).toBe(true);
+        expect(probe).not.toHaveBeenCalled();
+        expect(mock.upserts).toHaveLength(0);
+    });
+
+    it('re-measures when the cached entry has expired', async () => {
+        mock.setCacheRow({
+            selected_region: 'ap-southeast-1',
+            expires_at: new Date(NOW - 1).toISOString(), // expired
+        });
+        const probe = probeFrom({
+            [regionHealthUrl('us-east-1')]: 25,
+            [regionHealthUrl('eu-west-1')]: 300,
+            [regionHealthUrl('ap-southeast-1')]: 300,
+            [horizonTestnet]: 10,
+        });
+        const svc = new RegionSelectorService(mock.client, { probe, now: () => NOW });
+
+        const result = await svc.selectRegion({ cacheKey: 'user-1:testnet', network: 'testnet' });
+
+        expect(result.cached).toBe(false);
+        expect(result.region).toBe('us-east-1');
+        expect(mock.upserts).toHaveLength(1);
+    });
+
+    it('falls back to us-east-1 when all region probes fail', async () => {
+        const probe = probeFrom({}); // everything Infinity
+        const svc = new RegionSelectorService(mock.client, { probe, now: () => NOW });
+
+        const result = await svc.selectRegion({ cacheKey: 'user-1:testnet', network: 'testnet' });
+
+        expect(result.region).toBe<Region>('us-east-1');
+        expect(result.fallback).toBe(true);
+    });
+
+    it('honours REGION_HEALTH_* env overrides for endpoint URLs', () => {
+        vi.stubEnv('REGION_HEALTH_US_EAST_1', 'https://custom.example/health');
+        expect(regionHealthUrl('us-east-1')).toBe('https://custom.example/health');
+    });
+});

--- a/apps/backend/src/services/region-selector.service.ts
+++ b/apps/backend/src/services/region-selector.service.ts
@@ -1,0 +1,238 @@
+/**
+ * RegionSelectorService
+ *
+ * Picks the optimal Vercel deployment region for a user by combining two
+ * measured latencies:
+ *
+ *   - user_latency:    round-trip from the user to each region's health endpoint
+ *   - horizon_latency: round-trip from each region to the Stellar Horizon
+ *                      endpoint for the selected network
+ *
+ * The region that minimises  0.7 × user_latency + 0.3 × horizon_latency  is
+ * chosen. Selections are cached in Supabase with a 5-minute TTL to avoid
+ * re-measuring on every deployment, and us-east-1 is used as a fallback when
+ * measurement fails.
+ *
+ * Issue: #757 — Multi-Region Deployment Orchestration with Latency-Based
+ *               Routing Selection
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { createClient } from '@/lib/supabase/server';
+import {
+    getNetworkMetadata,
+    type StellarNetworkId,
+} from '@/services/stellar-network.service';
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+export const REGIONS = ['us-east-1', 'eu-west-1', 'ap-southeast-1'] as const;
+export type Region = (typeof REGIONS)[number];
+
+export const DEFAULT_REGION: Region = 'us-east-1';
+
+/** Scoring weights: user latency dominates, Horizon latency is secondary. */
+export const USER_LATENCY_WEIGHT = 0.7;
+export const HORIZON_LATENCY_WEIGHT = 0.3;
+
+/** Cache time-to-live: 5 minutes. */
+export const CACHE_TTL_MS = 5 * 60 * 1000;
+
+/** Default per-region health endpoints (override via REGION_HEALTH_<REGION> env). */
+const DEFAULT_REGION_HEALTH: Record<Region, string> = {
+    'us-east-1': 'https://us-east-1.health.craft.app/health',
+    'eu-west-1': 'https://eu-west-1.health.craft.app/health',
+    'ap-southeast-1': 'https://ap-southeast-1.health.craft.app/health',
+};
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export interface RegionMeasurement {
+    region: Region;
+    /** Measured user→region latency in ms (Infinity when unreachable). */
+    userLatencyMs: number;
+    /** Measured region→Horizon latency in ms (Infinity when unreachable). */
+    horizonLatencyMs: number;
+}
+
+export interface ScoredRegion extends RegionMeasurement {
+    /** Weighted score; lower is better. */
+    score: number;
+}
+
+export interface RegionSelection {
+    region: Region;
+    score: number | null;
+    /** True when the result came from the cache. */
+    cached: boolean;
+    /** True when measurement failed and the default region was used. */
+    fallback: boolean;
+    measurements?: ScoredRegion[];
+}
+
+export interface SelectRegionInput {
+    /** Stable key for caching (e.g. `${userId}:${network}` or `${ip}:${network}`). */
+    cacheKey: string;
+    network: StellarNetworkId;
+}
+
+/** Function used to measure round-trip latency to a URL (overridable for tests). */
+export type LatencyProbe = (url: string) => Promise<number>;
+
+// ── Pure scoring helpers ──────────────────────────────────────────────────────
+
+/** Weighted score for a single region; lower is better. */
+export function scoreRegion(userLatencyMs: number, horizonLatencyMs: number): number {
+    return USER_LATENCY_WEIGHT * userLatencyMs + HORIZON_LATENCY_WEIGHT * horizonLatencyMs;
+}
+
+/**
+ * Select the region with the lowest weighted score. Regions whose score is not
+ * finite (a failed measurement) are ignored. Falls back to {@link DEFAULT_REGION}
+ * when every region failed.
+ */
+export function selectOptimalRegion(measurements: RegionMeasurement[]): {
+    region: Region;
+    score: number | null;
+    fallback: boolean;
+    scored: ScoredRegion[];
+} {
+    const scored: ScoredRegion[] = measurements.map((m) => ({
+        ...m,
+        score: scoreRegion(m.userLatencyMs, m.horizonLatencyMs),
+    }));
+
+    let best: ScoredRegion | null = null;
+    for (const candidate of scored) {
+        if (!Number.isFinite(candidate.score)) continue;
+        if (!best || candidate.score < best.score) best = candidate;
+    }
+
+    if (!best) {
+        return { region: DEFAULT_REGION, score: null, fallback: true, scored };
+    }
+    return { region: best.region, score: best.score, fallback: false, scored };
+}
+
+// ── Service ───────────────────────────────────────────────────────────────────
+
+export class RegionSelectorService {
+    private readonly probe: LatencyProbe;
+    private readonly now: () => number;
+
+    constructor(
+        private readonly supabase?: SupabaseClient,
+        options: { probe?: LatencyProbe; now?: () => number } = {},
+    ) {
+        this.probe = options.probe ?? defaultLatencyProbe;
+        this.now = options.now ?? (() => Date.now());
+    }
+
+    private db(): SupabaseClient {
+        return this.supabase ?? (createClient() as unknown as SupabaseClient);
+    }
+
+    /**
+     * Return the optimal region for the input, using a cached selection when one
+     * is still within the 5-minute TTL, otherwise measuring and caching afresh.
+     */
+    async selectRegion(input: SelectRegionInput): Promise<RegionSelection> {
+        const cached = await this.readCache(input.cacheKey);
+        if (cached) {
+            return { region: cached, score: null, cached: true, fallback: false };
+        }
+
+        const measurements = await this.measureRegions(input.network);
+        const { region, score, fallback, scored } = selectOptimalRegion(measurements);
+
+        await this.writeCache(input.cacheKey, region, scored);
+
+        return { region, score, cached: false, fallback, measurements: scored };
+    }
+
+    /** Measure user- and Horizon-latency for every region. */
+    async measureRegions(network: StellarNetworkId): Promise<RegionMeasurement[]> {
+        const horizonUrl = getNetworkMetadata(network)?.horizonUrl;
+
+        return Promise.all(
+            REGIONS.map(async (region) => {
+                const [userLatencyMs, horizonLatencyMs] = await Promise.all([
+                    this.probe(regionHealthUrl(region)),
+                    horizonUrl ? this.probe(horizonUrl) : Promise.resolve(Infinity),
+                ]);
+                return { region, userLatencyMs, horizonLatencyMs };
+            }),
+        );
+    }
+
+    // ── Caching ───────────────────────────────────────────────────────────────
+
+    /** Return the cached region for a key when it is still within TTL. */
+    private async readCache(cacheKey: string): Promise<Region | null> {
+        const { data, error } = await this.db()
+            .from('region_latency_cache')
+            .select('selected_region, expires_at')
+            .eq('cache_key', cacheKey)
+            .maybeSingle();
+
+        if (error || !data) return null;
+
+        const row = data as { selected_region: string; expires_at: string };
+        if (new Date(row.expires_at).getTime() <= this.now()) return null;
+
+        return REGIONS.includes(row.selected_region as Region)
+            ? (row.selected_region as Region)
+            : null;
+    }
+
+    /** Upsert the selection with a fresh 5-minute expiry. */
+    private async writeCache(
+        cacheKey: string,
+        region: Region,
+        scored: ScoredRegion[],
+    ): Promise<void> {
+        const expiresAt = new Date(this.now() + CACHE_TTL_MS).toISOString();
+
+        const { error } = await this.db()
+            .from('region_latency_cache')
+            .upsert(
+                {
+                    cache_key: cacheKey,
+                    selected_region: region,
+                    scores: scored,
+                    expires_at: expiresAt,
+                },
+                { onConflict: 'cache_key' },
+            );
+
+        if (error) {
+            console.error('[RegionSelector] failed to cache selection:', error.message);
+        }
+    }
+}
+
+// ── Default latency probe ─────────────────────────────────────────────────────
+
+/** Resolve a region's health endpoint, honouring env overrides. */
+export function regionHealthUrl(region: Region): string {
+    const envKey = `REGION_HEALTH_${region.toUpperCase().replace(/-/g, '_')}`;
+    return process.env[envKey] ?? DEFAULT_REGION_HEALTH[region];
+}
+
+/**
+ * Measure round-trip latency to a URL with a HEAD request. Returns Infinity on
+ * any failure so the region is excluded from selection.
+ */
+export async function defaultLatencyProbe(url: string): Promise<number> {
+    const start = Date.now();
+    try {
+        const res = await fetch(url, { method: 'HEAD' });
+        if (!res.ok) return Infinity;
+        return Date.now() - start;
+    } catch {
+        return Infinity;
+    }
+}
+
+/** Shared singleton using the request-scoped Supabase server client. */
+export const regionSelectorService = new RegionSelectorService();

--- a/supabase/migrations/014_region_latency_cache.sql
+++ b/supabase/migrations/014_region_latency_cache.sql
@@ -1,0 +1,32 @@
+-- Migration 014: Region Latency Selection Cache
+--
+-- Caches the optimal Vercel deployment region chosen by RegionSelectorService
+-- for a given user/IP + network, with a 5-minute TTL, so latency does not have
+-- to be re-measured on every deployment.
+--
+-- Issue: #757 — Multi-Region Deployment Orchestration with Latency-Based
+--               Routing Selection
+
+CREATE TABLE IF NOT EXISTS region_latency_cache (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    -- Stable cache key, e.g. "<userId>:<network>" or "<ip>:<network>".
+    cache_key TEXT NOT NULL UNIQUE,
+    -- Chosen region: us-east-1 | eu-west-1 | ap-southeast-1.
+    selected_region TEXT NOT NULL CHECK (
+        selected_region IN ('us-east-1', 'eu-west-1', 'ap-southeast-1')
+    ),
+    -- Per-region measured latencies + weighted scores (audit / debugging).
+    scores JSONB,
+    -- When this cached selection expires (now + 5 minutes at write time).
+    expires_at TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT NOW() NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_region_latency_cache_cache_key
+    ON region_latency_cache(cache_key);
+
+CREATE INDEX IF NOT EXISTS idx_region_latency_cache_expires_at
+    ON region_latency_cache(expires_at);
+
+-- Written by the service role only.
+ALTER TABLE region_latency_cache ENABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
## Summary
Adds a region selection service that picks the optimal Vercel deployment region based on measured latency, instead of always targeting a single region.

- **`RegionSelectorService`** (`apps/backend/src/services/region-selector.service.ts`):
  - Supports regions **us-east-1**, **eu-west-1**, **ap-southeast-1**.
  - Measures **user→region** latency (per-region health-endpoint probe) and **region→Horizon** latency (Stellar Horizon endpoint for the chosen network, reusing `getNetworkMetadata`).
  - Selects the region minimising **`0.7 × user_latency + 0.3 × horizon_latency`**.
  - **Caches** the selection in Supabase with a **5-minute TTL** (`region_latency_cache`) to avoid re-measuring on every deployment.
  - **Fallback** to `us-east-1` when measurement fails.
- Pure, exported helpers `scoreRegion` / `selectOptimalRegion` keep the algorithm unit-testable; the latency probe is injectable.
- New `region_latency_cache` table (`supabase/migrations/014_region_latency_cache.sql`).

## Tests
`apps/backend/src/services/region-selector.service.test.ts` covers the weighted selection algorithm across latency combinations, the 5-minute cache (hit within TTL, miss when expired), cache writes, and the fallback path.

Run: `pnpm --filter @craft/backend test -- region-selector`

Closes #757