### PR TITLE
feat: Soroban dry-run forecasting, fee-bump orchestrator, multi-party issuance, and account merge protection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63,6 +63,30 @@
                 "vitest": "^1.1.0"
             }
         },
+        "apps/backend/node_modules/execa": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+            "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cross-spawn": "^7.0.3",
+                "get-stream": "^8.0.1",
+                "human-signals": "^5.0.0",
+                "is-stream": "^3.0.0",
+                "merge-stream": "^2.0.0",
+                "npm-run-path": "^5.1.0",
+                "onetime": "^6.0.0",
+                "signal-exit": "^4.1.0",
+                "strip-final-newline": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=16.17"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/execa?sponsor=1"
+            }
+        },
         "apps/backend/node_modules/fast-check": {
             "version": "3.23.2",
             "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.23.2.tgz",
@@ -84,6 +108,192 @@
             },
             "engines": {
                 "node": ">=8.0.0"
+            }
+        },
+        "apps/backend/node_modules/get-stream": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+            "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "apps/backend/node_modules/human-signals": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+            "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=16.17.0"
+            }
+        },
+        "apps/backend/node_modules/is-stream": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+            "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "apps/backend/node_modules/mimic-fn": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+            "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "apps/backend/node_modules/npm-run-path": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+            "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "path-key": "^4.0.0"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "apps/backend/node_modules/onetime": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+            "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mimic-fn": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "apps/backend/node_modules/path-key": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+            "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "apps/backend/node_modules/signal-exit": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+            "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "apps/backend/node_modules/strip-final-newline": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+            "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "apps/backend/node_modules/vitest": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.6.1.tgz",
+            "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/expect": "1.6.1",
+                "@vitest/runner": "1.6.1",
+                "@vitest/snapshot": "1.6.1",
+                "@vitest/spy": "1.6.1",
+                "@vitest/utils": "1.6.1",
+                "acorn-walk": "^8.3.2",
+                "chai": "^4.3.10",
+                "debug": "^4.3.4",
+                "execa": "^8.0.1",
+                "local-pkg": "^0.5.0",
+                "magic-string": "^0.30.5",
+                "pathe": "^1.1.1",
+                "picocolors": "^1.0.0",
+                "std-env": "^3.5.0",
+                "strip-literal": "^2.0.0",
+                "tinybench": "^2.5.1",
+                "tinypool": "^0.8.3",
+                "vite": "^5.0.0",
+                "vite-node": "1.6.1",
+                "why-is-node-running": "^2.2.2"
+            },
+            "bin": {
+                "vitest": "vitest.mjs"
+            },
+            "engines": {
+                "node": "^18.0.0 || >=20.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "@edge-runtime/vm": "*",
+                "@types/node": "^18.0.0 || >=20.0.0",
+                "@vitest/browser": "1.6.1",
+                "@vitest/ui": "1.6.1",
+                "happy-dom": "*",
+                "jsdom": "*"
+            },
+            "peerDependenciesMeta": {
+                "@edge-runtime/vm": {
+                    "optional": true
+                },
+                "@types/node": {
+                    "optional": true
+                },
+                "@vitest/browser": {
+                    "optional": true
+                },
+                "@vitest/ui": {
+                    "optional": true
+                },
+                "happy-dom": {
+                    "optional": true
+                },
+                "jsdom": {
+                    "optional": true
+                }
             }
         },
         "apps/frontend": {
@@ -120,6 +330,216 @@
                 "tailwindcss": "^3.4.0",
                 "typescript": "^5.3.3",
                 "vitest": "^1.1.0"
+            }
+        },
+        "apps/frontend/node_modules/execa": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+            "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cross-spawn": "^7.0.3",
+                "get-stream": "^8.0.1",
+                "human-signals": "^5.0.0",
+                "is-stream": "^3.0.0",
+                "merge-stream": "^2.0.0",
+                "npm-run-path": "^5.1.0",
+                "onetime": "^6.0.0",
+                "signal-exit": "^4.1.0",
+                "strip-final-newline": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=16.17"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/execa?sponsor=1"
+            }
+        },
+        "apps/frontend/node_modules/get-stream": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+            "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "apps/frontend/node_modules/human-signals": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+            "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=16.17.0"
+            }
+        },
+        "apps/frontend/node_modules/is-stream": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+            "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "apps/frontend/node_modules/mimic-fn": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+            "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "apps/frontend/node_modules/npm-run-path": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+            "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "path-key": "^4.0.0"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "apps/frontend/node_modules/onetime": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+            "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mimic-fn": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "apps/frontend/node_modules/path-key": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+            "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "apps/frontend/node_modules/signal-exit": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+            "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "apps/frontend/node_modules/strip-final-newline": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+            "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "apps/frontend/node_modules/vitest": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.6.1.tgz",
+            "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/expect": "1.6.1",
+                "@vitest/runner": "1.6.1",
+                "@vitest/snapshot": "1.6.1",
+                "@vitest/spy": "1.6.1",
+                "@vitest/utils": "1.6.1",
+                "acorn-walk": "^8.3.2",
+                "chai": "^4.3.10",
+                "debug": "^4.3.4",
+                "execa": "^8.0.1",
+                "local-pkg": "^0.5.0",
+                "magic-string": "^0.30.5",
+                "pathe": "^1.1.1",
+                "picocolors": "^1.0.0",
+                "std-env": "^3.5.0",
+                "strip-literal": "^2.0.0",
+                "tinybench": "^2.5.1",
+                "tinypool": "^0.8.3",
+                "vite": "^5.0.0",
+                "vite-node": "1.6.1",
+                "why-is-node-running": "^2.2.2"
+            },
+            "bin": {
+                "vitest": "vitest.mjs"
+            },
+            "engines": {
+                "node": "^18.0.0 || >=20.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "@edge-runtime/vm": "*",
+                "@types/node": "^18.0.0 || >=20.0.0",
+                "@vitest/browser": "1.6.1",
+                "@vitest/ui": "1.6.1",
+                "happy-dom": "*",
+                "jsdom": "*"
+            },
+            "peerDependenciesMeta": {
+                "@edge-runtime/vm": {
+                    "optional": true
+                },
+                "@types/node": {
+                    "optional": true
+                },
+                "@vitest/browser": {
+                    "optional": true
+                },
+                "@vitest/ui": {
+                    "optional": true
+                },
+                "happy-dom": {
+                    "optional": true
+                },
+                "jsdom": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@adobe/css-tools": {
@@ -990,6 +1410,24 @@
                 "node": ">=12"
             }
         },
+        "node_modules/@esbuild/netbsd-arm64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+            "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/@esbuild/netbsd-x64": {
             "version": "0.21.5",
             "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
@@ -1007,6 +1445,24 @@
                 "node": ">=12"
             }
         },
+        "node_modules/@esbuild/openbsd-arm64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+            "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/@esbuild/openbsd-x64": {
             "version": "0.21.5",
             "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
@@ -1022,6 +1478,24 @@
             ],
             "engines": {
                 "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/openharmony-arm64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+            "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/sunos-x64": {
@@ -1350,14 +1824,14 @@
             }
         },
         "node_modules/@napi-rs/wasm-runtime": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-            "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+            "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
             "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@tybys/wasm-util": "^0.10.1"
+                "@tybys/wasm-util": "^0.10.3"
             },
             "funding": {
                 "type": "github",
@@ -1574,6 +2048,326 @@
             "license": "MIT",
             "engines": {
                 "node": ">=12.4.0"
+            }
+        },
+        "node_modules/@oxc-project/types": {
+            "version": "0.137.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.137.0.tgz",
+            "integrity": "sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "funding": {
+                "url": "https://github.com/sponsors/Boshen"
+            }
+        },
+        "node_modules/@rolldown/binding-android-arm64": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.3.tgz",
+            "integrity": "sha512-DT6Z3PhvioeHMvxo+xHc3KtqggrI7CCTXCmC2h/5zUlp5jVitv7XEy+9q5/7v8IolhlioawpMo8Kg0EEBy7J0g==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-darwin-arm64": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.3.tgz",
+            "integrity": "sha512-0NwgwsjM7LrsuVnXMK3koTpagBNOhloc/BNjKqZjv4V5zI5r13qx69uVhRx+o5Z0yy4Hzq+lpy7TAgUG/ocvrw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-darwin-x64": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.3.tgz",
+            "integrity": "sha512-YtiBp4disu6V560loT6PjMdiRaWmVvDNrUunAalbiFx2ggeJwxdAsgZMcoGP17uyAsTwAj5V1niksxlHnVQ1Sw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-freebsd-x64": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.3.tgz",
+            "integrity": "sha512-yD3EkEdXk2LypPxnf/kSZHirarsI8gcPzc62SukhR9VJTyvV+F9Q/GxWNuCojc7sXyuVC4DxRGhdDK4X8VSsbw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.3.tgz",
+            "integrity": "sha512-c+8vieQbsD7HNAHKIA34w0GJ9FedFFuJGD+7E6vz7Q3uqAIugL5p45fhlsj4UaAsHpcmlqugBWMhA0/j7o0sIg==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-arm64-gnu": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.3.tgz",
+            "integrity": "sha512-50jD0uUwLvur7Zz9LHz17kaAdTPjn5wN93hEgjvmYFRZwiR7ZJYovTd5ipyWJDAnXKvZ+wgc+/Ika6dwSF5OcA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-arm64-musl": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.3.tgz",
+            "integrity": "sha512-BO9+oPL8K9poZJBfYPsXNtYjPE5uM3qeehT3aFcW4LITOl+iSqhp0abzjR2nWBUNjIZeKXjAEWBZ64WjNoHd6w==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.3.tgz",
+            "integrity": "sha512-f3VpLB1vQ0Eo6ecr/6cekLnvYMFF4YBFoVGkfkvPLq1bAkbAwHYQPZKoAmG6OJyTcxxoC+AvezGx/S1obNC0Mw==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-s390x-gnu": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.3.tgz",
+            "integrity": "sha512-AmurZ26Pqx/RI9N1gzEOCklkKXl927yjfXWUUS0O7Puh8ARM/Ob8qfrD3qnWksScdw6cSrW5PSHE9DyLu7+PtA==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-x64-gnu": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.3.tgz",
+            "integrity": "sha512-JJpqs8bRGITDOdbkNKnlojzBabbOHrqjSvDr0IVsZObE1lBcPjxItUEY9eWIDbxaJ3cGrXPWGfGkIxFijg/URg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-x64-musl": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.3.tgz",
+            "integrity": "sha512-rSJcdjPxzA/by/6/rYs+v+bXU7UjvnbUWz8MJb6kh6+knqB1dCrtHg0uu7C/4haqJvqdkYHQ5IGn+tCH9GLW/g==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-openharmony-arm64": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.3.tgz",
+            "integrity": "sha512-hQ3/PYkDJICgevvyNcVrihVeqq7k1Pp3VZ9lY+dauAYUJKO+auqApvANhvR1An9BhmqYKvW2Mu1F9u4DXSMLxQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-wasm32-wasi": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.3.tgz",
+            "integrity": "sha512-Elcv/BtML9lXrV6JuKITc/grN2kYV9gjsQpW8Jfw4ioK0TOkjBjye0nnyqQNy9STNaI20lXNaQBRrD5gSgR0Yg==",
+            "cpu": [
+                "wasm32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@emnapi/core": "1.11.1",
+                "@emnapi/runtime": "1.11.1",
+                "@napi-rs/wasm-runtime": "^1.1.6"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+            "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@emnapi/wasi-threads": "1.2.2",
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+            "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+            "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@rolldown/binding-win32-arm64-msvc": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.3.tgz",
+            "integrity": "sha512-2DrEfhluH9yhiaFApmsjsjwrSYbNcY1oFTzYSP1a535jDbV98zCFanA/96TBUd0iDFcxGmw9QRExwGCXz3U+/g==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-win32-x64-msvc": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.3.tgz",
+            "integrity": "sha512-OL4OMk7UPXOeVGGd3qo5zJyPIljf4AFgk5QAkPPS+OoLuOOozhuaQGC18MxVTnw/06q93gShAJzlwnSCY9YtqA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
             }
         },
         "node_modules/@rolldown/pluginutils": {
@@ -1953,6 +2747,14 @@
             "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@standard-schema/spec": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+            "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@stellar/js-xdr": {
             "version": "3.1.2",
@@ -2436,9 +3238,9 @@
             }
         },
         "node_modules/@tybys/wasm-util": {
-            "version": "0.10.2",
-            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
-            "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+            "version": "0.10.3",
+            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+            "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -2497,6 +3299,37 @@
             "dependencies": {
                 "@babel/types": "^7.28.2"
             }
+        },
+        "node_modules/@types/chai": {
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+            "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/deep-eql": "*",
+                "assertion-error": "^2.0.1"
+            }
+        },
+        "node_modules/@types/chai/node_modules/assertion-error": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+            "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@types/deep-eql": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+            "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@types/estree": {
             "version": "1.0.9",
@@ -2565,7 +3398,7 @@
             "version": "20.19.41",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
             "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "undici-types": "~6.21.0"
@@ -3091,6 +3924,20 @@
                 "@vitest/spy": "1.6.1",
                 "@vitest/utils": "1.6.1",
                 "chai": "^4.3.10"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/pretty-format": {
+            "version": "4.1.9",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+            "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "tinyrainbow": "^3.1.0"
             },
             "funding": {
                 "url": "https://opencollective.com/vitest"
@@ -4759,6 +5606,17 @@
                 "node": ">=0.4.0"
             }
         },
+        "node_modules/detect-libc": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+            "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/didyoumean": {
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
@@ -5012,6 +5870,14 @@
             "engines": {
                 "node": ">= 0.4"
             }
+        },
+        "node_modules/es-module-lexer": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+            "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/es-object-atoms": {
             "version": "1.1.2",
@@ -5748,6 +6614,17 @@
             },
             "funding": {
                 "url": "https://github.com/sindresorhus/execa?sponsor=1"
+            }
+        },
+        "node_modules/expect-type": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+            "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
+            "engines": {
+                "node": ">=12.0.0"
             }
         },
         "node_modules/external-editor": {
@@ -7563,6 +8440,279 @@
                 "node": ">= 0.8.0"
             }
         },
