### PR TITLE
fix: resolve 4 bugs — backoff jitter cap, DLQ dedup, SSE seq-reset de…

### DIFF
--- a/apps/backend/src/lib/dns/domain-verification.ts
+++ b/apps/backend/src/lib/dns/domain-verification.ts
@@ -43,6 +43,20 @@ export interface VerifyDomainOptions {
 /** Vercel CNAME target — must match dns-configuration.ts */
 const VERCEL_CNAME_TARGET = 'cname.vercel-dns.com';
 
+/**
+ * Strips a single trailing dot from a domain string to normalise canonical
+ * FQDN notation (e.g. "app.example.com.") before validation (fixes #924).
+ * Domains with two or more trailing dots are returned as-is so that
+ * isValidDomain() continues to reject them.
+ */
+function stripTrailingDot(domain: string): string {
+    // Only strip when there is exactly one trailing dot
+    if (domain.endsWith('.') && !domain.endsWith('..')) {
+        return domain.slice(0, -1);
+    }
+    return domain;
+}
+
 /** Basic domain sanity check — not a full RFC validator, just guards obvious garbage. */
 export function isValidDomain(domain: string): boolean {
     return /^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,}$/i.test(domain);
@@ -67,6 +81,9 @@ export async function verifyViaTxt(
     token: string,
     options: VerifyDomainOptions = {},
 ): Promise<VerificationResult> {
+    // Normalise canonical FQDN notation (fixes #924)
+    domain = stripTrailingDot(domain);
+
     if (!isValidDomain(domain)) {
         return {
             verified: false,
@@ -151,6 +168,9 @@ export async function verifyViaCname(
     domain: string,
     options: VerifyDomainOptions = {},
 ): Promise<VerificationResult> {
+    // Normalise canonical FQDN notation (fixes #924)
+    domain = stripTrailingDot(domain);
+
     if (!isValidDomain(domain)) {
         return {
             verified: false,

--- a/apps/backend/src/lib/retry/exponential-backoff.ts
+++ b/apps/backend/src/lib/retry/exponential-backoff.ts
@@ -69,6 +69,12 @@ export function isRetryableError(error: unknown): boolean {
 /**
  * Calculate backoff delay with jitter
  * Prevents thundering herd by adding random jitter (±10%)
+ *
+ * The jitter is computed as ±10% of the pre-cap exponential value so that
+ * it scales correctly, and the result is re-clamped to [0, maxDelayMs]
+ * after adding jitter. This ensures the returned value never exceeds
+ * maxDelayMs even when the exponential term has already saturated the cap
+ * (fixes #925).
  */
 export function calculateBackoffDelay(
     attempt: number,
@@ -77,14 +83,13 @@ export function calculateBackoffDelay(
     multiplier: number,
 ): number {
     // Exponential backoff: initial * (multiplier ^ attempt)
-    let delay = initialDelayMs * Math.pow(multiplier, attempt);
+    const exponential = initialDelayMs * Math.pow(multiplier, attempt);
 
-    // Cap at max delay
-    delay = Math.min(delay, maxDelayMs);
+    // Add jitter: ±10% of the pre-cap exponential value
+    const jitter = exponential * 0.1 * (Math.random() - 0.5) * 2;
 
-    // Add jitter: ±10% of the delay
-    const jitter = delay * 0.1 * (Math.random() - 0.5) * 2;
-    return Math.max(0, delay + jitter);
+    // Clamp once at the end so jitter never pushes the delay above maxDelayMs
+    return Math.min(Math.max(0, exponential + jitter), maxDelayMs);
 }
 
 /**

--- a/apps/backend/src/lib/sse/log-stream-buffer.ts
+++ b/apps/backend/src/lib/sse/log-stream-buffer.ts
@@ -107,10 +107,43 @@ export class LogStreamBuffer {
      * Replay retained events with a sequence number greater than `lastSeq`,
      * for a client reconnecting via `Last-Event-ID`. Returns entries that are
      * still inside the retained window (oldest-first). The caller can detect a
-     * gap when {@link earliestRetainedSeq} is greater than `lastSeq + 1`.
+     * normal capacity-overflow gap when {@link earliestRetainedSeq} is greater
+     * than `lastSeq + 1`.
+     *
+     * **Important — sequence-reset detection (fixes #927):**
+     * Before trusting an empty or partial replay result, callers must also check
+     * {@link hasSequenceReset}. A new buffer instance (e.g. after a process
+     * restart) starts numbering from 1, so a client reconnecting with a large
+     * `lastSeq` will pass the normal gap check (earliestRetainedSeq > lastSeq+1
+     * evaluates false) yet still receive a misleading empty replay. When
+     * `hasSequenceReset(lastSeq)` returns `true` the route should emit an
+     * explicit `"stream-reset"` SSE event so the client knows to discard its
+     * prior state and start fresh.
      */
     replayFrom(lastSeq: number): LogStreamEvent[] {
         return this.history.filter((e) => e.seq > lastSeq);
+    }
+
+    /**
+     * Returns `true` when the client's `lastSeq` is higher than any sequence
+     * number this buffer instance has ever emitted. This is only possible when
+     * the buffer was re-created (e.g. after a process restart) and its counter
+     * has reset to a lower starting point than the client's high-water mark.
+     *
+     * Use this alongside the normal {@link earliestRetainedSeq} gap check:
+     * ```
+     * if (buffer.hasSequenceReset(clientLastSeq)) {
+     *   // emit a "stream-reset" SSE event; do NOT replay
+     * } else if ((buffer.earliestRetainedSeq() ?? 0) > clientLastSeq + 1) {
+     *   // emit a "buffer_overflow" / gap event; replay what is available
+     * } else {
+     *   // normal replay
+     *   const missed = buffer.replayFrom(clientLastSeq);
+     * }
+     * ```
+     */
+    hasSequenceReset(lastSeq: number): boolean {
+        return lastSeq > this.lastSeq;
     }
 
     /** Sequence of the oldest retained event, or null when history is empty. */

--- a/apps/backend/src/lib/webhook-dlq/dead-letter-queue.ts
+++ b/apps/backend/src/lib/webhook-dlq/dead-letter-queue.ts
@@ -55,6 +55,8 @@ interface CircuitBreakerState {
 }
 
 const store = new Map<string, DLQEntry>();
+/** Secondary index: stable dedup key → entry id (fixes #926). */
+const dedupIndex = new Map<string, string>();
 const circuitBreakers = new Map<string, CircuitBreakerState>();
 
 let _stripeProcessor: ProcessorFn | null = null;
@@ -62,6 +64,15 @@ let _githubProcessor: ProcessorFn | null = null;
 
 function generateId(): string {
     return `dlq_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`;
+}
+
+/**
+ * Derive a stable dedup key from the logical identity of a webhook delivery.
+ * We use a simple deterministic string rather than a crypto hash so there are
+ * no extra dependencies and the key remains human-readable in logs.
+ */
+function deriveDedupKey(source: WebhookSource, eventType: string, payload: string): string {
+    return `${source}::${eventType}::${payload}`;
 }
 
 function getCircuitBreaker(endpoint: string): CircuitBreakerState {
@@ -112,6 +123,30 @@ export const webhookDLQ = {
         attempts: number,
         endpointUrl?: string,
     ): DLQEntry {
+        // --- Dedup check (fixes #926) ---
+        // Derive a stable key for this logical webhook delivery.
+        const dedupKey = deriveDedupKey(source, eventType, payload);
+        const existingId = dedupIndex.get(dedupKey);
+
+        if (existingId !== undefined) {
+            const existing = store.get(existingId);
+            // Only merge when the existing entry has NOT already succeeded —
+            // a succeeded entry must not be resurrected for reprocessing.
+            if (existing && existing.reprocessStatus !== 'succeeded') {
+                existing.attempts = attempts;
+                existing.failureReason = failureReason;
+                store.set(existingId, existing);
+                console.warn('[DLQ] Duplicate capture merged into existing entry', {
+                    id: existingId,
+                    source,
+                    eventType,
+                    attempts,
+                    failureReason,
+                });
+                return existing;
+            }
+        }
+
         const entry: DLQEntry = {
             id: generateId(),
             source,
@@ -124,6 +159,7 @@ export const webhookDLQ = {
             endpointUrl,
         };
         store.set(entry.id, entry);
+        dedupIndex.set(dedupKey, entry.id);
         console.error('[DLQ] Event captured', {
             id: entry.id,
             source,
@@ -281,6 +317,7 @@ export const webhookDLQ = {
     /** Exposed for testing only – resets all state. */
     _reset(): void {
         store.clear();
+        dedupIndex.clear();
         circuitBreakers.clear();
         _stripeProcessor = null;
         _githubProcessor = null;


### PR DESCRIPTION
…tection, DNS trailing-dot FQDN

Closes #924
Closes #925
Closes #926
Closes #927

──────────────────────────────────────────────────────────── Issue #925 — Repair Exponential Backoff Jitter Overflow File: apps/backend/src/lib/retry/exponential-backoff.ts ──────────────────────────────────────────────────────────── Root cause:
  calculateBackoffDelay() applied the ±10% jitter AFTER the Math.min()
  cap, so any attempt that had already saturated maxDelayMs could return
  a value up to 10% above the documented maximum.

Fix:
  Compute jitter as ±10% of the raw exponential value (before capping),
  then apply a single Math.min(…, maxDelayMs) clamp at the very end:

    const exponential = initialDelayMs * Math.pow(multiplier, attempt);
    const jitter      = exponential * 0.1 * (Math.random() - 0.5) * 2;
    return Math.min(Math.max(0, exponential + jitter), maxDelayMs);

  Early (uncapped) attempts are unaffected — jitter still scales with the
  exponential value. Saturated (capped) attempts are now guaranteed to
  stay within maxDelayMs regardless of the random sample. Both callers
  (retryWithBackoff and webhookDLQ.scheduleRetry) inherit the fix
  automatically.

──────────────────────────────────────────────────────────── Issue #926 — Eliminate Missing Dedup Key in Webhook DLQ Capture File: apps/backend/src/lib/webhook-dlq/dead-letter-queue.ts ──────────────────────────────────────────────────────────── Root cause:
  webhookDLQ.capture() always called generateId() and inserted a new
  DLQEntry unconditionally. Upstream retry pipelines (Stripe / GitHub
  redelivery) calling capture() for the same (source, eventType, payload)
  therefore accumulated multiple independent entries, which could cause
  duplicate side effects when reprocess() / scheduleRetry() ran per entry.

Fix:
  Introduced a secondary Map<string, string> (dedupIndex) mapping a
  deterministic dedup key to the existing entry's id:

    dedupKey = `${source}::${eventType}::${payload}`

  In capture():
  - If a live (non-succeeded) entry already exists for this key, merge the new failure info (attempts, failureReason) into the existing entry and return it — no new entry is created.
  - If the matching entry has already succeeded, fall through and create a new entry (the old side effect is done; a fresh failure is a new event).
  - Otherwise, insert normally and record the key in dedupIndex.

  _reset() now also clears dedupIndex so test isolation is preserved.

──────────────────────────────────────────────────────────── Issue #927 — Repair Sequence-Reset Gap Detection in SSE Log Buffer File: apps/backend/src/lib/sse/log-stream-buffer.ts ──────────────────────────────────────────────────────────── Root cause:
  After a process restart a new LogStreamBuffer starts numbering from 1.
  A reconnecting client with a large Last-Event-ID passes the existing
  gap check (earliestRetainedSeq() > lastSeq + 1 evaluates false because
  earliestRetainedSeq() is null or a small number), so replayFrom()
  silently returns an empty array with no signal that the entire history
  is gone.

Fix:
  Added a new public method:

    hasSequenceReset(lastSeq: number): boolean {
        return lastSeq > this.lastSeq;
    }

  It returns true when the client claims a sequence number higher than
  any this instance has ever emitted — which is only possible after a
  counter reset. The existing earliestRetainedSeq() / replayFrom()
  behaviour for normal capacity-overflow gaps is completely unchanged.

  Updated the replayFrom() doc comment to document the two-step check
  callers must perform:
    1. hasSequenceReset(clientLastSeq) → emit a "stream-reset" SSE event
    2. earliestRetainedSeq() > clientLastSeq + 1 → emit buffer_overflow
    3. otherwise → normal replayFrom() path

──────────────────────────────────────────────────────────── Issue #924 — Resolve Trailing-Dot FQDN Rejection in DNS Verification File: apps/backend/src/lib/dns/domain-verification.ts ──────────────────────────────────────────────────────────── Root cause:
  verifyViaTxt() and verifyViaCname() called isValidDomain() on the raw
  input. The isValidDomain() regex requires the string to end with a TLD
  label and no trailing dot, so canonical FQDN inputs such as
  "app.example.com." were unconditionally rejected with INVALID_DOMAIN
  even though the domain is otherwise valid. This was inconsistent with
  validate-domain.ts which already stripped a trailing dot before
  validation, and with verifyViaCname() itself which stripped the trailing
  dot from the resolved CNAME value later in the same function.

Fix:
  Added a private helper:

    function stripTrailingDot(domain: string): string {
        if (domain.endsWith('.') && !domain.endsWith('..')) {
            return domain.slice(0, -1);
        }
        return domain;
    }

  Applied at the very top of both verifyViaTxt() and verifyViaCname()
  before calling isValidDomain(), before computing txtHostname(), and
  before splitting on '.' for the apex-domain check. Domains with two or
  more trailing dots are passed through unchanged and continue to be
  rejected by isValidDomain() as required.