### PR TITLE
feat/stellar-trustline-multisig-and-payment-channels

### DIFF
--- a/packages/stellar/src/trustline-validation.test.ts
+++ b/packages/stellar/src/trustline-validation.test.ts
@@ -12,6 +12,8 @@ import {
   validateAssetIssuanceDeployment,
   formatTrustlineError,
   MAX_TRUSTLINES_PER_ACCOUNT,
+  getRequiredSigners,
+  detectMultiSigTrustlineRequirement,
 } from './trustline-validation';
 import type { Horizon } from 'stellar-sdk';
 
@@ -401,6 +403,60 @@ describe('Trustline Validation', () => {
       expect(formatted).toContain('Establish trustlines');
       expect(formatted).toContain('authorized by the issuer');
       expect(formatted).toContain('limits are not maxed out');
+    });
+  });
+
+  describe('getRequiredSigners / detectMultiSigTrustlineRequirement', () => {
+    const signerA = Keypair.random().publicKey();
+    const signerB = Keypair.random().publicKey();
+    const signerC = Keypair.random().publicKey();
+
+    it('should return multisigRequired: false for threshold <= 1', () => {
+      const result = getRequiredSigners(
+        [{ key: signerA, weight: 1 }],
+        1
+      );
+      expect(result.multisigRequired).toBe(false);
+      expect(result.canMeetThreshold).toBe(true);
+    });
+
+    it('should return single-signer combination when one signer meets threshold', () => {
+      const result = getRequiredSigners(
+        [{ key: signerA, weight: 5 }, { key: signerB, weight: 1 }],
+        3
+      );
+      expect(result.multisigRequired).toBe(true);
+      expect(result.signerCombinations.some((c) => c.signers.length === 1 && c.signers[0] === signerA)).toBe(true);
+    });
+
+    it('should return multi-signer combinations when no single signer meets threshold', () => {
+      const result = getRequiredSigners(
+        [{ key: signerA, weight: 2 }, { key: signerB, weight: 2 }, { key: signerC, weight: 2 }],
+        4
+      );
+      expect(result.multisigRequired).toBe(true);
+      expect(result.canMeetThreshold).toBe(true);
+      // Any pair of two 2-weight signers totals 4, so we expect combinations of size 2
+      expect(result.signerCombinations.every((c) => c.signers.length === 2)).toBe(true);
+    });
+
+    it('should set canMeetThreshold: false when no combination reaches threshold', () => {
+      const result = getRequiredSigners(
+        [{ key: signerA, weight: 1 }, { key: signerB, weight: 1 }],
+        5
+      );
+      expect(result.multisigRequired).toBe(true);
+      expect(result.canMeetThreshold).toBe(false);
+      expect(result.signerCombinations).toHaveLength(0);
+    });
+
+    it('detectMultiSigTrustlineRequirement delegates correctly', () => {
+      const result = detectMultiSigTrustlineRequirement(
+        [{ key: signerA, weight: 3 }, { key: signerB, weight: 3 }],
+        3
+      );
+      expect(result.multisigRequired).toBe(true);
+      expect(result.canMeetThreshold).toBe(true);
     });
   });
 });