+        "node_modules/lightningcss": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+            "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+            "dev": true,
+            "license": "MPL-2.0",
+            "peer": true,
+            "dependencies": {
+                "detect-libc": "^2.0.3"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            },
+            "optionalDependencies": {
+                "lightningcss-android-arm64": "1.32.0",
+                "lightningcss-darwin-arm64": "1.32.0",
+                "lightningcss-darwin-x64": "1.32.0",
+                "lightningcss-freebsd-x64": "1.32.0",
+                "lightningcss-linux-arm-gnueabihf": "1.32.0",
+                "lightningcss-linux-arm64-gnu": "1.32.0",
+                "lightningcss-linux-arm64-musl": "1.32.0",
+                "lightningcss-linux-x64-gnu": "1.32.0",
+                "lightningcss-linux-x64-musl": "1.32.0",
+                "lightningcss-win32-arm64-msvc": "1.32.0",
+                "lightningcss-win32-x64-msvc": "1.32.0"
+            }
+        },
+        "node_modules/lightningcss-android-arm64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+            "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-darwin-arm64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+            "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-darwin-x64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+            "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-freebsd-x64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+            "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm-gnueabihf": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+            "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm64-gnu": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+            "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm64-musl": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+            "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-x64-gnu": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+            "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-x64-musl": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+            "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-win32-arm64-msvc": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+            "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-win32-x64-msvc": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+            "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
         "node_modules/lilconfig": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
@@ -8441,6 +9591,21 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/obug": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+            "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+            "dev": true,
+            "funding": [
+                "https://github.com/sponsors/sxzz",
+                "https://opencollective.com/debug"
+            ],
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=12.20.0"
             }
         },
         "node_modules/once": {
@@ -9505,6 +10670,49 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "node_modules/rolldown": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.3.tgz",
+            "integrity": "sha512-1F1eEtUBtFvcGm1HQ9TiUIUHPQG7mSAODrhIzjxoUEFuo8OcbrGLiVLkevNgj84TE4lnHvnumwFjhJO5Eu135g==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@oxc-project/types": "=0.137.0",
+                "@rolldown/pluginutils": "^1.0.0"
+            },
+            "bin": {
+                "rolldown": "bin/cli.mjs"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "optionalDependencies": {
+                "@rolldown/binding-android-arm64": "1.1.3",
+                "@rolldown/binding-darwin-arm64": "1.1.3",
+                "@rolldown/binding-darwin-x64": "1.1.3",
+                "@rolldown/binding-freebsd-x64": "1.1.3",
+                "@rolldown/binding-linux-arm-gnueabihf": "1.1.3",
+                "@rolldown/binding-linux-arm64-gnu": "1.1.3",
+                "@rolldown/binding-linux-arm64-musl": "1.1.3",
+                "@rolldown/binding-linux-ppc64-gnu": "1.1.3",
+                "@rolldown/binding-linux-s390x-gnu": "1.1.3",
+                "@rolldown/binding-linux-x64-gnu": "1.1.3",
+                "@rolldown/binding-linux-x64-musl": "1.1.3",
+                "@rolldown/binding-openharmony-arm64": "1.1.3",
+                "@rolldown/binding-wasm32-wasi": "1.1.3",
+                "@rolldown/binding-win32-arm64-msvc": "1.1.3",
+                "@rolldown/binding-win32-x64-msvc": "1.1.3"
+            }
+        },
+        "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+            "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
         "node_modules/rollup": {
             "version": "4.60.4",
             "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
@@ -10518,10 +11726,21 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/tinyexec": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+            "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/tinyglobby": {
-            "version": "0.2.16",
-            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-            "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+            "version": "0.2.17",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+            "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -10565,6 +11784,17 @@
             "integrity": "sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==",
             "dev": true,
             "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/tinyrainbow": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+            "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=14.0.0"
             }
@@ -11056,7 +12286,7 @@
             "version": "6.21.0",
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
             "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/universalify": {
@@ -11301,58 +12531,80 @@
             }
         },
         "node_modules/vitest": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.6.1.tgz",
-            "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
+            "version": "4.1.9",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+            "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
-                "@vitest/expect": "1.6.1",
-                "@vitest/runner": "1.6.1",
-                "@vitest/snapshot": "1.6.1",
-                "@vitest/spy": "1.6.1",
-                "@vitest/utils": "1.6.1",
-                "acorn-walk": "^8.3.2",
-                "chai": "^4.3.10",
-                "debug": "^4.3.4",
-                "execa": "^8.0.1",
-                "local-pkg": "^0.5.0",
-                "magic-string": "^0.30.5",
-                "pathe": "^1.1.1",
-                "picocolors": "^1.0.0",
-                "std-env": "^3.5.0",
-                "strip-literal": "^2.0.0",
-                "tinybench": "^2.5.1",
-                "tinypool": "^0.8.3",
-                "vite": "^5.0.0",
-                "vite-node": "1.6.1",
-                "why-is-node-running": "^2.2.2"
+                "@vitest/expect": "4.1.9",
+                "@vitest/mocker": "4.1.9",
+                "@vitest/pretty-format": "4.1.9",
+                "@vitest/runner": "4.1.9",
+                "@vitest/snapshot": "4.1.9",
+                "@vitest/spy": "4.1.9",
+                "@vitest/utils": "4.1.9",
+                "es-module-lexer": "^2.0.0",
+                "expect-type": "^1.3.0",
+                "magic-string": "^0.30.21",
+                "obug": "^2.1.1",
+                "pathe": "^2.0.3",
+                "picomatch": "^4.0.3",
+                "std-env": "^4.0.0-rc.1",
+                "tinybench": "^2.9.0",
+                "tinyexec": "^1.0.2",
+                "tinyglobby": "^0.2.15",
+                "tinyrainbow": "^3.1.0",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+                "why-is-node-running": "^2.3.0"
             },
             "bin": {
                 "vitest": "vitest.mjs"
             },
             "engines": {
-                "node": "^18.0.0 || >=20.0.0"
+                "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
             },
             "funding": {
                 "url": "https://opencollective.com/vitest"
             },
             "peerDependencies": {
                 "@edge-runtime/vm": "*",
-                "@types/node": "^18.0.0 || >=20.0.0",
-                "@vitest/browser": "1.6.1",
-                "@vitest/ui": "1.6.1",
+                "@opentelemetry/api": "^1.9.0",
+                "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+                "@vitest/browser-playwright": "4.1.9",
+                "@vitest/browser-preview": "4.1.9",
+                "@vitest/browser-webdriverio": "4.1.9",
+                "@vitest/coverage-istanbul": "4.1.9",
+                "@vitest/coverage-v8": "4.1.9",
+                "@vitest/ui": "4.1.9",
                 "happy-dom": "*",
-                "jsdom": "*"
+                "jsdom": "*",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
             },
             "peerDependenciesMeta": {
                 "@edge-runtime/vm": {
                     "optional": true
                 },
+                "@opentelemetry/api": {
+                    "optional": true
+                },
                 "@types/node": {
                     "optional": true
                 },
-                "@vitest/browser": {
+                "@vitest/browser-playwright": {
+                    "optional": true
+                },
+                "@vitest/browser-preview": {
+                    "optional": true
+                },
+                "@vitest/browser-webdriverio": {
+                    "optional": true
+                },
+                "@vitest/coverage-istanbul": {
+                    "optional": true
+                },
+                "@vitest/coverage-v8": {
                     "optional": true
                 },
                 "@vitest/ui": {
@@ -11363,151 +12615,694 @@
                 },
                 "jsdom": {
                     "optional": true
+                },
+                "vite": {
+                    "optional": false
                 }
             }
         },
-        "node_modules/vitest/node_modules/execa": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
-            "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+        "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+            "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+            "cpu": [
+                "ppc64"
+            ],
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "os": [
+                "aix"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/android-arm": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+            "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/android-arm64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+            "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/android-x64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+            "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+            "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+            "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+            "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+            "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/linux-arm": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+            "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+            "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+            "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+            "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+            "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+            "cpu": [
+                "mips64el"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+            "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+            "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+            "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/linux-x64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+            "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+            "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+            "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+            "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+            "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+            "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/win32-x64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+            "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@vitest/expect": {
+            "version": "4.1.9",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+            "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
             "dependencies": {
-                "cross-spawn": "^7.0.3",
-                "get-stream": "^8.0.1",
-                "human-signals": "^5.0.0",
-                "is-stream": "^3.0.0",
-                "merge-stream": "^2.0.0",
-                "npm-run-path": "^5.1.0",
-                "onetime": "^6.0.0",
-                "signal-exit": "^4.1.0",
-                "strip-final-newline": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=16.17"
+                "@standard-schema/spec": "^1.1.0",
+                "@types/chai": "^5.2.2",
+                "@vitest/spy": "4.1.9",
+                "@vitest/utils": "4.1.9",
+                "chai": "^6.2.2",
+                "tinyrainbow": "^3.1.0"
             },
             "funding": {
-                "url": "https://github.com/sindresorhus/execa?sponsor=1"
+                "url": "https://opencollective.com/vitest"
             }
         },
-        "node_modules/vitest/node_modules/get-stream": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
-            "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+        "node_modules/vitest/node_modules/@vitest/mocker": {
+            "version": "4.1.9",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+            "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
             "dev": true,
             "license": "MIT",
-            "engines": {
-                "node": ">=16"
+            "peer": true,
+            "dependencies": {
+                "@vitest/spy": "4.1.9",
+                "estree-walker": "^3.0.3",
+                "magic-string": "^0.30.21"
             },
             "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "msw": "^2.4.9",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "msw": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": true
+                }
             }
         },
-        "node_modules/vitest/node_modules/human-signals": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
-            "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=16.17.0"
-            }
-        },
-        "node_modules/vitest/node_modules/is-stream": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
-            "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+        "node_modules/vitest/node_modules/@vitest/runner": {
+            "version": "4.1.9",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+            "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
             "dev": true,
             "license": "MIT",
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            "peer": true,
+            "dependencies": {
+                "@vitest/utils": "4.1.9",
+                "pathe": "^2.0.3"
             },
             "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
+                "url": "https://opencollective.com/vitest"
             }
         },
-        "node_modules/vitest/node_modules/mimic-fn": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
-            "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+        "node_modules/vitest/node_modules/@vitest/snapshot": {
+            "version": "4.1.9",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+            "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@vitest/pretty-format": "4.1.9",
+                "@vitest/utils": "4.1.9",
+                "magic-string": "^0.30.21",
+                "pathe": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/vitest/node_modules/@vitest/spy": {
+            "version": "4.1.9",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+            "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/vitest/node_modules/@vitest/utils": {
+            "version": "4.1.9",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+            "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@vitest/pretty-format": "4.1.9",
+                "convert-source-map": "^2.0.0",
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/vitest/node_modules/chai": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+            "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/esbuild": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+            "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "bin": {
+                "esbuild": "bin/esbuild"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "optionalDependencies": {
+                "@esbuild/aix-ppc64": "0.28.1",
+                "@esbuild/android-arm": "0.28.1",
+                "@esbuild/android-arm64": "0.28.1",
+                "@esbuild/android-x64": "0.28.1",
+                "@esbuild/darwin-arm64": "0.28.1",
+                "@esbuild/darwin-x64": "0.28.1",
+                "@esbuild/freebsd-arm64": "0.28.1",
+                "@esbuild/freebsd-x64": "0.28.1",
+                "@esbuild/linux-arm": "0.28.1",
+                "@esbuild/linux-arm64": "0.28.1",
+                "@esbuild/linux-ia32": "0.28.1",
+                "@esbuild/linux-loong64": "0.28.1",
+                "@esbuild/linux-mips64el": "0.28.1",
+                "@esbuild/linux-ppc64": "0.28.1",
+                "@esbuild/linux-riscv64": "0.28.1",
+                "@esbuild/linux-s390x": "0.28.1",
+                "@esbuild/linux-x64": "0.28.1",
+                "@esbuild/netbsd-arm64": "0.28.1",
+                "@esbuild/netbsd-x64": "0.28.1",
+                "@esbuild/openbsd-arm64": "0.28.1",
+                "@esbuild/openbsd-x64": "0.28.1",
+                "@esbuild/openharmony-arm64": "0.28.1",
+                "@esbuild/sunos-x64": "0.28.1",
+                "@esbuild/win32-arm64": "0.28.1",
+                "@esbuild/win32-ia32": "0.28.1",
+                "@esbuild/win32-x64": "0.28.1"
+            }
+        },
+        "node_modules/vitest/node_modules/pathe": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+            "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/vitest/node_modules/picomatch": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
             "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
+                "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
-        "node_modules/vitest/node_modules/npm-run-path": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
-            "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "path-key": "^4.0.0"
-            },
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/vitest/node_modules/onetime": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
-            "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "mimic-fn": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/vitest/node_modules/path-key": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-            "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/vitest/node_modules/signal-exit": {
+        "node_modules/vitest/node_modules/std-env": {
             "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-            "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": ">=14"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/vitest/node_modules/strip-final-newline": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
-            "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+            "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+            "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true
+        },
+        "node_modules/vitest/node_modules/vite": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.0.tgz",
+            "integrity": "sha512-BuJcQK/56NQTWDGn4ABea3q4SSBdNPWwNZKTkkUpcMPnLoquSYH8llRtSUIgoL1KSCpHt5eghLShn50mH36y7Q==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "lightningcss": "^1.32.0",
+                "picomatch": "^4.0.4",
+                "postcss": "^8.5.15",
+                "rolldown": "~1.1.2",
+                "tinyglobby": "^0.2.17"
+            },
+            "bin": {
+                "vite": "bin/vite.js"
+            },
             "engines": {
-                "node": ">=12"
+                "node": "^20.19.0 || >=22.12.0"
             },
             "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
