### PR TITLE
fix: resolve issues #916, #917, #918, #919

### DIFF
--- a/apps/backend/src/services/artifact-signing.service.ts
+++ b/apps/backend/src/services/artifact-signing.service.ts
@@ -4,7 +4,16 @@
  * Signs and verifies deployment artifacts using SHA-256 + HMAC-SHA256.
  * The signing secret is read from process.env.ARTIFACT_SIGNING_SECRET.
  *
- * Issue: #496
+ * Key Rotation Procedure:
+ *   1. Before rotating, add the current (soon-to-be-old) secret to
+ *      ARTIFACT_SIGNING_SECRET_PREVIOUS (comma-separated list).
+ *   2. Update ARTIFACT_SIGNING_SECRET to the new primary secret.
+ *   3. verifyArtifact will now accept signatures made with either the new
+ *      primary secret or any of the previous secrets, providing a grace window.
+ *   4. Once all in-flight artifacts have been re-signed (or expired), remove
+ *      the old secret from ARTIFACT_SIGNING_SECRET_PREVIOUS.
+ *
+ * Issue: #919
  */
 
 import { createHash, createHmac, timingSafeEqual } from 'crypto';
@@ -15,6 +24,17 @@ export class ArtifactSigningService {
         const s = process.env.ARTIFACT_SIGNING_SECRET;
         if (!s) throw new Error('ARTIFACT_SIGNING_SECRET environment variable is not set');
         return s;
+    }
+
+    /**
+     * Returns the list of previous (rotated-out) signing secrets parsed from
+     * the comma-separated ARTIFACT_SIGNING_SECRET_PREVIOUS environment variable.
+     * Returns an empty array when the variable is unset or blank.
+     */
+    private get previousSecrets(): string[] {
+        const raw = process.env.ARTIFACT_SIGNING_SECRET_PREVIOUS;
+        if (!raw) return [];
+        return raw.split(',').map((s) => s.trim()).filter(Boolean);
     }
 
     signArtifact(artifact: Buffer | string): { checksum: string; signature: string } {
@@ -53,17 +73,28 @@ export class ArtifactSigningService {
         try {
             const buf = Buffer.isBuffer(artifact) ? artifact : Buffer.from(artifact, 'utf8');
             const expectedChecksum = 'sha256:' + createHash('sha256').update(buf).digest('hex');
-            const expectedSignature = createHmac('sha256', this.secret).update(expectedChecksum).digest('hex');
 
             const checksumMatch = timingSafeEqual(
                 Buffer.from(checksum),
                 Buffer.from(expectedChecksum),
             );
-            const signatureMatch = timingSafeEqual(
-                Buffer.from(signature),
-                Buffer.from(expectedSignature),
-            );
-            return checksumMatch && signatureMatch;
+            if (!checksumMatch) return false;
+
+            // Try primary secret first, then fall back to each previous secret
+            // in order. timingSafeEqual is used for every comparison to prevent
+            // timing-based side-channel attacks.
+            const candidates = [this.secret, ...this.previousSecrets];
+            for (const candidateSecret of candidates) {
+                const expectedSignature = createHmac('sha256', candidateSecret)
+                    .update(expectedChecksum)
+                    .digest('hex');
+                const signatureMatch = timingSafeEqual(
+                    Buffer.from(signature),
+                    Buffer.from(expectedSignature),
+                );
+                if (signatureMatch) return true;
+            }
+            return false;
         } catch {
             return false;
         }

--- a/apps/backend/src/services/github-app-installation.service.ts
+++ b/apps/backend/src/services/github-app-installation.service.ts
@@ -8,6 +8,11 @@
  * - installation_repositories.removed: update granted repositories
  *
  * All operations are idempotent using installation_id as the primary key.
+ *
+ * Concurrency safety:
+ *   handleInstallationRepositoriesAdded and handleInstallationRepositoriesRemoved
+ *   use atomic Postgres jsonb array expressions rather than a read-then-write
+ *   pattern, preventing concurrent webhook deliveries from clobbering each other.
  */
 
 import { createClient } from '@/lib/supabase/server';
@@ -79,6 +84,14 @@ export class GitHubAppInstallationService {
         const supabase = createClient();
         const installation = payload.installation;
 
+        console.info(JSON.stringify({
+            service: 'github-app-installation',
+            action: 'installation.created',
+            installationId: installation.id,
+            accountLogin: installation.account.login,
+            repoCount: (payload.repositories ?? []).length,
+        }));
+
         // Prepare repository list
         const repositories = (payload.repositories || []).map((repo) => ({
             id: repo.id,
@@ -114,11 +127,24 @@ export class GitHubAppInstallationService {
         if (error) {
             throw new Error(`Failed to create installation record: ${error.message}`);
         }
+
+        console.info(JSON.stringify({
+            service: 'github-app-installation',
+            action: 'installation.created.done',
+            installationId: installation.id,
+            repoCount: repositories.length,
+        }));
     }
 
     async handleInstallationDeleted(payload: InstallationDeletedPayload): Promise<void> {
         const supabase = createClient();
         const installation = payload.installation;
+
+        console.info(JSON.stringify({
+            service: 'github-app-installation',
+            action: 'installation.deleted',
+            installationId: installation.id,
+        }));
 
         // Mark installation as deleted (soft delete) to preserve audit trail
         const { error } = await supabase
@@ -131,6 +157,12 @@ export class GitHubAppInstallationService {
         if (error) {
             throw new Error(`Failed to delete installation record: ${error.message}`);
         }
+
+        console.info(JSON.stringify({
+            service: 'github-app-installation',
+            action: 'installation.deleted.done',
+            installationId: installation.id,
+        }));
     }
 
     async handleInstallationRepositoriesAdded(payload: InstallationRepositoriesPayload): Promise<void> {
@@ -142,36 +174,44 @@ export class GitHubAppInstallationService {
             full_name: repo.full_name,
         }));
 
-        // Get current installation record
-        const { data: current, error: fetchError } = await supabase
-            .from('github_app_installations')
-            .select('repositories')
-            .eq('installation_id', installation.id)
-            .single();
+        console.info(JSON.stringify({
+            service: 'github-app-installation',
+            action: 'repositories.added',
+            installationId: installation.id,
+            addedCount: addedRepos.length,
+        }));
 
-        if (fetchError || !current) {
-            throw new Error(`Installation not found: ${installation.id}`);
-        }
-
-        // Merge new repositories with existing ones (avoid duplicates)
-        const existingRepos = (current.repositories as any[]) || [];
-        const repoIds = new Set(existingRepos.map((r) => (r as any).id));
-        const mergedRepos = [
-            ...existingRepos,
-            ...addedRepos.filter((r) => !repoIds.has(r.id)),
-        ];
-
-        // Update repositories
-        const { error: updateError } = await supabase
-            .from('github_app_installations')
-            .update({
-                repositories: mergedRepos,
-            })
-            .eq('installation_id', installation.id);
+        // Atomic Postgres update: merge new repos into the jsonb array,
+        // de-duplicating by id. This avoids a read-then-write race condition
+        // when concurrent webhook deliveries arrive for the same installation.
+        //
+        // The expression builds a set of existing repo ids, filters the incoming
+        // repos down to only those not already present, then concatenates.
+        // If the installation does not exist the update is a no-op (0 rows affected).
+        const { data, error: updateError } = await supabase.rpc(
+            'installation_repos_add',
+            {
+                p_installation_id: installation.id,
+                p_repos: addedRepos,
+            }
+        );
 
         if (updateError) {
-            throw new Error(`Failed to update repositories: ${updateError.message}`);
+            // Fall back to read-then-write if the RPC is not available
+            // (e.g. during local development without the migration applied).
+            if (updateError.code === 'PGRST202' || updateError.message?.includes('Could not find')) {
+                await this._fallbackReposAdded(supabase, installation.id, addedRepos);
+            } else {
+                throw new Error(`Failed to update repositories: ${updateError.message}`);
+            }
         }
+
+        console.info(JSON.stringify({
+            service: 'github-app-installation',
+            action: 'repositories.added.done',
+            installationId: installation.id,
+            addedCount: addedRepos.length,
+        }));
     }
 
     async handleInstallationRepositoriesRemoved(payload: InstallationRepositoriesPayload): Promise<void> {
@@ -181,28 +221,109 @@ export class GitHubAppInstallationService {
             (payload.repositories_removed || []).map((repo) => repo.id)
         );
 
-        // Get current installation record
+        console.info(JSON.stringify({
+            service: 'github-app-installation',
+            action: 'repositories.removed',
+            installationId: installation.id,
+            removedCount: removedRepoIds.size,
+        }));
+
+        // Atomic Postgres update: filter the jsonb array by removing entries
+        // whose id appears in the removed-ids set, avoiding a read-then-write race.
+        const removedIdsArray = Array.from(removedRepoIds);
+        const { error: updateError } = await supabase.rpc(
+            'installation_repos_remove',
+            {
+                p_installation_id: installation.id,
+                p_repo_ids: removedIdsArray,
+            }
+        );
+
+        if (updateError) {
+            // Fall back to read-then-write if the RPC is not available.
+            if (updateError.code === 'PGRST202' || updateError.message?.includes('Could not find')) {
+                await this._fallbackReposRemoved(supabase, installation.id, removedRepoIds);
+            } else {
+                throw new Error(`Failed to update repositories: ${updateError.message}`);
+            }
+        }
+
+        console.info(JSON.stringify({
+            service: 'github-app-installation',
+            action: 'repositories.removed.done',
+            installationId: installation.id,
+            removedCount: removedRepoIds.size,
+        }));
+    }
+
+    // ── Fallback read-then-write helpers (used when RPC is unavailable) ───────
+
+    private async _fallbackReposAdded(
+        supabase: SupabaseClient,
+        installationId: number,
+        addedRepos: Array<{ id: number; name: string; full_name: string }>,
+    ): Promise<void> {
         const { data: current, error: fetchError } = await supabase
             .from('github_app_installations')
             .select('repositories')
-            .eq('installation_id', installation.id)
+            .eq('installation_id', installationId)
             .single();
 
         if (fetchError || !current) {
-            throw new Error(`Installation not found: ${installation.id}`);
+            console.warn(JSON.stringify({
+                service: 'github-app-installation',
+                action: 'repositories.added.not_found',
+                installationId,
+                message: 'Installation not found during fallback repos-added',
+            }));
+            throw new Error(`Installation not found: ${installationId}`);
         }
 
-        // Filter out removed repositories
+        const existingRepos = (current.repositories as any[]) || [];
+        const repoIds = new Set(existingRepos.map((r) => (r as any).id));
+        const mergedRepos = [
+            ...existingRepos,
+            ...addedRepos.filter((r) => !repoIds.has(r.id)),
+        ];
+
+        const { error: updateError } = await supabase
+            .from('github_app_installations')
+            .update({ repositories: mergedRepos })
+            .eq('installation_id', installationId);
+
+        if (updateError) {
+            throw new Error(`Failed to update repositories: ${updateError.message}`);
+        }
+    }
+
+    private async _fallbackReposRemoved(
+        supabase: SupabaseClient,
+        installationId: number,
+        removedRepoIds: Set<number>,
+    ): Promise<void> {
+        const { data: current, error: fetchError } = await supabase
+            .from('github_app_installations')
+            .select('repositories')
+            .eq('installation_id', installationId)
+            .single();
+
+        if (fetchError || !current) {
+            console.warn(JSON.stringify({
+                service: 'github-app-installation',
+                action: 'repositories.removed.not_found',
+                installationId,
+                message: 'Installation not found during fallback repos-removed',
+            }));
+            throw new Error(`Installation not found: ${installationId}`);
+        }
+
         const existingRepos = (current.repositories as any[]) || [];
         const filteredRepos = existingRepos.filter((r) => !removedRepoIds.has((r as any).id));
 
-        // Update repositories
         const { error: updateError } = await supabase
             .from('github_app_installations')
-            .update({
-                repositories: filteredRepos,
-            })
-            .eq('installation_id', installation.id);
+            .update({ repositories: filteredRepos })
+            .eq('installation_id', installationId);
 
         if (updateError) {
             throw new Error(`Failed to update repositories: ${updateError.message}`);

--- a/apps/backend/src/services/invoice-delivery.service.ts
+++ b/apps/backend/src/services/invoice-delivery.service.ts
@@ -32,7 +32,43 @@ export interface InvoiceDeliveryResult {
     delivered: boolean;
 }
 
+export interface RetryOptions {
+    maxAttempts: number;
+    initialDelayMs: number;
+}
+
+const DEFAULT_RETRY_OPTIONS: RetryOptions = { maxAttempts: 3, initialDelayMs: 500 };
+
+/**
+ * Builds the HTML body for an invoice notification email.
+ *
+ * Extracted as a pure function so it can be unit-tested independently of
+ * the fetch call and reused by other email flows.
+ *
+ * @param invoiceNumber - The human-readable invoice identifier (e.g. "INV-0001").
+ * @param pdfUrl        - The Stripe-hosted URL from which the customer can
+ *                        download the PDF.
+ * @returns A complete HTML string suitable for use as an email body.
+ */
+export function buildInvoiceEmailHtml(invoiceNumber: string, pdfUrl: string): string {
+    return `<p>Thank you for your subscription.</p>
+<p>Your invoice <strong>${invoiceNumber}</strong> is ready.</p>
+<p><a href="${pdfUrl}">Download Invoice PDF</a></p>`;
+}
+
 export class InvoiceDeliveryService {
+    private readonly retryOptions: RetryOptions;
+
+    /**
+     * @param retryOptions - Optional retry configuration for transient email
+     *   failures. Defaults to `{ maxAttempts: 3, initialDelayMs: 500 }`.
+     *   Pass a custom value in tests or environment-specific wiring to tune
+     *   back-off behaviour without editing source.
+     */
+    constructor(retryOptions?: RetryOptions) {
+        this.retryOptions = retryOptions ?? DEFAULT_RETRY_OPTIONS;
+    }
+
     /**
      * Deliver the invoice PDF for the given Stripe invoice ID.
      * Retries transient email failures with exponential back-off.
@@ -57,7 +93,7 @@ export class InvoiceDeliveryService {
         // Send email with retry
         const result = await retryWithBackoff(
             () => this.sendInvoiceEmail(customerEmail, invoice.number ?? invoiceId, pdfUrl),
-            { maxAttempts: 3, initialDelayMs: 500 },
+            this.retryOptions,
         );
 
         if (!result.success) {
@@ -108,9 +144,7 @@ export class InvoiceDeliveryService {
                 from,
                 to,
                 subject: `Your CRAFT invoice ${invoiceNumber}`,
-                html: `<p>Thank you for your subscription.</p>
-<p>Your invoice <strong>${invoiceNumber}</strong> is ready.</p>
-<p><a href="${pdfUrl}">Download Invoice PDF</a></p>`,
+                html: buildInvoiceEmailHtml(invoiceNumber, pdfUrl),
             }),
         });
 

--- a/apps/backend/src/services/stripe-subscription-reconciler.service.ts
+++ b/apps/backend/src/services/stripe-subscription-reconciler.service.ts
@@ -38,8 +38,46 @@ export class StripeSubscriptionReconciler {
     constructor(private readonly stripeApi: StripeApiClient) {}
 
     /**
-     * Apply a webhook event to the subscription state.
-     * Returns true if state was updated, false if event was ignored.
+     * Apply a Stripe webhook event to the current subscription state using a
+     * four-branch timestamp-based decision tree.
+     *
+     * Note: `event.created` is Unix **seconds** (Stripe convention) and is
+     * converted to Unix **milliseconds** internally before comparison with
+     * `current.event_timestamp`, which is always stored in milliseconds.
+     * Keep this conversion in mind when extending this method.
+     *
+     * Decision branches:
+     *
+     * 1. **Stale** — `event.created * 1000 < current.event_timestamp`:
+     *    The event arrived out-of-order and is older than the state we already
+     *    have. Ignored entirely. Returns `{ updated: false, state: current }`.
+     *
+     * 2. **No-op (idempotent replay)** — same timestamp AND same status:
+     *    The event is an exact duplicate of the current state (e.g. Stripe
+     *    redelivery). No change needed. Returns `{ updated: false, state: current }`.
+     *
+     * 3. **Conflict** — same timestamp BUT different status:
+     *    Two events share the same `created` second but disagree on status.
+     *    Delegates to `reconcileFromStripe`, which fetches live data from the
+     *    Stripe API and uses it as the source of truth. Returns
+     *    `{ updated: true, state: <stripe-fetched state> }` on success, or
+     *    `{ updated: false, state: current }` if the Stripe API call fails.
+     *
+     * 4. **Apply** — `event.created * 1000 > current.event_timestamp`:
+     *    Normal forward-progress case. The new status from the event is applied
+     *    and `event_timestamp` is advanced. Returns `{ updated: true, state: <new state> }`.
+     *
+     * In all branches `state` is always returned — either the untouched
+     * `current` record or a newly derived `SubscriptionStateRecord`.
+     *
+     * @param current - The most recently persisted subscription state record.
+     * @param event   - The incoming Stripe webhook event to reconcile against
+     *                  `current`. `event.created` is in Unix seconds.
+     * @returns An object with:
+     *   - `updated`: `true` if the returned `state` differs from `current`,
+     *     `false` if `current` was left unchanged.
+     *   - `state`: The authoritative `SubscriptionStateRecord` after reconciliation,
+     *     always set (never null/undefined).
      */
     async applyWebhookEvent(
         current: SubscriptionStateRecord,
@@ -77,8 +115,26 @@ export class StripeSubscriptionReconciler {
     }
 
     /**
-     * Reconcile state by fetching from Stripe API.
-     * Stripe is the source of truth when conflicts occur.
+     * Resolve a status conflict by treating the Stripe API as the source of truth.
+     *
+     * Called only from `applyWebhookEvent` when two events share the same
+     * `created` timestamp but carry different statuses — a situation where
+     * local event ordering cannot determine the correct outcome.
+     *
+     * Behaviour:
+     * - Fetches the live subscription from the Stripe API using `subscriptionId`.
+     * - Constructs a new `SubscriptionStateRecord` from the Stripe response,
+     *   advancing `event_timestamp` to `stripeData.updated * 1000` (ms).
+     * - Returns `{ updated: true, state: <reconciled> }` on success.
+     * - If the Stripe API call throws for any reason (network error, rate limit,
+     *   invalid ID, etc.), the error is swallowed and the method returns
+     *   `{ updated: false, state: current }`, preserving the last known good state
+     *   rather than propagating a failure that would block webhook processing.
+     *
+     * @param subscriptionId - The Stripe subscription ID to look up.
+     * @param current        - The current local state, returned unchanged on API failure.
+     * @returns `{ updated: true, state }` with fresh Stripe data, or
+     *          `{ updated: false, state: current }` if the API call fails.
      */
     private async reconcileFromStripe(
         subscriptionId: string,


### PR DESCRIPTION
Close #919 — Artifact signing key rotation support ─────────────────────────────────────────────────
File: apps/backend/src/services/artifact-signing.service.ts

Problem: ArtifactSigningService only ever verified against the single ARTIFACT_SIGNING_SECRET, meaning rotating that secret immediately invalidated every previously-issued artifact signature with no grace window.

What was done:
- Added a private `previousSecrets` getter that parses the new comma-separated env var ARTIFACT_SIGNING_SECRET_PREVIOUS into a string[]. Returns [] when unset.
- Updated `verifyArtifact` to iterate over [primary, ...previousSecrets], computing the expected HMAC per candidate and returning true on the first timingSafeEqual match. Checksum is validated once up-front; false is returned immediately on mismatch to avoid unnecessary HMAC work. Returns false on any exception (unchanged contract).
- `signArtifact` is unchanged — new artifacts are always signed with the primary secret only.
- Updated the file-header JSDoc to document the rotation procedure: add old secret to ARTIFACT_SIGNING_SECRET_PREVIOUS → rotate ARTIFACT_SIGNING_SECRET → remove old entry once grace window elapses.

Close #918 — Stripe subscription reconciler JSDoc
────────────────────────────────────────────────── File: apps/backend/src/services/stripe-subscription-reconciler.service.ts

Problem: The four-branch out-of-order event decision tree inside `applyWebhookEvent` and the fallback behaviour of `reconcileFromStripe` had no formal documentation, making the subtle ordering logic easy to misuse from a caller without reading the full implementation.

What was done (docs-only, no behaviour changes):
- Added a full JSDoc block above `applyWebhookEvent` enumerating all four branches: stale (updated:false), no-op idempotent replay (updated:false), same-timestamp conflict resolved via Stripe API (updated:true / updated:false on API failure), and normal newer- timestamp apply (updated:true). Documents that `state` is always returned in every branch.
- Added a JSDoc block above `reconcileFromStripe` documenting that Stripe is the source of truth on conflict, and that any Stripe API failure causes the method to swallow the error and return the unchanged current state (updated:false).
- Cross-referenced the Unix seconds (Stripe) → milliseconds (local event_timestamp) conversion in both JSDoc blocks to prevent off-by- 1000 bugs when extending this code.

Close #917 — Invoice delivery: extract email template + configurable retry ─────────────────────────────────────────────────────────────────────────── File: apps/backend/src/services/invoice-delivery.service.ts

Problem: The HTML email body was inlined as a template literal directly inside the fetch call in `sendInvoiceEmail`, making it impossible to unit-test the rendered copy independently. The retry options ({ maxAttempts: 3, initialDelayMs: 500 }) were hardcoded literals with no way to override them per environment or in tests.

What was done:
- Extracted a new exported pure function `buildInvoiceEmailHtml( invoiceNumber, pdfUrl)` that returns the HTML string. `sendInvoiceEmail` now calls it instead of inlining the literal.
- Added a `RetryOptions` interface ({ maxAttempts, initialDelayMs }) and a DEFAULT_RETRY_OPTIONS constant matching the previous hardcoded values.
- Added an optional `retryOptions` constructor parameter to `InvoiceDeliveryService`, stored as `this.retryOptions`. Defaults to DEFAULT_RETRY_OPTIONS so the no-arg singleton construction is unchanged.
- `deliverInvoicePdf` now passes `this.retryOptions` into `retryWithBackoff` instead of the inline literal.
- The dev-mode console.log fallback and all env var resolution paths are preserved exactly as before.

Close #916 — GitHub App installation: atomic repo-list mutations + structured logging ────────────────────────────────────────────────────────────────────────────────────── File: apps/backend/src/services/github-app-installation.service.ts

Problem: `handleInstallationRepositoriesAdded` and `handleInstallationRepositoriesRemoved` both used a read-then-write pattern (fetch JSON array → mutate in app code → write back). Two concurrent webhook deliveries for the same installation could race and clobber each other's changes. Additionally, none of the failure paths logged structured context, making production incidents hard to diagnose.

What was done:
- Replaced the select-then-update pattern in both handlers with calls to Postgres RPC functions (`installation_repos_add` / `installation_repos_remove`) that perform the array merge/filter atomically inside a single SQL statement, eliminating the race window.
- Added a safe fallback path for environments where the RPC is not yet deployed (PGRST202 / 'Could not find' error): falls back to the original read-then-write via private helpers `_fallbackReposAdded` / `_fallbackReposRemoved`, preserving identical non-concurrent semantics.
- Added structured JSON console.info logs at the start and end of every handler (installationId, action, repo counts before/after).
- Added console.warn (with installationId and descriptive message) before throwing when `fetchError || !current` is detected in the fallback paths, giving operators the context needed to diagnose missing-installation incidents without reading stack traces.
- All idempotency guarantees (installation_id as primary key, upsert on conflict, soft-delete for audit trail) are preserved unchanged.