### PR TITLE
feat(vercel): expose Vercel circuit breaker state in deployment health endpoint

### DIFF
--- a/apps/backend/src/app/api/deployments/[id]/health/route.ts
+++ b/apps/backend/src/app/api/deployments/[id]/health/route.ts
@@ -1,11 +1,17 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { withDeploymentAuth } from '@/lib/api/with-auth';
 import { healthMonitorService } from '@/services/health-monitor.service';
+import { VercelService } from '@/services/vercel.service';
+
+const vercelService = new VercelService();
 
 export const GET = withDeploymentAuth(async (_req: NextRequest, { params }) => {
     try {
         const health = await healthMonitorService.checkDeploymentHealth(params.id);
-        return NextResponse.json(health);
+        return NextResponse.json({
+            ...health,
+            circuitState: vercelService.breaker.currentState,
+        });
     } catch (error: any) {
         console.error('Error checking deployment health:', error);
         return NextResponse.json(


### PR DESCRIPTION
Closes #766

## Summary
The Vercel API client is already wrapped with a circuit breaker (`@/lib/api/circuit-breaker`, fast-failing during outages with open/half-open/close transitions). This PR completes the issue by surfacing the circuit state to operators via the deployment health endpoint.

## Changes
- Expose `circuitState` (`CLOSED` / `OPEN` / `HALF_OPEN`) from the Vercel service breaker in the `GET /api/deployments/[id]/health` response.

## Notes
- Circuit breaker behaviour (open after 5 consecutive failures, fast-fail while open, single half-open probe after the reset timeout, close on probe success) and its transition tests already live in `circuit-breaker.test.ts` / `vercel-circuit-breaker.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)