+                "url": "https://github.com/vitejs/vite?sponsor=1"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.3"
+            },
+            "peerDependencies": {
+                "@types/node": "^20.19.0 || >=22.12.0",
+                "@vitejs/devtools": "^0.3.0",
+                "esbuild": "^0.27.0 || ^0.28.0",
+                "jiti": ">=1.21.0",
+                "less": "^4.0.0",
+                "sass": "^1.70.0",
+                "sass-embedded": "^1.70.0",
+                "stylus": ">=0.54.8",
+                "sugarss": "^5.0.0",
+                "terser": "^5.16.0",
+                "tsx": "^4.8.1",
+                "yaml": "^2.4.2"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                },
+                "@vitejs/devtools": {
+                    "optional": true
+                },
+                "esbuild": {
+                    "optional": true
+                },
+                "jiti": {
+                    "optional": true
+                },
+                "less": {
+                    "optional": true
+                },
+                "sass": {
+                    "optional": true
+                },
+                "sass-embedded": {
+                    "optional": true
+                },
+                "stylus": {
+                    "optional": true
+                },
+                "sugarss": {
+                    "optional": true
+                },
+                "terser": {
+                    "optional": true
+                },
+                "tsx": {
+                    "optional": true
+                },
+                "yaml": {
+                    "optional": true
+                }
             }
         },
         "node_modules/w3c-xmlserializer": {
@@ -11857,6 +13652,216 @@
                 "vitest": "^1.1.0"
             }
         },
+        "packages/sdk/node_modules/execa": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+            "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cross-spawn": "^7.0.3",
+                "get-stream": "^8.0.1",
+                "human-signals": "^5.0.0",
+                "is-stream": "^3.0.0",
+                "merge-stream": "^2.0.0",
+                "npm-run-path": "^5.1.0",
+                "onetime": "^6.0.0",
+                "signal-exit": "^4.1.0",
+                "strip-final-newline": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=16.17"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/execa?sponsor=1"
+            }
+        },
+        "packages/sdk/node_modules/get-stream": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+            "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "packages/sdk/node_modules/human-signals": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+            "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=16.17.0"
+            }
+        },
+        "packages/sdk/node_modules/is-stream": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+            "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "packages/sdk/node_modules/mimic-fn": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+            "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "packages/sdk/node_modules/npm-run-path": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+            "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "path-key": "^4.0.0"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "packages/sdk/node_modules/onetime": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+            "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mimic-fn": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "packages/sdk/node_modules/path-key": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+            "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "packages/sdk/node_modules/signal-exit": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+            "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "packages/sdk/node_modules/strip-final-newline": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+            "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "packages/sdk/node_modules/vitest": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.6.1.tgz",
+            "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/expect": "1.6.1",
+                "@vitest/runner": "1.6.1",
+                "@vitest/snapshot": "1.6.1",
+                "@vitest/spy": "1.6.1",
+                "@vitest/utils": "1.6.1",
+                "acorn-walk": "^8.3.2",
+                "chai": "^4.3.10",
+                "debug": "^4.3.4",
+                "execa": "^8.0.1",
+                "local-pkg": "^0.5.0",
+                "magic-string": "^0.30.5",
+                "pathe": "^1.1.1",
+                "picocolors": "^1.0.0",
+                "std-env": "^3.5.0",
+                "strip-literal": "^2.0.0",
+                "tinybench": "^2.5.1",
+                "tinypool": "^0.8.3",
+                "vite": "^5.0.0",
+                "vite-node": "1.6.1",
+                "why-is-node-running": "^2.2.2"
+            },
+            "bin": {
+                "vitest": "vitest.mjs"
+            },
+            "engines": {
+                "node": "^18.0.0 || >=20.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "@edge-runtime/vm": "*",
+                "@types/node": "^18.0.0 || >=20.0.0",
+                "@vitest/browser": "1.6.1",
+                "@vitest/ui": "1.6.1",
+                "happy-dom": "*",
+                "jsdom": "*"
+            },
+            "peerDependenciesMeta": {
+                "@edge-runtime/vm": {
+                    "optional": true
+                },
+                "@types/node": {
+                    "optional": true
+                },
+                "@vitest/browser": {
+                    "optional": true
+                },
+                "@vitest/ui": {
+                    "optional": true
+                },
+                "happy-dom": {
+                    "optional": true
+                },
+                "jsdom": {
+                    "optional": true
+                }
+            }
+        },
         "packages/stellar": {
             "name": "@craft/stellar",
             "version": "0.1.0",
@@ -11870,6 +13875,216 @@
                 "vitest": "^1.1.0"
             }
         },