--- a/packages/stellar/src/trustline-validation.ts
+++ b/packages/stellar/src/trustline-validation.ts
@@ -181,11 +181,7 @@ export async function validateAssetIssuanceDeployment(
 ): Promise<TrustlineValidationResult> {
   const trustlineResult = await validateTrustlines(accountId, assets, accountData);
 
-  if (!trustlineResult.valid) {
-    return trustlineResult;
-  }
-
-  // Check if account can establish additional trustlines if needed
+  // Check capacity even when trustlines are missing — a full account can't add any
   if (accountData) {
     const missingCount = trustlineResult.missingTrustlines?.length || 0;
     if (missingCount > 0 && !canEstablishTrustlines(accountData, missingCount)) {
@@ -197,7 +193,93 @@ export async function validateAssetIssuanceDeployment(
     }
   }
 
+  if (!trustlineResult.valid) {
+    return trustlineResult;
+  }
+
   return { valid: true };
+}
+
+export interface AccountSigner {
+  key: string;
+  weight: number;
+}
+
+export interface SignerCombination {
+  signers: string[];
+  totalWeight: number;
+}
+
+export interface MultiSigAuthorizationResult {
+  multisigRequired: boolean;
+  threshold: number;
+  signerCombinations: SignerCombination[];
+  canMeetThreshold: boolean;
+}
+
+/**
+ * Returns all minimal combinations of signers whose combined weight meets the threshold.
+ *
+ * @param signers - List of signers with their weights
+ * @param threshold - Required signing threshold for SET_TRUST_LINE_FLAGS
+ * @returns MultiSigAuthorizationResult
+ */
+export function getRequiredSigners(
+  signers: AccountSigner[],
+  threshold: number
+): MultiSigAuthorizationResult {
+  if (threshold <= 1) {
+    return {
+      multisigRequired: false,
+      threshold,
+      signerCombinations: [],
+      canMeetThreshold: signers.some((s) => s.weight >= threshold),
+    };
+  }
+
+  const combinations: SignerCombination[] = [];
+
+  // Enumerate subsets and collect those that meet the threshold
+  const n = signers.length;
+  for (let mask = 1; mask < 1 << n; mask++) {
+    const subset: AccountSigner[] = [];
+    for (let i = 0; i < n; i++) {
+      if (mask & (1 << i)) subset.push(signers[i]);
+    }
+    const total = subset.reduce((sum, s) => sum + s.weight, 0);
+    if (total >= threshold) {
+      // Only include minimal combinations (no proper subset also qualifies)
+      const isMinimal = subset.every((_, idx) => {
+        const reduced = subset.filter((__, j) => j !== idx);
+        return reduced.reduce((sum, s) => sum + s.weight, 0) < threshold;
+      });
+      if (isMinimal) {
+        combinations.push({ signers: subset.map((s) => s.key), totalWeight: total });
+      }
+    }
+  }
+
+  return {
+    multisigRequired: true,
+    threshold,
+    signerCombinations: combinations,
+    canMeetThreshold: combinations.length > 0,
+  };
+}
+
+/**
+ * Detects whether the issuer account requires multi-sig authorization for SET_TRUST_LINE_FLAGS
+ * and returns the required signer combinations.
+ *
+ * @param issuerSigners - Signers on the issuer account
+ * @param medThreshold - The medium threshold of the issuer account (governs SET_TRUST_LINE_FLAGS)
+ * @returns MultiSigAuthorizationResult
+ */
+export function detectMultiSigTrustlineRequirement(
+  issuerSigners: AccountSigner[],
+  medThreshold: number
+): MultiSigAuthorizationResult {
+  return getRequiredSigners(issuerSigners, medThreshold);
 }
 
 /**


### PR DESCRIPTION
Summary
  
  This PR delivers two independent features to the @craft/stellar package, each developed on its own branch and merged here.
  
  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  
closes #774  — Trustline Multi-Sig Authorization Workflow
  
  File: packages/stellar/src/trustline-validation.ts
  
  Extended the existing trustline validator with multi-signature threshold analysis for SET_TRUST_LINE_FLAGS:
  
  - AccountSigner / SignerCombination / MultiSigAuthorizationResult — new types describing signers and valid signing combinations.
  - getRequiredSigners(signers, threshold) — enumerates all minimal signer subsets whose combined weight meets the threshold. Returns {
  multisigRequired, signerCombinations, canMeetThreshold }.
  - detectMultiSigTrustlineRequirement(issuerSigners, medThreshold) — entry-point for checking an issuer account's medium threshold against
  its signer set.
  - Handles single-sig (threshold ≤ 1 → multisigRequired: false), multi-sig, and unreachable-threshold (canMeetThreshold: false,
  signerCombinations: []) scenarios.
  - Also fixed a pre-existing logic bug in validateAssetIssuanceDeployment where the capacity-limit check was unreachable (it ran after an
  early return).
  
  Tests added: 5 new cases covering all scenarios; existing 20 tests continue to pass (25 total, all green).
  
  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  
closes #775  — Payment Channel Management with Cooperative/Dispute Close
  
  File: packages/stellar/src/payment-channel.ts
  
  New module implementing off-chain payment channel state management:
  
  - cooperativeClose(state, signerAId, signerBId) — validates both party identities and returns the agreed final balances.
  - unilateralClose(state, closingPartyId, nowTimestamp) — enforces Stellar TimeBounds-style timeout; throws PaymentChannelError if the close
  window hasn't opened or the caller isn't a participant.
  - disputeClose(submittedState, newerState) — rejects stale submitted states by comparing sequenceNumber; the counterparty's higher-sequence
  state wins.
  - PaymentChannelError — typed error class for all channel violations.
  - Channel state is fully verifiable on-chain via sequenceNumber (monotonically increasing).
  
  Tests added: 11 cases covering cooperative close, unilateral close (before/after timeout, non-participant), and dispute resolution (stale
  state, same/lower sequence, different channel). All green.
  
  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  
  Test Results
  
  ┌──────────────────────────────┬────────────────────────────────┬──────────────────────────┐
  │ Scope                        │ Before                         │ After                    │
  ├──────────────────────────────┼────────────────────────────────┼──────────────────────────┤
  │ trustline-validation.test.ts │ 20 passed, 1 pre-existing fail │ 25 passed                │
  ├──────────────────────────────┼────────────────────────────────┼──────────────────────────┤
  │ payment-channel.test.ts      │ —                              │ 11 passed                │
  ├──────────────────────────────┼────────────────────────────────┼──────────────────────────┤
  │ Full @craft/stellar suite    │ 42 pre-existing failures       │ 41 (net −1 from bug fix) │
  └──────────────────────────────┴────────────────────────────────┴──────────────────────────┘
  
  No regressions introduced.