+        "packages/stellar/node_modules/execa": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+            "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cross-spawn": "^7.0.3",
+                "get-stream": "^8.0.1",
+                "human-signals": "^5.0.0",
+                "is-stream": "^3.0.0",
+                "merge-stream": "^2.0.0",
+                "npm-run-path": "^5.1.0",
+                "onetime": "^6.0.0",
+                "signal-exit": "^4.1.0",
+                "strip-final-newline": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=16.17"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/execa?sponsor=1"
+            }
+        },
+        "packages/stellar/node_modules/get-stream": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+            "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "packages/stellar/node_modules/human-signals": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+            "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=16.17.0"
+            }
+        },
+        "packages/stellar/node_modules/is-stream": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+            "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "packages/stellar/node_modules/mimic-fn": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+            "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "packages/stellar/node_modules/npm-run-path": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+            "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "path-key": "^4.0.0"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "packages/stellar/node_modules/onetime": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+            "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mimic-fn": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "packages/stellar/node_modules/path-key": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+            "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "packages/stellar/node_modules/signal-exit": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+            "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "packages/stellar/node_modules/strip-final-newline": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+            "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "packages/stellar/node_modules/vitest": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.6.1.tgz",
+            "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/expect": "1.6.1",
+                "@vitest/runner": "1.6.1",
+                "@vitest/snapshot": "1.6.1",
+                "@vitest/spy": "1.6.1",
+                "@vitest/utils": "1.6.1",
+                "acorn-walk": "^8.3.2",
+                "chai": "^4.3.10",
+                "debug": "^4.3.4",
+                "execa": "^8.0.1",
+                "local-pkg": "^0.5.0",
+                "magic-string": "^0.30.5",
+                "pathe": "^1.1.1",
+                "picocolors": "^1.0.0",
+                "std-env": "^3.5.0",
+                "strip-literal": "^2.0.0",
+                "tinybench": "^2.5.1",
+                "tinypool": "^0.8.3",
+                "vite": "^5.0.0",
+                "vite-node": "1.6.1",
+                "why-is-node-running": "^2.2.2"
+            },
+            "bin": {
+                "vitest": "vitest.mjs"
+            },
+            "engines": {
+                "node": "^18.0.0 || >=20.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "@edge-runtime/vm": "*",
+                "@types/node": "^18.0.0 || >=20.0.0",
+                "@vitest/browser": "1.6.1",
+                "@vitest/ui": "1.6.1",
+                "happy-dom": "*",
+                "jsdom": "*"
+            },
+            "peerDependenciesMeta": {
+                "@edge-runtime/vm": {
+                    "optional": true
+                },
+                "@types/node": {
+                    "optional": true
+                },
+                "@vitest/browser": {
+                    "optional": true
+                },
+                "@vitest/ui": {
+                    "optional": true
+                },
+                "happy-dom": {
+                    "optional": true
+                },
+                "jsdom": {
+                    "optional": true
+                }
+            }
+        },
         "packages/types": {
             "name": "@craft/types",
             "version": "0.1.0",
@@ -11877,6 +14092,216 @@
                 "@types/node": "^20.10.6",
                 "typescript": "^5.3.3",
                 "vitest": "^1.1.0"
+            }
+        },
+        "packages/types/node_modules/execa": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+            "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cross-spawn": "^7.0.3",
+                "get-stream": "^8.0.1",
+                "human-signals": "^5.0.0",
+                "is-stream": "^3.0.0",
+                "merge-stream": "^2.0.0",
+                "npm-run-path": "^5.1.0",
+                "onetime": "^6.0.0",
+                "signal-exit": "^4.1.0",
+                "strip-final-newline": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=16.17"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/execa?sponsor=1"
+            }
+        },
+        "packages/types/node_modules/get-stream": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+            "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "packages/types/node_modules/human-signals": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+            "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=16.17.0"
+            }
+        },
+        "packages/types/node_modules/is-stream": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+            "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "packages/types/node_modules/mimic-fn": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+            "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "packages/types/node_modules/npm-run-path": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+            "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "path-key": "^4.0.0"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "packages/types/node_modules/onetime": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+            "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mimic-fn": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "packages/types/node_modules/path-key": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+            "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "packages/types/node_modules/signal-exit": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+            "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "packages/types/node_modules/strip-final-newline": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+            "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "packages/types/node_modules/vitest": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.6.1.tgz",
+            "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/expect": "1.6.1",
+                "@vitest/runner": "1.6.1",
+                "@vitest/snapshot": "1.6.1",
+                "@vitest/spy": "1.6.1",
+                "@vitest/utils": "1.6.1",
+                "acorn-walk": "^8.3.2",
+                "chai": "^4.3.10",
+                "debug": "^4.3.4",
+                "execa": "^8.0.1",
+                "local-pkg": "^0.5.0",
+                "magic-string": "^0.30.5",
+                "pathe": "^1.1.1",
+                "picocolors": "^1.0.0",
+                "std-env": "^3.5.0",
+                "strip-literal": "^2.0.0",
+                "tinybench": "^2.5.1",
+                "tinypool": "^0.8.3",
+                "vite": "^5.0.0",
+                "vite-node": "1.6.1",
+                "why-is-node-running": "^2.2.2"
+            },
+            "bin": {
+                "vitest": "vitest.mjs"
+            },
+            "engines": {
+                "node": "^18.0.0 || >=20.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "@edge-runtime/vm": "*",
+                "@types/node": "^18.0.0 || >=20.0.0",
+                "@vitest/browser": "1.6.1",
+                "@vitest/ui": "1.6.1",
+                "happy-dom": "*",
+                "jsdom": "*"
+            },
+            "peerDependenciesMeta": {
+                "@edge-runtime/vm": {
+                    "optional": true
+                },
+                "@types/node": {
+                    "optional": true
+                },
+                "@vitest/browser": {
+                    "optional": true
+                },
+                "@vitest/ui": {
+                    "optional": true
+                },
+                "happy-dom": {
+                    "optional": true
+                },
+                "jsdom": {
+                    "optional": true
+                }
             }
         },
         "packages/ui": {

--- a/packages/stellar/src/__snapshots__/config.test.ts.snap
+++ b/packages/stellar/src/__snapshots__/config.test.ts.snap
@@ -1,0 +1,120 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Stellar Config — Snapshot Regression Tests (#540) > Configuration Consistency > should have all required fields in config output 1`] = `
+[
+  "horizonUrl",
+  "network",
+  "networkPassphrase",
+  "sorobanRpcUrl",
+]
+`;
+
+exports[`Stellar Config — Snapshot Regression Tests (#540) > Configuration Consistency > should have matching network keys across all config objects 1`] = `
+[
+  "mainnet",
+  "testnet",
+]
+`;
+
+exports[`Stellar Config — Snapshot Regression Tests (#540) > Configuration Consistency > should return consistent config shape for all networks 1`] = `
+[
+  "horizonUrl",
+  "network",
+  "networkPassphrase",
+  "sorobanRpcUrl",
+]
+`;
+
+exports[`Stellar Config — Snapshot Regression Tests (#540) > Network Configuration Constants > should have all required networks in HORIZON_URLS 1`] = `
+[
+  "mainnet",
+  "testnet",
+]
+`;
+
+exports[`Stellar Config — Snapshot Regression Tests (#540) > Network Configuration Constants > should have all required networks in NETWORK_PASSPHRASES 1`] = `
+[
+  "mainnet",
+  "testnet",
+]
+`;
+
+exports[`Stellar Config — Snapshot Regression Tests (#540) > Network Configuration Constants > should have all required networks in SOROBAN_RPC_URLS 1`] = `
+[
+  "mainnet",
+  "testnet",
+]
+`;
+
+exports[`Stellar Config — Snapshot Regression Tests (#540) > Network Configuration Constants > should match snapshot for HORIZON_URLS 1`] = `
+{
+  "mainnet": "https://horizon.stellar.org",
+  "testnet": "https://horizon-testnet.stellar.org",
+}
+`;
+
+exports[`Stellar Config — Snapshot Regression Tests (#540) > Network Configuration Constants > should match snapshot for NETWORK_PASSPHRASES 1`] = `
+{
+  "mainnet": "Public Global Stellar Network ; September 2015",
+  "testnet": "Test SDF Network ; September 2015",
+}
+`;
+
+exports[`Stellar Config — Snapshot Regression Tests (#540) > Network Configuration Constants > should match snapshot for SOROBAN_RPC_URLS 1`] = `
+{
+  "mainnet": "https://mainnet.stellar.validationcloud.io/v1/soroban/rpc",
+  "testnet": "https://soroban-testnet.stellar.org",
+}
+`;
+
+exports[`Stellar Config — Snapshot Regression Tests (#540) > Passphrase Format Validation > should have valid Stellar network passphrases 1`] = `"Public Global Stellar Network ; September 2015"`;
+
+exports[`Stellar Config — Snapshot Regression Tests (#540) > Passphrase Format Validation > should have valid Stellar network passphrases 2`] = `"Test SDF Network ; September 2015"`;
+
+exports[`Stellar Config — Snapshot Regression Tests (#540) > Serialization Stability > should deserialize and re-serialize to same value 1`] = `"{"network":"testnet","horizonUrl":"https://horizon-testnet.stellar.org","networkPassphrase":"Test SDF Network ; September 2015","sorobanRpcUrl":"https://soroban-testnet.stellar.org"}"`;
+
+exports[`Stellar Config — Snapshot Regression Tests (#540) > Serialization Stability > should serialize mainnet config consistently 1`] = `"{"network":"mainnet","horizonUrl":"https://horizon.stellar.org","networkPassphrase":"Public Global Stellar Network ; September 2015","sorobanRpcUrl":"https://mainnet.stellar.validationcloud.io/v1/soroban/rpc"}"`;
+
+exports[`Stellar Config — Snapshot Regression Tests (#540) > Serialization Stability > should serialize testnet config consistently 1`] = `"{"network":"testnet","horizonUrl":"https://horizon-testnet.stellar.org","networkPassphrase":"Test SDF Network ; September 2015","sorobanRpcUrl":"https://soroban-testnet.stellar.org"}"`;
+
+exports[`Stellar Config — Snapshot Regression Tests (#540) > URL Format Validation > should have valid HTTPS URLs for Horizon endpoints 1`] = `"https://horizon.stellar.org"`;
+
+exports[`Stellar Config — Snapshot Regression Tests (#540) > URL Format Validation > should have valid HTTPS URLs for Horizon endpoints 2`] = `"https://horizon-testnet.stellar.org"`;
+
+exports[`Stellar Config — Snapshot Regression Tests (#540) > URL Format Validation > should have valid HTTPS URLs for Soroban RPC endpoints 1`] = `"https://mainnet.stellar.validationcloud.io/v1/soroban/rpc"`;
+
+exports[`Stellar Config — Snapshot Regression Tests (#540) > URL Format Validation > should have valid HTTPS URLs for Soroban RPC endpoints 2`] = `"https://soroban-testnet.stellar.org"`;
+
+exports[`Stellar Config — Snapshot Regression Tests (#540) > getNetworkConfig — mainnet > should have correct Horizon URL for mainnet 1`] = `"https://horizon.stellar.org"`;
+
+exports[`Stellar Config — Snapshot Regression Tests (#540) > getNetworkConfig — mainnet > should have correct Soroban RPC URL for mainnet 1`] = `"https://mainnet.stellar.validationcloud.io/v1/soroban/rpc"`;
+
+exports[`Stellar Config — Snapshot Regression Tests (#540) > getNetworkConfig — mainnet > should have correct network passphrase for mainnet 1`] = `"Public Global Stellar Network ; September 2015"`;
+
+exports[`Stellar Config — Snapshot Regression Tests (#540) > getNetworkConfig — mainnet > should have network field set to mainnet 1`] = `"mainnet"`;
+
+exports[`Stellar Config — Snapshot Regression Tests (#540) > getNetworkConfig — mainnet > should match snapshot for mainnet configuration 1`] = `
+{
+  "horizonUrl": "https://horizon.stellar.org",
+  "network": "mainnet",
+  "networkPassphrase": "Public Global Stellar Network ; September 2015",
+  "sorobanRpcUrl": "https://mainnet.stellar.validationcloud.io/v1/soroban/rpc",
+}
+`;
+
+exports[`Stellar Config — Snapshot Regression Tests (#540) > getNetworkConfig — testnet > should have correct Horizon URL for testnet 1`] = `"https://horizon-testnet.stellar.org"`;
+
+exports[`Stellar Config — Snapshot Regression Tests (#540) > getNetworkConfig — testnet > should have correct Soroban RPC URL for testnet 1`] = `"https://soroban-testnet.stellar.org"`;
+
+exports[`Stellar Config — Snapshot Regression Tests (#540) > getNetworkConfig — testnet > should have correct network passphrase for testnet 1`] = `"Test SDF Network ; September 2015"`;
+
+exports[`Stellar Config — Snapshot Regression Tests (#540) > getNetworkConfig — testnet > should have network field set to testnet 1`] = `"testnet"`;
+
+exports[`Stellar Config — Snapshot Regression Tests (#540) > getNetworkConfig — testnet > should match snapshot for testnet configuration 1`] = `
+{
+  "horizonUrl": "https://horizon-testnet.stellar.org",
+  "network": "testnet",
+  "networkPassphrase": "Test SDF Network ; September 2015",
+  "sorobanRpcUrl": "https://soroban-testnet.stellar.org",
+}
+`;

--- a/packages/stellar/src/account-merge-protection.test.ts
+++ b/packages/stellar/src/account-merge-protection.test.ts
@@ -1,0 +1,286 @@
+/**
+ * Account Merge Protection Tests (#785)
+ *
+ * Covers: blocked merge (open trustlines), allowed merge, balance transfer
+ * verification, active-offer blocking, wrong-destination blocking, and audit logging.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+    Networks,
+    Keypair,
+    TransactionBuilder,
+    BASE_FEE,
+    Operation,
+    Asset,
+} from 'stellar-sdk';
+import {
+    inspectMergeTransaction,
+    checkMergeAllowed,
+    protectAgainstMerge,
+    registerManagedAccount,
+    isManagedAccount,
+    onMergeDetected,
+    getMergeAuditLog,
+    clearMergeAuditLog,
+    clearManagedAccounts,
+    type AccountState,
+    type MergeOperation,
+} from './account-merge-protection';
+
+const NETWORK = Networks.TESTNET;
+const SOURCE_KP = Keypair.random();
+const DEST_KP = Keypair.random();
+
+function buildMergeTxXdr(sourceKp: Keypair, destination: string): string {
+    const account = {
+        accountId: () => sourceKp.publicKey(),
+        sequenceNumber: () => '200',
+        incrementSequenceNumber: () => {},
+    } as any;
+
+    const tx = new TransactionBuilder(account, { fee: BASE_FEE, networkPassphrase: NETWORK })
+        .addOperation(Operation.accountMerge({ destination }))
+        .setTimeout(30)
+        .build();
+
+    tx.sign(sourceKp);
+    return tx.toXDR();
+}
+
+function buildPaymentTxXdr(): string {
+    const account = {
+        accountId: () => SOURCE_KP.publicKey(),
+        sequenceNumber: () => '200',
+        incrementSequenceNumber: () => {},
+    } as any;
+
+    const tx = new TransactionBuilder(account, { fee: BASE_FEE, networkPassphrase: NETWORK })
+        .addOperation(
+            Operation.payment({
+                destination: DEST_KP.publicKey(),
+                asset: Asset.native(),
+                amount: '1',
+            }),
+        )
+        .setTimeout(30)
+        .build();
+
+    tx.sign(SOURCE_KP);
+    return tx.toXDR();
+}
+
+function makeAccountState(overrides: Partial<AccountState> = {}): AccountState {
+    return {
+        trustlines: [],
+        offers: [],
+        xlmBalanceStroops: '10000000',
+        ...overrides,
+    };
+}
+
+beforeEach(() => {
+    clearMergeAuditLog();
+    clearManagedAccounts();
+});
+
+// ---------------------------------------------------------------------------
+// inspectMergeTransaction
+// ---------------------------------------------------------------------------
+
+describe('inspectMergeTransaction', () => {
+    it('detects an AccountMerge operation', () => {
+        const txXdr = buildMergeTxXdr(SOURCE_KP, DEST_KP.publicKey());
+        const merges = inspectMergeTransaction(txXdr, NETWORK);
+
+        expect(merges).toHaveLength(1);
+        expect(merges[0].sourceAccount).toBe(SOURCE_KP.publicKey());
+        expect(merges[0].destination).toBe(DEST_KP.publicKey());
+    });
+
+    it('returns empty array when no merge operation is present', () => {
+        const txXdr = buildPaymentTxXdr();
+        const merges = inspectMergeTransaction(txXdr, NETWORK);
+
+        expect(merges).toHaveLength(0);
+    });
+
+    it('returns empty array for invalid XDR', () => {
+        const merges = inspectMergeTransaction('not-valid-xdr', NETWORK);
+        expect(merges).toHaveLength(0);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// checkMergeAllowed
+// ---------------------------------------------------------------------------
+
+describe('checkMergeAllowed – blocked merge (open trustlines)', () => {
+    it('blocks merge when account has open trustlines', () => {
+        const merge: MergeOperation = {
+            sourceAccount: SOURCE_KP.publicKey(),
+            destination: DEST_KP.publicKey(),
+        };
+        const state = makeAccountState({
+            trustlines: [
+                { assetCode: 'USDC', assetIssuer: 'GABC...', balance: '100', limit: '1000' },
+            ],
+        });
+
+        const decision = checkMergeAllowed(merge, state);
+
+        expect(decision.allowed).toBe(false);
+        if (decision.allowed) return;
+        expect(decision.reason).toMatch(/trustline/);
+    });
+
+    it('blocks merge when account has active DEX offers', () => {
+        const merge: MergeOperation = {
+            sourceAccount: SOURCE_KP.publicKey(),
+            destination: DEST_KP.publicKey(),
+        };
+        const state = makeAccountState({ offers: [{ id: 'offer-1' }] });
+
+        const decision = checkMergeAllowed(merge, state);
+
+        expect(decision.allowed).toBe(false);
+        if (decision.allowed) return;
+        expect(decision.reason).toMatch(/offer/);
+    });
+
+    it('blocks merge when destination does not match expected', () => {
+        const merge: MergeOperation = {
+            sourceAccount: SOURCE_KP.publicKey(),
+            destination: DEST_KP.publicKey(),
+        };
+        const state = makeAccountState();
+        const wrongExpected = Keypair.random().publicKey();
+
+        const decision = checkMergeAllowed(merge, state, wrongExpected);
+
+        expect(decision.allowed).toBe(false);
+        if (decision.allowed) return;
+        expect(decision.reason).toMatch(/destination/);
+    });
+});
+
+describe('checkMergeAllowed – allowed merge', () => {
+    it('allows merge when no trustlines, no offers, and destination matches', () => {
+        const merge: MergeOperation = {
+            sourceAccount: SOURCE_KP.publicKey(),
+            destination: DEST_KP.publicKey(),
+        };
+        const state = makeAccountState({ xlmBalanceStroops: '50000000' });
+
+        const decision = checkMergeAllowed(merge, state, DEST_KP.publicKey());
+
+        expect(decision.allowed).toBe(true);
+    });
+
+    it('allows merge when no expectedDestination is enforced', () => {
+        const merge: MergeOperation = {
+            sourceAccount: SOURCE_KP.publicKey(),
+            destination: DEST_KP.publicKey(),
+        };
+        const state = makeAccountState();
+
+        const decision = checkMergeAllowed(merge, state);
+
+        expect(decision.allowed).toBe(true);
+    });
+});
+
+describe('checkMergeAllowed – residual balance verification', () => {
+    it('returns the residual XLM balance when allowed', () => {
+        const merge: MergeOperation = {
+            sourceAccount: SOURCE_KP.publicKey(),
+            destination: DEST_KP.publicKey(),
+        };
+        const state = makeAccountState({ xlmBalanceStroops: '75000000' });
+
+        const decision = checkMergeAllowed(merge, state);
+
+        expect(decision.allowed).toBe(true);
+        if (!decision.allowed) return;
+        expect(decision.residualXlmStroops).toBe('75000000');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// protectAgainstMerge (integration)
+// ---------------------------------------------------------------------------
+
+describe('protectAgainstMerge', () => {
+    it('returns a decision map with one entry for a merge transaction', async () => {
+        const txXdr = buildMergeTxXdr(SOURCE_KP, DEST_KP.publicKey());
+        const getState = vi.fn().mockResolvedValue(makeAccountState());
+
+        const decisions = await protectAgainstMerge(txXdr, NETWORK, getState);
+
+        expect(decisions.size).toBe(1);
+        expect(decisions.get(SOURCE_KP.publicKey())?.allowed).toBe(true);
+    });
+
+    it('returns an empty map for a transaction without merge ops', async () => {
+        const txXdr = buildPaymentTxXdr();
+        const getState = vi.fn();
+
+        const decisions = await protectAgainstMerge(txXdr, NETWORK, getState);
+
+        expect(decisions.size).toBe(0);
+        expect(getState).not.toHaveBeenCalled();
+    });
+
+    it('emits an audit log entry when a merge is detected', async () => {
+        const txXdr = buildMergeTxXdr(SOURCE_KP, DEST_KP.publicKey());
+        const getState = vi.fn().mockResolvedValue(makeAccountState());
+
+        await protectAgainstMerge(txXdr, NETWORK, getState);
+
+        const log = getMergeAuditLog();
+        expect(log).toHaveLength(1);
+        expect(log[0].sourceAccount).toBe(SOURCE_KP.publicKey());
+        expect(log[0].destination).toBe(DEST_KP.publicKey());
+    });
+
+    it('fires onMergeDetected handlers when a merge is detected', async () => {
+        const handler = vi.fn();
+        const off = onMergeDetected(handler);
+
+        const txXdr = buildMergeTxXdr(SOURCE_KP, DEST_KP.publicKey());
+        const getState = vi.fn().mockResolvedValue(makeAccountState());
+
+        await protectAgainstMerge(txXdr, NETWORK, getState);
+
+        expect(handler).toHaveBeenCalledOnce();
+        expect(handler.mock.calls[0][0].sourceAccount).toBe(SOURCE_KP.publicKey());
+        off();
+    });
+
+    it('records blocked merges in the audit log', async () => {
+        const txXdr = buildMergeTxXdr(SOURCE_KP, DEST_KP.publicKey());
+        const getState = vi.fn().mockResolvedValue(
+            makeAccountState({
+                trustlines: [{ assetCode: 'USDC', assetIssuer: 'GABC', balance: '50', limit: '1000' }],
+            }),
+        );
+
+        const decisions = await protectAgainstMerge(txXdr, NETWORK, getState);
+
+        expect(decisions.get(SOURCE_KP.publicKey())?.allowed).toBe(false);
+        const log = getMergeAuditLog();
+        expect(log[0].decision.allowed).toBe(false);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Managed-account registry
+// ---------------------------------------------------------------------------
+
+describe('managed-account registry', () => {
+    it('registers and checks managed accounts', () => {
+        expect(isManagedAccount(SOURCE_KP.publicKey())).toBe(false);
+        registerManagedAccount(SOURCE_KP.publicKey());
+        expect(isManagedAccount(SOURCE_KP.publicKey())).toBe(true);
+    });
+});

--- a/packages/stellar/src/account-merge-protection.ts
+++ b/packages/stellar/src/account-merge-protection.ts
@@ -1,0 +1,246 @@
+/**
+ * Stellar Account Merge Protection Service (#785)
+ *
+ * Detects `ACCOUNT_MERGE` operations targeting platform-managed accounts,
+ * blocks merges when the account has open trustlines or active offers, and
+ * verifies the residual XLM balance is transferred to the correct destination.
+ *
+ * ## Why this matters
+ * `ACCOUNT_MERGE` permanently removes an account and transfers its XLM balance
+ * to a destination.  If a deployment account is merged accidentally it becomes
+ * unrecoverable – all contract associations and remaining balances are lost.
+ *
+ * ## Flow
+ * 1. Call `inspectMergeTransaction(txXdr, networkPassphrase)` to scan a
+ *    submitted transaction for any `AccountMerge` operations.
+ * 2. For each detected merge, call `checkMergeAllowed` with the account's
+ *    current trustline/offer state (injected via `AccountStateProvider`).
+ * 3. If allowed, emit an audit log entry via the registered audit handler.
+ *
+ * ## Extending for production
+ * - Replace the in-memory audit log with a Supabase insert.
+ * - Wire `checkMergeAllowed` into your transaction pre-flight middleware.
+ */
+
+import { TransactionBuilder } from 'stellar-sdk';
+import type { Transaction } from 'stellar-sdk';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface MergeOperation {
+    /** Public key of the account being merged (source account). */
+    sourceAccount: string;
+    /** Destination account that will receive the XLM balance. */
+    destination: string;
+}
+
+export interface AccountState {
+    /** Non-native asset balances; an open trustline is one with limit > 0. */
+    trustlines: Array<{ assetCode: string; assetIssuer: string; balance: string; limit: string }>;
+    /** Active offers on the DEX (buy or sell). */
+    offers: Array<{ id: string }>;
+    /** Current XLM balance in stroops. */
+    xlmBalanceStroops: string;
+}
+
+export type MergeDecision =
+    | { allowed: true; residualXlmStroops: string }
+    | { allowed: false; reason: string };
+
+export interface MergeAuditEntry {
+    timestamp: number;
+    sourceAccount: string;
+    destination: string;
+    decision: MergeDecision;
+    txXdr: string;
+}
+
+/** Called for every detected merge, whether allowed or blocked. */
+export type MergeAuditHandler = (entry: MergeAuditEntry) => void;
+
+// ---------------------------------------------------------------------------
+// Managed-account registry
+// ---------------------------------------------------------------------------
+
+const managedAccounts = new Set<string>();
+
+/** Register an account as platform-managed (subject to merge protection). */
+export function registerManagedAccount(publicKey: string): void {
+    managedAccounts.add(publicKey);
+}
+
+/** Deregister a managed account. */
+export function deregisterManagedAccount(publicKey: string): void {
+    managedAccounts.delete(publicKey);
+}
+
+/** Return whether the given public key is a platform-managed account. */
+export function isManagedAccount(publicKey: string): boolean {
+    return managedAccounts.has(publicKey);
+}
+
+/** Flush the managed-account registry. Call in test teardown. */
+export function clearManagedAccounts(): void {
+    managedAccounts.clear();
+}
+
+// ---------------------------------------------------------------------------
+// Audit log
+// ---------------------------------------------------------------------------
+
+const auditLog: MergeAuditEntry[] = [];
+const auditHandlers: MergeAuditHandler[] = [];
+
+/** Return a read-only snapshot of all recorded audit entries. */
+export function getMergeAuditLog(): readonly MergeAuditEntry[] {
+    return auditLog;
+}
+
+/** Register a handler invoked whenever a merge is detected. Returns an unsubscribe fn. */
+export function onMergeDetected(handler: MergeAuditHandler): () => void {
+    auditHandlers.push(handler);
+    return () => {
+        const idx = auditHandlers.indexOf(handler);
+        if (idx !== -1) auditHandlers.splice(idx, 1);
+    };
+}
+
+/** Flush the audit log. Call in test teardown. */
+export function clearMergeAuditLog(): void {
+    auditLog.length = 0;
+}
+
+// ---------------------------------------------------------------------------
+// Core logic
+// ---------------------------------------------------------------------------
+
+/**
+ * Scan a transaction XDR for `AccountMerge` operations.
+ *
+ * @returns An array of detected merge operations (may be empty).
+ */
+export function inspectMergeTransaction(
+    txXdr: string,
+    networkPassphrase: string,
+): MergeOperation[] {
+    let tx: Transaction;
+    try {
+        tx = TransactionBuilder.fromXDR(txXdr, networkPassphrase) as Transaction;
+    } catch {
+        return [];
+    }
+
+    const merges: MergeOperation[] = [];
+    const sourceAccount = tx.source;
+
+    for (const op of tx.operations) {
+        if (op.type === 'accountMerge') {
+            // The source of a merge op defaults to the transaction source account
+            // unless overridden at the operation level.
+            const opSource = (op as any).source ?? sourceAccount;
+            merges.push({
+                sourceAccount: opSource,
+                destination: (op as any).destination as string,
+            });
+        }
+    }
+
+    return merges;
+}
+
+/**
+ * Determine whether a detected merge operation should be allowed.
+ *
+ * Rules:
+ * 1. Accounts with open trustlines (limit > 0 and balance > 0) are blocked –
+ *    they cannot be merged until trustlines are cleared.
+ * 2. Accounts with active offers are blocked.
+ * 3. The expected destination must match the actual operation destination.
+ *
+ * @param merge               - The detected merge operation
+ * @param accountState        - Current on-chain state of the source account
+ * @param expectedDestination - Optional override for the required destination
+ */
+export function checkMergeAllowed(
+    merge: MergeOperation,
+    accountState: AccountState,
+    expectedDestination?: string,
+): MergeDecision {
+    // Check open trustlines (non-zero balance or limit)
+    const openTrustlines = accountState.trustlines.filter(
+        (t) => Number(t.limit) > 0,
+    );
+    if (openTrustlines.length > 0) {
+        return {
+            allowed: false,
+            reason: `Account has ${openTrustlines.length} open trustline(s): ${openTrustlines
+                .map((t) => `${t.assetCode}:${t.assetIssuer}`)
+                .join(', ')}`,
+        };
+    }
+
+    // Check active offers
+    if (accountState.offers.length > 0) {
+        return {
+            allowed: false,
+            reason: `Account has ${accountState.offers.length} active offer(s) on the DEX`,
+        };
+    }
+
+    // Verify destination matches expected
+    if (expectedDestination && merge.destination !== expectedDestination) {
+        return {
+            allowed: false,
+            reason: `Merge destination '${merge.destination}' does not match expected '${expectedDestination}'`,
+        };
+    }
+
+    return {
+        allowed: true,
+        residualXlmStroops: accountState.xlmBalanceStroops,
+    };
+}
+
+/**
+ * Full protection check: inspect the transaction, evaluate each merge
+ * against the provided account states, emit audit entries, and return
+ * a per-merge decision map.
+ *
+ * @param txXdr             - Transaction XDR to inspect
+ * @param networkPassphrase - Stellar network passphrase
+ * @param getAccountState   - Provider called for each detected merge's source account
+ * @param expectedDestination - Optional required destination for all merges
+ */
+export async function protectAgainstMerge(
+    txXdr: string,
+    networkPassphrase: string,
+    getAccountState: (publicKey: string) => Promise<AccountState>,
+    expectedDestination?: string,
+): Promise<Map<string, MergeDecision>> {
+    const merges = inspectMergeTransaction(txXdr, networkPassphrase);
+    const decisions = new Map<string, MergeDecision>();
+
+    for (const merge of merges) {
+        const state = await getAccountState(merge.sourceAccount);
+        const decision = checkMergeAllowed(merge, state, expectedDestination);
+
+        const entry: MergeAuditEntry = {
+            timestamp: Date.now(),
+            sourceAccount: merge.sourceAccount,
+            destination: merge.destination,
+            decision,
+            txXdr,
+        };
+
+        auditLog.push(entry);
+        for (const handler of auditHandlers) {
+            handler(entry);
+        }
+
+        decisions.set(merge.sourceAccount, decision);
+    }
+
+    return decisions;
+}

--- a/packages/stellar/src/fee-bump-orchestrator.test.ts
+++ b/packages/stellar/src/fee-bump-orchestrator.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Fee-Bump Orchestrator Tests (#784)
+ *
+ * Covers: valid wrapping, invalid inner transaction rejection, and fee tracking.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Networks, Keypair, TransactionBuilder, BASE_FEE, Operation, Asset } from 'stellar-sdk';
+import {
+    orchestrateFeeBump,
+    clearFeeBumpUsage,
+    getFeeBumpUsage,
+} from './fee-bump-orchestrator';
+
+const NETWORK_PASSPHRASE = Networks.TESTNET;
+const SOURCE_KEYPAIR = Keypair.random();
+const FEE_SOURCE_PUBKEY = Keypair.random().publicKey();
+const USER_ID = 'user-abc-123';
+
+function buildSignedInnerTxXdr(): string {
+    const account = {
+        accountId: () => SOURCE_KEYPAIR.publicKey(),
+        sequenceNumber: () => '100',
+        incrementSequenceNumber: () => {},
+    } as any;
+
+    const tx = new TransactionBuilder(account, {
+        fee: BASE_FEE,
+        networkPassphrase: NETWORK_PASSPHRASE,
+    })
+        .addOperation(
+            Operation.payment({
+                destination: Keypair.random().publicKey(),
+                asset: Asset.native(),
+                amount: '1',
+            }),
+        )
+        .setTimeout(30)
+        .build();
+
+    tx.sign(SOURCE_KEYPAIR);
+    return tx.toXDR();
+}
+
+function makeMockBuildFeeBump(feeCharged: number) {
+    return vi.fn().mockResolvedValue({
+        ok: true,
+        feeBumpXdr: 'mock-fee-bump-xdr',
+        feeCharged,
+    });
+}
+
+beforeEach(() => {
+    clearFeeBumpUsage();
+});
+
+describe('orchestrateFeeBump – valid wrapping', () => {
+    it('returns ok:true with feeBumpXdr and feeCharged when inner tx is valid', async () => {
+        const innerXdr = buildSignedInnerTxXdr();
+        const mockBuild = makeMockBuildFeeBump(300);
+
+        const result = await orchestrateFeeBump(
+            innerXdr,
+            FEE_SOURCE_PUBKEY,
+            USER_ID,
+            {} as any,
+            NETWORK_PASSPHRASE,
+            mockBuild,
+        );
+
+        expect(result.ok).toBe(true);
+        if (!result.ok) return;
+        expect(result.feeBumpXdr).toBe('mock-fee-bump-xdr');
+        expect(result.feeCharged).toBe(300);
+    });
+
+    it('calls buildFeeBumpTransaction with the inner XDR and fee source', async () => {
+        const innerXdr = buildSignedInnerTxXdr();
+        const mockBuild = makeMockBuildFeeBump(150);
+
+        await orchestrateFeeBump(
+            innerXdr,
+            FEE_SOURCE_PUBKEY,
+            USER_ID,
+            {} as any,
+            NETWORK_PASSPHRASE,
+            mockBuild,
+        );
+
+        expect(mockBuild).toHaveBeenCalledWith(innerXdr, FEE_SOURCE_PUBKEY, {});
+    });
+});
+
+describe('orchestrateFeeBump – invalid inner transaction rejection', () => {
+    it('returns ok:false for unparseable XDR without calling buildFeeBumpTransaction', async () => {
+        const mockBuild = makeMockBuildFeeBump(300);
+
+        const result = await orchestrateFeeBump(
+            'not-valid-xdr',
+            FEE_SOURCE_PUBKEY,
+            USER_ID,
+            {} as any,
+            NETWORK_PASSPHRASE,
+            mockBuild,
+        );
+
+        expect(result.ok).toBe(false);
+        if (result.ok) return;
+        expect(result.error).toMatch(/Invalid inner transaction XDR/);
+        expect(mockBuild).not.toHaveBeenCalled();
+    });
+
+    it('returns ok:false when buildFeeBumpTransaction fails', async () => {
+        const innerXdr = buildSignedInnerTxXdr();
+        const mockBuild = vi.fn().mockResolvedValue({ ok: false, error: 'RPC unavailable' });
+
+        const result = await orchestrateFeeBump(
+            innerXdr,
+            FEE_SOURCE_PUBKEY,
+            USER_ID,
+            {} as any,
+            NETWORK_PASSPHRASE,
+            mockBuild,
+        );
+
+        expect(result.ok).toBe(false);
+        if (result.ok) return;
+        expect(result.error).toBe('RPC unavailable');
+    });
+});
+
+describe('orchestrateFeeBump – fee tracking', () => {
+    it('creates a usage record on first transaction', async () => {
+        const innerXdr = buildSignedInnerTxXdr();
+        const mockBuild = makeMockBuildFeeBump(300);
+
+        await orchestrateFeeBump(innerXdr, FEE_SOURCE_PUBKEY, USER_ID, {} as any, NETWORK_PASSPHRASE, mockBuild);
+
+        const usage = getFeeBumpUsage(USER_ID);
+        expect(usage).toBeDefined();
+        expect(usage!.count).toBe(1);
+        expect(usage!.totalFeesPaid).toBe(300);
+        expect(usage!.lastUsedAt).toBeGreaterThan(0);
+    });
+
+    it('accumulates count and totalFeesPaid across multiple transactions', async () => {
+        const innerXdr = buildSignedInnerTxXdr();
+        const mockBuild = makeMockBuildFeeBump(200);
+
+        await orchestrateFeeBump(innerXdr, FEE_SOURCE_PUBKEY, USER_ID, {} as any, NETWORK_PASSPHRASE, mockBuild);
+        await orchestrateFeeBump(innerXdr, FEE_SOURCE_PUBKEY, USER_ID, {} as any, NETWORK_PASSPHRASE, mockBuild);
+        await orchestrateFeeBump(innerXdr, FEE_SOURCE_PUBKEY, USER_ID, {} as any, NETWORK_PASSPHRASE, mockBuild);
+
+        const usage = getFeeBumpUsage(USER_ID);
+        expect(usage!.count).toBe(3);
+        expect(usage!.totalFeesPaid).toBe(600);
+    });
+
+    it('tracks different users independently', async () => {
+        const innerXdr = buildSignedInnerTxXdr();
+
+        await orchestrateFeeBump(innerXdr, FEE_SOURCE_PUBKEY, 'user-1', {} as any, NETWORK_PASSPHRASE, makeMockBuildFeeBump(100));
+        await orchestrateFeeBump(innerXdr, FEE_SOURCE_PUBKEY, 'user-2', {} as any, NETWORK_PASSPHRASE, makeMockBuildFeeBump(500));
+
+        expect(getFeeBumpUsage('user-1')!.totalFeesPaid).toBe(100);
+        expect(getFeeBumpUsage('user-2')!.totalFeesPaid).toBe(500);
+    });
+
+    it('does not update usage when inner XDR is invalid', async () => {
+        const mockBuild = makeMockBuildFeeBump(300);
+
+        await orchestrateFeeBump('bad-xdr', FEE_SOURCE_PUBKEY, USER_ID, {} as any, NETWORK_PASSPHRASE, mockBuild);
+
+        expect(getFeeBumpUsage(USER_ID)).toBeUndefined();
+    });
+});

--- a/packages/stellar/src/fee-bump-orchestrator.ts
+++ b/packages/stellar/src/fee-bump-orchestrator.ts
@@ -1,0 +1,111 @@
+/**
+ * Fee-Bump Transaction Orchestrator – Platform-Sponsored User Execution (#784)
+ *
+ * Wraps any user-submitted Stellar transaction in a platform-sponsored fee-bump
+ * envelope, applying a priority fee and tracking per-user usage for monthly billing.
+ *
+ * ## Flow
+ * 1. Validate the inner transaction XDR (must be parseable by stellar-sdk).
+ * 2. Call `buildFeeBumpTransaction` to compute the priority fee and construct
+ *    the fee-bump envelope.
+ * 3. Record the fee-bump usage (count + total stroops paid) against the user.
+ * 4. Return the fee-bump transaction XDR ready for signing by the fee account.
+ *
+ * ## Usage tracking
+ * Usage is stored in an in-memory Map keyed by `userId`.  In production this
+ * should be replaced with a Supabase upsert for durability across restarts.
+ * The in-memory store is intentionally simple so tests can remain unit tests
+ * without a live database.
+ */
+
+import { TransactionBuilder } from 'stellar-sdk';
+import type { SorobanRpc } from 'stellar-sdk';
+import { buildFeeBumpTransaction } from './soroban';
+import type { FeeBumpResult } from './soroban';
+
+// ---------------------------------------------------------------------------
+// Usage tracking
+// ---------------------------------------------------------------------------
+
+export interface FeeBumpUsageRecord {
+    userId: string;
+    /** Number of fee-bump transactions orchestrated this billing period. */
+    count: number;
+    /** Cumulative fee paid in stroops. */
+    totalFeesPaid: number;
+    /** Unix timestamp (ms) of the most recent transaction. */
+    lastUsedAt: number;
+}
+
+const usageStore = new Map<string, FeeBumpUsageRecord>();
+
+/** Flush all usage records. Call in test teardown for isolation. */
+export function clearFeeBumpUsage(): void {
+    usageStore.clear();
+}
+
+/** Return the current usage record for a user, or undefined if none exists. */
+export function getFeeBumpUsage(userId: string): FeeBumpUsageRecord | undefined {
+    const record = usageStore.get(userId);
+    return record ? { ...record } : undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Orchestrator
+// ---------------------------------------------------------------------------
+
+export type OrchestrateFeeBumpResult =
+    | { ok: true; feeBumpXdr: string; feeCharged: number }
+    | { ok: false; error: string };
+
+/**
+ * Orchestrates a fee-bump transaction for a user-submitted inner transaction.
+ *
+ * Validates the inner XDR, wraps it in a fee-bump envelope signed by the
+ * platform fee account, and records the fee-bump against the user.
+ *
+ * @param innerTxXdr        - Signed inner transaction XDR submitted by the user
+ * @param feeSourcePublicKey - Platform fee account that pays the bump fee
+ * @param userId             - Identifier for the user (used for usage tracking)
+ * @param client             - Soroban RPC client for fee statistics
+ * @param networkPassphrase  - Stellar network passphrase for XDR validation
+ * @param _buildFeeBump      - Override for `buildFeeBumpTransaction` (for testing)
+ */
+export async function orchestrateFeeBump(
+    innerTxXdr: string,
+    feeSourcePublicKey: string,
+    userId: string,
+    client: SorobanRpc.Server,
+    networkPassphrase: string,
+    _buildFeeBump: typeof buildFeeBumpTransaction = buildFeeBumpTransaction,
+): Promise<OrchestrateFeeBumpResult> {
+    // Validate the inner transaction XDR before attempting to wrap it.
+    try {
+        TransactionBuilder.fromXDR(innerTxXdr, networkPassphrase);
+    } catch {
+        return { ok: false, error: 'Invalid inner transaction XDR: unable to parse' };
+    }
+
+    // Construct the fee-bump envelope.
+    const result: FeeBumpResult = await _buildFeeBump(innerTxXdr, feeSourcePublicKey, client);
+    if (!result.ok) {
+        return result;
+    }
+
+    // Record usage for monthly billing.
+    const existing = usageStore.get(userId);
+    if (existing) {
+        existing.count += 1;
+        existing.totalFeesPaid += result.feeCharged;
+        existing.lastUsedAt = Date.now();
+    } else {
+        usageStore.set(userId, {
+            userId,
+            count: 1,
+            totalFeesPaid: result.feeCharged,
+            lastUsedAt: Date.now(),
+        });
+    }
+
+    return { ok: true, feeBumpXdr: result.feeBumpXdr, feeCharged: result.feeCharged };
+}

--- a/packages/stellar/src/index.ts
+++ b/packages/stellar/src/index.ts
@@ -11,3 +11,4 @@ export * from './soroban-budget-monitor';
 export * from './soroban-xdr-deserializer';
 export * from './dex-price-feed';
 export * from './soroban-ttl-manager';
+export * from './multi-party-issuance';

--- a/packages/stellar/src/index.ts
+++ b/packages/stellar/src/index.ts
@@ -12,3 +12,4 @@ export * from './soroban-xdr-deserializer';
 export * from './dex-price-feed';
 export * from './soroban-ttl-manager';
 export * from './multi-party-issuance';
+export * from './fee-bump-orchestrator';

--- a/packages/stellar/src/index.ts
+++ b/packages/stellar/src/index.ts
@@ -13,3 +13,4 @@ export * from './dex-price-feed';
 export * from './soroban-ttl-manager';
 export * from './multi-party-issuance';
 export * from './fee-bump-orchestrator';
+export * from './account-merge-protection';

--- a/packages/stellar/src/multi-party-issuance.test.ts
+++ b/packages/stellar/src/multi-party-issuance.test.ts
@@ -1,0 +1,296 @@
+/**
+ * Multi-Party Asset Issuance Tests (#783)
+ *
+ * Covers: 2-of-3 approval, timeout expiry, and combined transaction submission.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+    Networks,
+    Keypair,
+    TransactionBuilder,
+    BASE_FEE,
+    Operation,
+    Asset,
+} from 'stellar-sdk';
+import {
+    createIssuanceSession,
+    addCoSignerSignature,
+    markIssued,
+    expireTimedOutSessions,
+    getIssuanceSession,
+    clearIssuanceSessions,
+    type MultiPartyConfig,
+} from './multi-party-issuance';
+
+const NETWORK = Networks.TESTNET;
+
+const SOURCE_KP = Keypair.random();
+const SIGNER_A = Keypair.random();
+const SIGNER_B = Keypair.random();
+const SIGNER_C = Keypair.random();
+
+function buildBaseTxXdr(): string {
+    const account = {
+        accountId: () => SOURCE_KP.publicKey(),
+        sequenceNumber: () => '1000',
+        incrementSequenceNumber: () => {},
+    } as any;
+
+    return new TransactionBuilder(account, { fee: BASE_FEE, networkPassphrase: NETWORK })
+        .addOperation(
+            Operation.payment({
+                destination: Keypair.random().publicKey(),
+                asset: Asset.native(),
+                amount: '10',
+            }),
+        )
+        .setTimeout(60)
+        .build()
+        .toXDR();
+}
+
+function signTxXdr(txXdr: string, keypair: Keypair): string {
+    const tx = TransactionBuilder.fromXDR(txXdr, NETWORK) as any;
+    tx.sign(keypair);
+    return tx.toXDR();
+}
+
+beforeEach(() => {
+    clearIssuanceSessions();
+});
+
+// ---------------------------------------------------------------------------
+// Session creation
+// ---------------------------------------------------------------------------
+
+describe('createIssuanceSession', () => {
+    it('creates a session in pending state', () => {
+        const config: MultiPartyConfig = { required: 2, total: 3 };
+        const baseTxXdr = buildBaseTxXdr();
+        const session = createIssuanceSession(config, baseTxXdr);
+
+        expect(session.state).toBe('pending');
+        expect(session.collectedSignerKeys).toHaveLength(0);
+        expect(session.id).toBeTruthy();
+        expect(session.expiresAt).toBeGreaterThan(session.createdAt);
+    });
+
+    it('throws for invalid N-of-M configuration', () => {
+        expect(() => createIssuanceSession({ required: 4, total: 3 }, 'xdr')).toThrow();
+        expect(() => createIssuanceSession({ required: 0, total: 3 }, 'xdr')).toThrow();
+    });
+
+    it('respects a custom timeout', () => {
+        const config: MultiPartyConfig = { required: 1, total: 1, timeoutMs: 5_000 };
+        const session = createIssuanceSession(config, buildBaseTxXdr());
+
+        expect(session.expiresAt - session.createdAt).toBe(5_000);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// 2-of-3 approval flow
+// ---------------------------------------------------------------------------
+
+describe('2-of-3 authorization flow', () => {
+    it('transitions pending → partial_approval after first signature', () => {
+        const baseTxXdr = buildBaseTxXdr();
+        const session = createIssuanceSession({ required: 2, total: 3 }, baseTxXdr);
+
+        const result = addCoSignerSignature(
+            session.id,
+            SIGNER_A.publicKey(),
+            signTxXdr(baseTxXdr, SIGNER_A),
+            NETWORK,
+        );
+
+        expect(result.ok).toBe(true);
+        if (!result.ok) return;
+        expect(result.session.state).toBe('partial_approval');
+        expect(result.session.collectedSignerKeys).toHaveLength(1);
+    });
+
+    it('transitions partial_approval → approved after second signature', () => {
+        const baseTxXdr = buildBaseTxXdr();
+        const session = createIssuanceSession({ required: 2, total: 3 }, baseTxXdr);
+
+        addCoSignerSignature(session.id, SIGNER_A.publicKey(), signTxXdr(baseTxXdr, SIGNER_A), NETWORK);
+        const result = addCoSignerSignature(session.id, SIGNER_B.publicKey(), signTxXdr(baseTxXdr, SIGNER_B), NETWORK);
+
+        expect(result.ok).toBe(true);
+        if (!result.ok) return;
+        expect(result.session.state).toBe('approved');
+        expect(result.session.combinedTxXdr).toBeTruthy();
+        expect(result.session.collectedSignerKeys).toHaveLength(2);
+    });
+
+    it('the combined XDR is parseable', () => {
+        const baseTxXdr = buildBaseTxXdr();
+        const session = createIssuanceSession({ required: 2, total: 3 }, baseTxXdr);
+
+        addCoSignerSignature(session.id, SIGNER_A.publicKey(), signTxXdr(baseTxXdr, SIGNER_A), NETWORK);
+        const result = addCoSignerSignature(session.id, SIGNER_B.publicKey(), signTxXdr(baseTxXdr, SIGNER_B), NETWORK);
+
+        expect(result.ok).toBe(true);
+        if (!result.ok) return;
+        expect(() =>
+            TransactionBuilder.fromXDR(result.session.combinedTxXdr!, NETWORK),
+        ).not.toThrow();
+    });
+
+    it('does not advance state beyond approved when a third signature arrives', () => {
+        const baseTxXdr = buildBaseTxXdr();
+        const session = createIssuanceSession({ required: 2, total: 3 }, baseTxXdr);
+
+        addCoSignerSignature(session.id, SIGNER_A.publicKey(), signTxXdr(baseTxXdr, SIGNER_A), NETWORK);
+        addCoSignerSignature(session.id, SIGNER_B.publicKey(), signTxXdr(baseTxXdr, SIGNER_B), NETWORK);
+
+        const result = addCoSignerSignature(session.id, SIGNER_C.publicKey(), signTxXdr(baseTxXdr, SIGNER_C), NETWORK);
+        expect(result.ok).toBe(false);
+        if (result.ok) return;
+        expect(result.error).toMatch(/already in state/);
+    });
+
+    it('rejects a duplicate signature from the same signer', () => {
+        const baseTxXdr = buildBaseTxXdr();
+        const session = createIssuanceSession({ required: 2, total: 3 }, baseTxXdr);
+
+        addCoSignerSignature(session.id, SIGNER_A.publicKey(), signTxXdr(baseTxXdr, SIGNER_A), NETWORK);
+        const result = addCoSignerSignature(session.id, SIGNER_A.publicKey(), signTxXdr(baseTxXdr, SIGNER_A), NETWORK);
+
+        expect(result.ok).toBe(false);
+        if (result.ok) return;
+        expect(result.error).toMatch(/already signed/);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// 3-of-5 approval flow
+// ---------------------------------------------------------------------------
+
+describe('3-of-5 authorization flow', () => {
+    const EXTRA_A = Keypair.random();
+    const EXTRA_B = Keypair.random();
+
+    it('reaches approved after exactly 3 signatures', () => {
+        const baseTxXdr = buildBaseTxXdr();
+        const session = createIssuanceSession({ required: 3, total: 5 }, baseTxXdr);
+
+        addCoSignerSignature(session.id, SIGNER_A.publicKey(), signTxXdr(baseTxXdr, SIGNER_A), NETWORK);
+        expect(getIssuanceSession(session.id)!.state).toBe('partial_approval');
+
+        addCoSignerSignature(session.id, SIGNER_B.publicKey(), signTxXdr(baseTxXdr, SIGNER_B), NETWORK);
+        expect(getIssuanceSession(session.id)!.state).toBe('partial_approval');
+
+        addCoSignerSignature(session.id, EXTRA_A.publicKey(), signTxXdr(baseTxXdr, EXTRA_A), NETWORK);
+        expect(getIssuanceSession(session.id)!.state).toBe('approved');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Timeout expiry
+// ---------------------------------------------------------------------------
+
+describe('session timeout expiry', () => {
+    it('expireTimedOutSessions marks overdue sessions as expired', () => {
+        const baseTxXdr = buildBaseTxXdr();
+        const session = createIssuanceSession(
+            { required: 2, total: 3, timeoutMs: 60_000 },
+            baseTxXdr,
+        );
+
+        // Pass a far-future timestamp so the session looks past its timeout.
+        const count = expireTimedOutSessions(Date.now() + 1_000_000_000);
+
+        expect(count).toBe(1);
+        expect(getIssuanceSession(session.id)!.state).toBe('expired');
+    });
+
+    it('addCoSignerSignature detects an expired session', () => {
+        const baseTxXdr = buildBaseTxXdr();
+        // Create with a negative timeout so expiresAt is already in the past.
+        const session = createIssuanceSession(
+            { required: 2, total: 3, timeoutMs: -1 },
+            baseTxXdr,
+        );
+
+        const result = addCoSignerSignature(
+            session.id,
+            SIGNER_A.publicKey(),
+            signTxXdr(baseTxXdr, SIGNER_A),
+            NETWORK,
+        );
+
+        expect(result.ok).toBe(false);
+        if (result.ok) return;
+        expect(result.error).toMatch(/expired/);
+    });
+
+    it('does not expire approved or issued sessions', () => {
+        const baseTxXdr = buildBaseTxXdr();
+        const session = createIssuanceSession(
+            { required: 1, total: 1, timeoutMs: 60_000 },
+            baseTxXdr,
+        );
+
+        addCoSignerSignature(session.id, SIGNER_A.publicKey(), signTxXdr(baseTxXdr, SIGNER_A), NETWORK);
+        markIssued(session.id);
+
+        // Simulate far-future "now" so every session looks past its timeout.
+        // Issued sessions must not be expired regardless.
+        const count = expireTimedOutSessions(Date.now() + 1_000_000_000);
+        expect(count).toBe(0);
+        expect(getIssuanceSession(session.id)!.state).toBe('issued');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// markIssued
+// ---------------------------------------------------------------------------
+
+describe('markIssued', () => {
+    it('transitions approved → issued', () => {
+        const baseTxXdr = buildBaseTxXdr();
+        const session = createIssuanceSession({ required: 1, total: 1 }, baseTxXdr);
+
+        addCoSignerSignature(session.id, SIGNER_A.publicKey(), signTxXdr(baseTxXdr, SIGNER_A), NETWORK);
+        const result = markIssued(session.id);
+
+        expect(result.ok).toBe(true);
+        if (!result.ok) return;
+        expect(result.session.state).toBe('issued');
+    });
+
+    it('fails when session is not in approved state', () => {
+        const baseTxXdr = buildBaseTxXdr();
+        const session = createIssuanceSession({ required: 2, total: 3 }, baseTxXdr);
+
+        const result = markIssued(session.id);
+
+        expect(result.ok).toBe(false);
+        if (result.ok) return;
+        expect(result.error).toMatch(/approved/);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Error cases
+// ---------------------------------------------------------------------------
+
+describe('error handling', () => {
+    it('returns error for unknown session id', () => {
+        const result = addCoSignerSignature('nonexistent', SIGNER_A.publicKey(), 'xdr', NETWORK);
+        expect(result.ok).toBe(false);
+    });
+
+    it('rejects invalid signed XDR', () => {
+        const baseTxXdr = buildBaseTxXdr();
+        const session = createIssuanceSession({ required: 2, total: 3 }, baseTxXdr);
+
+        const result = addCoSignerSignature(session.id, SIGNER_A.publicKey(), 'invalid-xdr', NETWORK);
+        expect(result.ok).toBe(false);
+        if (result.ok) return;
+        expect(result.error).toMatch(/Invalid signed transaction XDR/);
+    });
+});

--- a/packages/stellar/src/multi-party-issuance.ts
+++ b/packages/stellar/src/multi-party-issuance.ts
@@ -1,0 +1,285 @@
+/**
+ * Multi-Party Asset Issuance with Authorization Gate (#783)
+ *
+ * Manages a state machine that requires N-of-M co-issuer signatures before
+ * an asset distribution account is funded and trust-line flags are set.
+ *
+ * ## Supported configurations
+ * - 2-of-3: two co-signers required out of three
+ * - 3-of-5: three co-signers required out of five
+ * - Any N-of-M where N ≤ M
+ *
+ * ## State machine
+ * ```
+ *   pending → partial_approval → approved → issued
+ *                  ↓                ↓
+ *               expired          expired
+ * ```
+ * - `pending`          – session created, no signatures yet
+ * - `partial_approval` – at least one signature collected, fewer than N
+ * - `approved`         – N signatures reached; combined XDR is ready to submit
+ * - `issued`           – caller confirmed the transaction was submitted
+ * - `expired`          – 24-hour timeout elapsed before reaching `approved`
+ *
+ * ## Signature protocol
+ * Each co-signer receives the base (unsigned) transaction XDR, signs it
+ * off-chain, and submits the signed XDR back via `addCoSignerSignature`.
+ * When N signatures are collected the signed transactions are merged into a
+ * single envelope that carries all required signatures.
+ *
+ * ## Persistence
+ * Sessions are held in an in-memory Map.  In production, replace the store
+ * operations with Supabase upserts for durability across restarts and
+ * multi-instance deployments.
+ */
+
+import { TransactionBuilder, Transaction } from 'stellar-sdk';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export type IssuanceState = 'pending' | 'partial_approval' | 'approved' | 'issued' | 'expired';
+
+export interface MultiPartyConfig {
+    /** N: number of co-signer signatures required to approve. */
+    required: number;
+    /** M: total number of eligible co-signers (must be ≥ required). */
+    total: number;
+    /**
+     * Milliseconds until the session expires if not fully signed.
+     * Defaults to 24 hours.
+     */
+    timeoutMs?: number;
+}
+
+export interface IssuanceSession {
+    id: string;
+    config: MultiPartyConfig;
+    state: IssuanceState;
+    /** Base (unsigned) issuance transaction XDR distributed to co-signers. */
+    baseTxXdr: string;
+    /** Public keys of co-signers who have submitted a signed transaction. */
+    collectedSignerKeys: string[];
+    /** Combined transaction XDR (set once state reaches `approved`). */
+    combinedTxXdr?: string;
+    createdAt: number;
+    expiresAt: number;
+}
+
+export type AddSignatureResult =
+    | { ok: true; session: IssuanceSession }
+    | { ok: false; error: string };
+
+export type MarkIssuedResult =
+    | { ok: true; session: IssuanceSession }
+    | { ok: false; error: string };
+
+// ---------------------------------------------------------------------------
+// In-memory session store
+// ---------------------------------------------------------------------------
+
+const DEFAULT_TIMEOUT_MS = 24 * 60 * 60 * 1_000;
+
+const sessionStore = new Map<string, IssuanceSession>();
+let _nextId = 1;
+
+/** Flush all sessions. Call in test teardown for isolation. */
+export function clearIssuanceSessions(): void {
+    sessionStore.clear();
+    _nextId = 1;
+}
+
+/** Return a snapshot of an existing session, or undefined. */
+export function getIssuanceSession(id: string): IssuanceSession | undefined {
+    const s = sessionStore.get(id);
+    return s ? { ...s, collectedSignerKeys: [...s.collectedSignerKeys] } : undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Session lifecycle
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a new issuance session for the given N-of-M configuration.
+ *
+ * @param config      - Authorization requirements
+ * @param baseTxXdr   - Unsigned transaction XDR to be co-signed
+ */
+export function createIssuanceSession(config: MultiPartyConfig, baseTxXdr: string): IssuanceSession {
+    if (config.required < 1 || config.required > config.total) {
+        throw new Error(
+            `Invalid config: required (${config.required}) must be between 1 and total (${config.total})`,
+        );
+    }
+
+    const now = Date.now();
+    const session: IssuanceSession = {
+        id: `issuance-${_nextId++}`,
+        config,
+        state: 'pending',
+        baseTxXdr,
+        collectedSignerKeys: [],
+        createdAt: now,
+        expiresAt: now + (config.timeoutMs ?? DEFAULT_TIMEOUT_MS),
+    };
+
+    sessionStore.set(session.id, session);
+    return { ...session };
+}
+
+/**
+ * Submit a co-signer's signed version of the base transaction.
+ *
+ * - Rejects if the session is expired, already approved/issued, or if the
+ *   signer has already contributed.
+ * - Transitions state: `pending → partial_approval → approved`.
+ * - When `approved`, combines all collected signatures into `combinedTxXdr`.
+ *
+ * @param sessionId        - Target issuance session
+ * @param signerPublicKey  - Public key of the co-signer submitting the signature
+ * @param signedTxXdr      - Transaction signed by this co-signer
+ * @param networkPassphrase - Stellar network passphrase for XDR parsing
+ */
+export function addCoSignerSignature(
+    sessionId: string,
+    signerPublicKey: string,
+    signedTxXdr: string,
+    networkPassphrase: string,
+): AddSignatureResult {
+    const session = sessionStore.get(sessionId);
+    if (!session) {
+        return { ok: false, error: `Session '${sessionId}' not found` };
+    }
+
+    // Expire sessions that exceeded the timeout
+    if (Date.now() > session.expiresAt) {
+        session.state = 'expired';
+        return { ok: false, error: 'Session has expired' };
+    }
+
+    if (session.state === 'approved' || session.state === 'issued') {
+        return { ok: false, error: `Session is already in state '${session.state}'` };
+    }
+
+    if (session.state === 'expired') {
+        return { ok: false, error: 'Session has expired' };
+    }
+
+    if (session.collectedSignerKeys.includes(signerPublicKey)) {
+        return { ok: false, error: `Co-signer '${signerPublicKey}' has already signed` };
+    }
+
+    // Validate the signed XDR
+    try {
+        TransactionBuilder.fromXDR(signedTxXdr, networkPassphrase);
+    } catch {
+        return { ok: false, error: 'Invalid signed transaction XDR' };
+    }
+
+    // Store the signed XDR alongside the signer key (we embed it in the session
+    // transiently; only combinedTxXdr survives the snapshot).
+    (session as any)._signedXdrs = (session as any)._signedXdrs ?? [];
+    (session as any)._signedXdrs.push(signedTxXdr);
+    session.collectedSignerKeys.push(signerPublicKey);
+
+    const count = session.collectedSignerKeys.length;
+
+    if (count >= session.config.required) {
+        // Combine all collected signatures into one transaction envelope.
+        try {
+            session.combinedTxXdr = combineSignedTransactions(
+                (session as any)._signedXdrs as string[],
+                networkPassphrase,
+            );
+        } catch (e) {
+            return { ok: false, error: `Signature combination failed: ${e}` };
+        }
+        session.state = 'approved';
+    } else {
+        session.state = 'partial_approval';
+    }
+
+    return {
+        ok: true,
+        session: { ...session, collectedSignerKeys: [...session.collectedSignerKeys] },
+    };
+}
+
+/**
+ * Mark an approved session as issued after the combined transaction has been
+ * submitted to the Stellar network.
+ *
+ * @param sessionId - Target issuance session (must be in `approved` state)
+ */
+export function markIssued(sessionId: string): MarkIssuedResult {
+    const session = sessionStore.get(sessionId);
+    if (!session) {
+        return { ok: false, error: `Session '${sessionId}' not found` };
+    }
+    if (session.state !== 'approved') {
+        return {
+            ok: false,
+            error: `Cannot mark issued: session is in state '${session.state}' (expected 'approved')`,
+        };
+    }
+
+    session.state = 'issued';
+    return { ok: true, session: { ...session, collectedSignerKeys: [...session.collectedSignerKeys] } };
+}
+
+/**
+ * Expire sessions that have passed their timeout without reaching `approved`.
+ * Call this on demand or as a scheduled cleanup job.
+ *
+ * @param _now - Override the current timestamp (for testing).
+ * @returns Number of sessions transitioned to `expired`.
+ */
+export function expireTimedOutSessions(_now: number = Date.now()): number {
+    let expired = 0;
+
+    for (const session of sessionStore.values()) {
+        if (
+            session.state !== 'approved' &&
+            session.state !== 'issued' &&
+            session.state !== 'expired' &&
+            _now > session.expiresAt
+        ) {
+            session.state = 'expired';
+            expired++;
+        }
+    }
+
+    return expired;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Merge the signatures from multiple signed transaction XDRs into a single
+ * transaction envelope, deduplicating by signature hint.
+ */
+function combineSignedTransactions(signedXdrs: string[], networkPassphrase: string): string {
+    if (signedXdrs.length === 0) {
+        throw new Error('No signed transactions to combine');
+    }
+
+    const base = TransactionBuilder.fromXDR(signedXdrs[0], networkPassphrase) as Transaction;
+
+    for (let i = 1; i < signedXdrs.length; i++) {
+        const other = TransactionBuilder.fromXDR(signedXdrs[i], networkPassphrase) as Transaction;
+        for (const sig of other.signatures) {
+            const hintHex = sig.hint().toString('hex');
+            const alreadyPresent = base.signatures.some(
+                (s) => s.hint().toString('hex') === hintHex,
+            );
+            if (!alreadyPresent) {
+                base.signatures.push(sig);
+            }
+        }
+    }
+
+    return base.toXDR();
+}

--- a/packages/stellar/src/soroban.dryrun.test.ts
+++ b/packages/stellar/src/soroban.dryrun.test.ts
@@ -7,7 +7,7 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { SorobanRpc, xdr } from 'stellar-sdk';
-import { performContractDryRun, simulateContractCall } from './soroban';
+import { performContractDryRun, simulateContractCall, dryRunWithForecast, clearForecastCache } from './soroban';
 
 describe('Soroban Contract Simulation Dry-Run', () => {
   const mockContractId = 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM';
@@ -195,5 +195,115 @@ describe('Soroban Contract Simulation Dry-Run', () => {
       expect(dryRunResult).toHaveProperty('success');
       expect(dryRunResult).toHaveProperty('result');
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// dryRunWithForecast – resource consumption forecasting (#782)
+// ---------------------------------------------------------------------------
+
+function makeSuccessSimulation(overrides: Record<string, any> = {}): SorobanRpc.Api.SimulateTransactionResponse {
+  return {
+    cost: { cpuInsns: '5000000', memBytes: '2097152' },
+    minResourceFee: '500',
+    events: [],
+    ...overrides,
+  } as unknown as SorobanRpc.Api.SimulateTransactionResponse;
+}
+
+function makeErrorSimulation(): SorobanRpc.Api.SimulateTransactionResponse {
+  return { error: 'contract trap' } as unknown as SorobanRpc.Api.SimulateTransactionResponse;
+}
+
+describe('dryRunWithForecast', () => {
+  const CONTRACT = 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM';
+  const SOURCE = 'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ';
+  const ARGS: xdr.ScVal[] = [];
+
+  beforeEach(() => {
+    clearForecastCache();
+  });
+
+  it('returns all forecast fields for a successful simulation', async () => {
+    const mockSim = vi.fn().mockResolvedValue(makeSuccessSimulation());
+    const result = await dryRunWithForecast(CONTRACT, 'transfer', ARGS, SOURCE, mockSim);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.forecast.estimatedFee).toBe('500');
+    expect(result.forecast.cpuInstructions).toBe('5000000');
+    expect(result.forecast.memoryBytes).toBe('2097152');
+    expect(typeof result.forecast.ledgerEntriesRead).toBe('number');
+    expect(typeof result.forecast.ledgerEntriesWritten).toBe('number');
+    expect(typeof result.forecast.eventsEmitted).toBe('number');
+    expect(Array.isArray(result.forecast.warnings)).toBe(true);
+  });
+
+  it('returns ok:false for a simulation error', async () => {
+    const mockSim = vi.fn().mockResolvedValue(makeErrorSimulation());
+    const result = await dryRunWithForecast(CONTRACT, 'transfer', ARGS, SOURCE, mockSim);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toBeTruthy();
+  });
+
+  it('populates warnings when CPU instructions exceed 80% of limit', async () => {
+    // 100_000_000 * 0.85 = 85_000_000
+    const mockSim = vi.fn().mockResolvedValue(
+      makeSuccessSimulation({ cost: { cpuInsns: '85000000', memBytes: '0' } }),
+    );
+    const result = await dryRunWithForecast(CONTRACT, 'heavy', ARGS, SOURCE, mockSim);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.forecast.warnings.some((w) => w.includes('CPU instructions'))).toBe(true);
+  });
+
+  it('populates warnings when memory bytes exceed 80% of limit', async () => {
+    // 41_943_040 * 0.85 ≈ 35_651_584
+    const mockSim = vi.fn().mockResolvedValue(
+      makeSuccessSimulation({ cost: { cpuInsns: '0', memBytes: '35651584' } }),
+    );
+    const result = await dryRunWithForecast(CONTRACT, 'bigAlloc', ARGS, SOURCE, mockSim);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.forecast.warnings.some((w) => w.includes('Memory bytes'))).toBe(true);
+  });
+
+  it('counts events emitted from the simulation events array', async () => {
+    const fakeEvents = [{}, {}, {}] as any[];
+    const mockSim = vi.fn().mockResolvedValue(makeSuccessSimulation({ events: fakeEvents }));
+    const result = await dryRunWithForecast(CONTRACT, 'emit', ARGS, SOURCE, mockSim);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.forecast.eventsEmitted).toBe(3);
+  });
+
+  it('caches results for identical calls within 60 seconds', async () => {
+    const mockSim = vi.fn().mockResolvedValue(makeSuccessSimulation());
+    await dryRunWithForecast(CONTRACT, 'transfer', ARGS, SOURCE, mockSim);
+    await dryRunWithForecast(CONTRACT, 'transfer', ARGS, SOURCE, mockSim);
+
+    expect(mockSim).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not emit warnings when resources are below 80% of limits', async () => {
+    const mockSim = vi.fn().mockResolvedValue(makeSuccessSimulation());
+    const result = await dryRunWithForecast(CONTRACT, 'cheap', ARGS, SOURCE, mockSim);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.forecast.warnings).toHaveLength(0);
+  });
+
+  it('returns ok:false when simulate throws', async () => {
+    const mockSim = vi.fn().mockRejectedValue(new Error('RPC timeout'));
+    const result = await dryRunWithForecast(CONTRACT, 'crash', ARGS, SOURCE, mockSim);
+
+    expect(result.ok).toBe(false);
   });
 });

--- a/packages/stellar/src/soroban.ts
+++ b/packages/stellar/src/soroban.ts
@@ -412,6 +412,147 @@ export function assertValidWasmSize(wasmBinary: Buffer | Uint8Array): void {
 }
 
 // ---------------------------------------------------------------------------
+// Dry-Run Resource Forecasting (#782)
+// ---------------------------------------------------------------------------
+
+/** Soroban protocol hard limits used for threshold warnings. */
+const SOROBAN_FORECAST_LIMITS = {
+    cpuInstructions: 100_000_000,
+    memoryBytes: 41_943_040,
+    ledgerEntriesRead: 40,
+    ledgerEntriesWritten: 25,
+    eventsEmitted: 25,
+    estimatedFeeStroops: 10_000_000,
+} as const;
+
+/** Fraction of a limit that triggers a warning in the forecast. */
+const FORECAST_WARN_THRESHOLD = 0.8;
+
+/** TTL for the dry-run forecast cache (60 seconds). */
+const FORECAST_CACHE_TTL_MS = 60_000;
+
+export interface DryRunForecast {
+    estimatedFee: string;
+    ledgerEntriesRead: number;
+    ledgerEntriesWritten: number;
+    eventsEmitted: number;
+    cpuInstructions: string;
+    memoryBytes: string;
+    /** Human-readable warnings for metrics that exceed 80 % of their network limit. */
+    warnings: string[];
+}
+
+export type DryRunForecastResult =
+    | { ok: true; forecast: DryRunForecast }
+    | { ok: false; error: string };
+
+interface ForecastCacheEntry {
+    forecast: DryRunForecast;
+    storedAt: number;
+}
+
+const forecastCache = new Map<string, ForecastCacheEntry>();
+
+/** Flush the forecast cache. Call in test teardown for isolation. */
+export function clearForecastCache(): void {
+    forecastCache.clear();
+}
+
+/**
+ * Performs a dry-run simulation and returns a detailed resource forecast.
+ *
+ * Returns estimated fee, ledger entries read/written, events emitted, CPU
+ * instructions, and memory bytes.  Any metric that exceeds 80 % of its
+ * Soroban network limit is included in the `warnings` array.
+ *
+ * Results are cached for 60 seconds keyed on (contractId, functionName, args).
+ *
+ * @param contractId  - The contract address (C...)
+ * @param functionName - The contract function to simulate
+ * @param args         - XDR-encoded function arguments
+ * @param sourcePublicKey - Source account for the simulation transaction
+ * @param _simulate    - Override for `simulateContractCall` (for testing)
+ */
+export async function dryRunWithForecast(
+    contractId: string,
+    functionName: string,
+    args: xdr.ScVal[],
+    sourcePublicKey: string,
+    _simulate: typeof simulateContractCall = simulateContractCall,
+): Promise<DryRunForecastResult> {
+    const cacheKey = buildCacheKey(contractId, functionName, args, sourcePublicKey);
+    const now = Date.now();
+
+    const cached = forecastCache.get(cacheKey);
+    if (cached && now - cached.storedAt < FORECAST_CACHE_TTL_MS) {
+        return { ok: true, forecast: cached.forecast };
+    }
+
+    try {
+        const simulation = await _simulate(contractId, functionName, args, sourcePublicKey);
+
+        if (SorobanRpc.Api.isSimulationError(simulation)) {
+            return {
+                ok: false,
+                error: `Simulation error: ${(simulation as any).error ?? 'unknown'}`,
+            };
+        }
+
+        const sim = simulation as any;
+
+        const estimatedFee: string = sim.minResourceFee ?? '0';
+        const cpuInstructions: string = sim.cost?.cpuInsns ?? '0';
+        const memoryBytes: string = sim.cost?.memBytes ?? '0';
+
+        let ledgerEntriesRead = 0;
+        let ledgerEntriesWritten = 0;
+        if (sim.transactionData) {
+            try {
+                const sorobanData = sim.transactionData.build();
+                const footprint = sorobanData.resources().footprint();
+                ledgerEntriesRead = footprint.readOnly().length;
+                ledgerEntriesWritten = footprint.readWrite().length;
+            } catch {
+                // transactionData not parseable in test fixture — leave as 0
+            }
+        }
+
+        const eventsEmitted: number = Array.isArray(sim.events) ? sim.events.length : 0;
+
+        const warnings: string[] = [];
+        const check = (label: string, value: number, limit: number) => {
+            if (value > limit * FORECAST_WARN_THRESHOLD) {
+                warnings.push(
+                    `${label} (${value}) exceeds ${FORECAST_WARN_THRESHOLD * 100}% of network limit (${limit})`,
+                );
+            }
+        };
+        check('CPU instructions', Number(cpuInstructions), SOROBAN_FORECAST_LIMITS.cpuInstructions);
+        check('Memory bytes', Number(memoryBytes), SOROBAN_FORECAST_LIMITS.memoryBytes);
+        check('Ledger entries read', ledgerEntriesRead, SOROBAN_FORECAST_LIMITS.ledgerEntriesRead);
+        check('Ledger entries written', ledgerEntriesWritten, SOROBAN_FORECAST_LIMITS.ledgerEntriesWritten);
+        check('Events emitted', eventsEmitted, SOROBAN_FORECAST_LIMITS.eventsEmitted);
+        check('Estimated fee (stroops)', Number(estimatedFee), SOROBAN_FORECAST_LIMITS.estimatedFeeStroops);
+
+        const forecast: DryRunForecast = {
+            estimatedFee,
+            ledgerEntriesRead,
+            ledgerEntriesWritten,
+            eventsEmitted,
+            cpuInstructions,
+            memoryBytes,
+            warnings,
+        };
+
+        forecastCache.set(cacheKey, { forecast, storedAt: now });
+        return { ok: true, forecast };
+    } catch (error: unknown) {
+        const parsed = parseStellarError(error);
+        return { ok: false, error: `Dry-run forecast failed: ${parsed.message}` };
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Fee Bump Transaction Builder (#618)
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- **#782** — Extends `soroban.ts` with `dryRunWithForecast()`: returns a full resource forecast (`estimatedFee`, `ledgerEntriesRead/Written`, `eventsEmitted`, `cpuInstructions`, `memoryBytes`) with a `warnings[]` array for any metric exceeding 80 % of its Soroban network limit. Results are cached for 60 seconds per `(contractId, functionName, args)`.
- **#783** — Adds `multi-party-issuance.ts`: N-of-M co-signer state machine (`pending → partial_approval → approved → issued / expired`) with off-chain signature collection, XDR merging, and a 24-hour default timeout enforced by `expireTimedOutSessions()`.
- **#784** — Adds `fee-bump-orchestrator.ts`: validates inner transaction XDR before wrapping, delegates to the existing `buildFeeBumpTransaction` (1.5× p90, capped at 10 M stroops), and tracks per-user fee-bump usage (count + cumulative stroops) for monthly billing.
- **#785** — Adds `account-merge-protection.ts`: detects `AccountMerge` operations in transaction XDR, blocks merges on accounts with open trustlines or active DEX offers, verifies residual balance destination, and emits every detection to a subscribable audit log.

## Test plan

- [ ] `src/soroban.dryrun.test.ts` — 8 new `dryRunWithForecast` tests (all forecast fields, warning thresholds, caching, error paths)
- [ ] `src/multi-party-issuance.test.ts` — 16 tests (2-of-3 flow, 3-of-5 flow, timeout expiry, `markIssued`, error cases)
- [ ] `src/fee-bump-orchestrator.test.ts` — 8 tests (valid wrapping, invalid XDR rejection, RPC failure, per-user accumulation)
- [ ] `src/account-merge-protection.test.ts` — 15 tests (trustline blocking, offer blocking, destination mismatch, allowed merge, residual balance, audit log)

Closes #782
Closes #783
Closes #784
Closes #785

🤖 Generated with [Claude Code](https://claude.com/claude-code)