### PR TITLE
Fix four concurrency and overload bugs in backend services

### DIFF
--- a/apps/backend/src/app/api/deployments/[id]/https/route.test.ts
+++ b/apps/backend/src/app/api/deployments/[id]/https/route.test.ts
@@ -3,7 +3,7 @@ import { NextRequest } from 'next/server';
 
 const mockGetUser = vi.fn();
 const mockFrom = vi.fn();
-const mockAddDomain = vi.fn();
+const mockAddProjectDomain = vi.fn();
 const mockGetCertificate = vi.fn();
 
 vi.mock('@/lib/supabase/server', () => ({
@@ -15,7 +15,7 @@ vi.mock('@/lib/supabase/server', () => ({
 
 vi.mock('@/services/vercel.service', () => ({
     VercelService: vi.fn().mockImplementation(() => ({
-        addDomain: mockAddDomain,
+        addProjectDomain: mockAddProjectDomain,
         getCertificate: mockGetCertificate,
     })),
     VercelApiError: class VercelApiError extends Error {
@@ -116,7 +116,7 @@ describe('POST /api/deployments/[id]/https', () => {
     it('returns 409 when domain already added', async () => {
         mockFrom.mockReturnValue(withProTier([{ data: fullDeployment, error: null }]));
         const { VercelApiError } = await import('@/services/vercel.service');
-        mockAddDomain.mockRejectedValue(new VercelApiError('exists', 'DOMAIN_EXISTS'));
+        mockAddProjectDomain.mockRejectedValue(new VercelApiError('exists', 'DOMAIN_EXISTS'));
         const { POST } = await import('./route');
         expect((await POST(makeRequest('POST'), { params })).status).toBe(409);
     });
@@ -124,7 +124,7 @@ describe('POST /api/deployments/[id]/https', () => {
     it('returns 429 with Retry-After when rate limited', async () => {
         mockFrom.mockReturnValue(withProTier([{ data: fullDeployment, error: null }]));
         const { VercelApiError } = await import('@/services/vercel.service');
-        mockAddDomain.mockRejectedValue(new VercelApiError('rate limited', 'RATE_LIMITED', 30_000));
+        mockAddProjectDomain.mockRejectedValue(new VercelApiError('rate limited', 'RATE_LIMITED', 30_000));
         const { POST } = await import('./route');
         const res = await POST(makeRequest('POST'), { params });
         expect(res.status).toBe(429);
@@ -133,7 +133,7 @@ describe('POST /api/deployments/[id]/https', () => {
 
     it('returns 200 with cert state on success', async () => {
         mockFrom.mockReturnValue(withProTier([{ data: fullDeployment, error: null }]));
-        mockAddDomain.mockResolvedValue(undefined);
+        mockAddProjectDomain.mockResolvedValue(undefined);
         mockGetCertificate.mockResolvedValue({ domain: 'example.com', state: 'pending' });
         const { POST } = await import('./route');
         const res = await POST(makeRequest('POST'), { params });
@@ -146,7 +146,7 @@ describe('POST /api/deployments/[id]/https', () => {
     // Certificate provisioning begins in 'pending' state immediately after domain is added
     it('returns pending cert state immediately after domain add', async () => {
         mockFrom.mockReturnValue(withProTier([{ data: fullDeployment, error: null }]));
-        mockAddDomain.mockResolvedValue(undefined);
+        mockAddProjectDomain.mockResolvedValue(undefined);
         mockGetCertificate.mockResolvedValue({ domain: 'example.com', state: 'pending', expiresAt: null });
 
         const { POST } = await import('./route');
@@ -162,7 +162,7 @@ describe('POST /api/deployments/[id]/https', () => {
     it('returns 500 when Vercel authentication fails (AUTH_FAILED)', async () => {
         mockFrom.mockReturnValue(withProTier([{ data: fullDeployment, error: null }]));
         const { VercelApiError } = await import('@/services/vercel.service');
-        mockAddDomain.mockRejectedValue(new VercelApiError('Invalid Vercel token', 'AUTH_FAILED'));
+        mockAddProjectDomain.mockRejectedValue(new VercelApiError('Invalid Vercel token', 'AUTH_FAILED'));
 
         const { POST } = await import('./route');
         expect((await POST(makeRequest('POST'), { params })).status).toBe(500);
@@ -171,7 +171,7 @@ describe('POST /api/deployments/[id]/https', () => {
     // Generic unexpected error from addDomain
     it('returns 500 on unexpected addDomain error', async () => {
         mockFrom.mockReturnValue(withProTier([{ data: fullDeployment, error: null }]));
-        mockAddDomain.mockRejectedValue(new Error('Unexpected Vercel error'));
+        mockAddProjectDomain.mockRejectedValue(new Error('Unexpected Vercel error'));
 
         const { POST } = await import('./route');
         const res = await POST(makeRequest('POST'), { params });
@@ -183,7 +183,7 @@ describe('POST /api/deployments/[id]/https', () => {
     // getCertificate fails after domain successfully added
     it('propagates error when getCertificate throws after successful domain add', async () => {
         mockFrom.mockReturnValue(withProTier([{ data: fullDeployment, error: null }]));
-        mockAddDomain.mockResolvedValue(undefined);
+        mockAddProjectDomain.mockResolvedValue(undefined);
         mockGetCertificate.mockRejectedValue(new Error('Certificate fetch failed'));
 
         const { POST } = await import('./route');
@@ -195,7 +195,7 @@ describe('POST /api/deployments/[id]/https', () => {
     it('rounds Retry-After up to nearest second for fractional retryAfterMs', async () => {
         mockFrom.mockReturnValue(withProTier([{ data: fullDeployment, error: null }]));
         const { VercelApiError } = await import('@/services/vercel.service');
-        mockAddDomain.mockRejectedValue(new VercelApiError('rate limited', 'RATE_LIMITED', 1500));
+        mockAddProjectDomain.mockRejectedValue(new VercelApiError('rate limited', 'RATE_LIMITED', 1500));
 
         const { POST } = await import('./route');
         const res = await POST(makeRequest('POST'), { params });
@@ -207,7 +207,7 @@ describe('POST /api/deployments/[id]/https', () => {
     it('omits Retry-After header when retryAfterMs is undefined', async () => {
         mockFrom.mockReturnValue(withProTier([{ data: fullDeployment, error: null }]));
         const { VercelApiError } = await import('@/services/vercel.service');
-        mockAddDomain.mockRejectedValue(new VercelApiError('rate limited', 'RATE_LIMITED'));
+        mockAddProjectDomain.mockRejectedValue(new VercelApiError('rate limited', 'RATE_LIMITED'));
 
         const { POST } = await import('./route');
         const res = await POST(makeRequest('POST'), { params });

--- a/apps/backend/src/app/api/deployments/[id]/https/route.ts
+++ b/apps/backend/src/app/api/deployments/[id]/https/route.ts
@@ -60,7 +60,7 @@ export const POST = withDomainTierCheck(async (_req: NextRequest, { params, supa
     }
 
     try {
-        await vercel.addDomain(deployment.vercel_project_id, deployment.custom_domain);
+        await vercel.addProjectDomain(deployment.vercel_project_id, deployment.custom_domain);
     } catch (err: unknown) {
         const vercelErr = err as VercelApiError;
         if (vercelErr.code === 'DOMAIN_EXISTS') {

--- a/apps/backend/src/services/deployment.service.ts
+++ b/apps/backend/src/services/deployment.service.ts
@@ -477,13 +477,13 @@ export class DeploymentService {
             // Log failure
             await this.logProgress(deploymentId, 'failed', `Redeployment failed: ${error.message}`);
 
-            // Restore previous status if it was completed
-            if (deployment.status === 'completed') {
-                await supabase.from('deployments').update({
-                    status: 'completed' as DeploymentStatusType,
-                    updated_at: new Date().toISOString(),
-                }).eq('id', deploymentId);
-            }
+            // Restore the pre-redeploy status (either 'completed' or 'failed' —
+            // both are valid entries in redeployableStatuses) so the row never
+            // gets stuck at 'deploying' with no work actually in flight.
+            await supabase.from('deployments').update({
+                status: deployment.status as DeploymentStatusType,
+                updated_at: new Date().toISOString(),
+            }).eq('id', deploymentId);
 
             return {
                 success: false,

--- a/apps/backend/src/services/multi-provider-auth.service.test.ts
+++ b/apps/backend/src/services/multi-provider-auth.service.test.ts
@@ -14,11 +14,14 @@ vi.mock('@/lib/github/token-encryption', () => ({
 // ── helpers ───────────────────────────────────────────────────────────────────
 
 type UpdatePayload = Record<string, unknown>;
+type RpcCall = { fn: string; args: Record<string, unknown> };
 
 function makeSupabase(rows: Record<string, unknown> = {}) {
     const updateCalls: UpdatePayload[] = [];
+    const rpcCalls: RpcCall[] = [];
     const client = {
         _updateCalls: updateCalls,
+        _rpcCalls: rpcCalls,
         from: vi.fn().mockReturnValue({
             select: vi.fn().mockReturnThis(),
             update: vi.fn().mockImplementation((payload: UpdatePayload) => {
@@ -29,6 +32,10 @@ function makeSupabase(rows: Record<string, unknown> = {}) {
             }),
             eq: vi.fn().mockReturnThis(),
             single: vi.fn().mockResolvedValue({ data: rows, error: null }),
+        }),
+        rpc: vi.fn().mockImplementation((fn: string, args: Record<string, unknown>) => {
+            rpcCalls.push({ fn, args });
+            return Promise.resolve({ error: null });
         }),
     };
     return client as any;
@@ -82,26 +89,31 @@ describe('MultiProviderAuthService', () => {
         expect(result.connected).toBe(true);
         expect(result.provider).toBe('stellar');
 
-        const payload = supabase._updateCalls[0];
-        expect(payload.provider_connections).toMatchObject({
-            stellar: { publicKey: 'GABC123' },
-        });
+        const rpcCall = supabase._rpcCalls[0];
+        expect(rpcCall.args.p_value).toMatchObject({ publicKey: 'GABC123' });
         // No private key field
-        expect(JSON.stringify(payload)).not.toContain('privateKey');
-        expect(JSON.stringify(payload)).not.toContain('secretKey');
+        expect(JSON.stringify(rpcCall.args)).not.toContain('privateKey');
+        expect(JSON.stringify(rpcCall.args)).not.toContain('secretKey');
     });
 
-    it('preserves existing provider_connections when adding Stellar', async () => {
-        const existing = { someOther: { data: 'value' } };
-        const supabase = makeSupabase({ provider_connections: existing });
+    it('merges Stellar into provider_connections atomically via RPC (no client-side read-modify-write)', async () => {
+        // Regression test: connectStellar/disconnectProvider used to read
+        // provider_connections, merge in memory, then write the whole object
+        // back — a race between two concurrent requests could silently drop
+        // one side's change. The merge now happens inside a single row-locked
+        // Postgres function (see supabase/migrations/017_provider_connections_atomic_rpc.sql),
+        // so the client only ever sends its own provider's value, never a
+        // merged snapshot of the whole column.
+        const supabase = makeSupabase({ provider_connections: { someOther: { data: 'value' } } });
         const { multiProviderAuthService } = await import('./multi-provider-auth.service');
 
         await multiProviderAuthService.connectStellar(supabase, 'user-1', 'GXYZ');
 
-        const payload = supabase._updateCalls[0];
-        expect(payload.provider_connections).toMatchObject({
-            someOther: { data: 'value' },
-            stellar: { publicKey: 'GXYZ' },
+        expect(supabase.from).not.toHaveBeenCalled();
+        expect(supabase.rpc).toHaveBeenCalledWith('set_provider_connection', {
+            p_user_id: 'user-1',
+            p_provider: 'stellar',
+            p_value: expect.objectContaining({ publicKey: 'GXYZ' }),
         });
     });
 
@@ -121,7 +133,7 @@ describe('MultiProviderAuthService', () => {
         expect(payload.github_token_encrypted).toBeNull();
     });
 
-    it('removes only the stellar key from provider_connections on disconnect', async () => {
+    it('removes only the stellar key from provider_connections on disconnect via atomic RPC', async () => {
         const supabase = makeSupabase({
             provider_connections: { stellar: { publicKey: 'G1' }, other: { x: 1 } },
         });
@@ -129,9 +141,14 @@ describe('MultiProviderAuthService', () => {
 
         await multiProviderAuthService.disconnectProvider(supabase, 'user-1', 'stellar');
 
-        const payload = supabase._updateCalls[0];
-        expect(payload.provider_connections).not.toHaveProperty('stellar');
-        expect(payload.provider_connections).toMatchObject({ other: { x: 1 } });
+        // No client-side select-then-update — the removal happens inside
+        // remove_provider_connection's row-locked UPDATE, closing the race
+        // where a concurrent connect/disconnect could clobber this change.
+        expect(supabase.from).not.toHaveBeenCalled();
+        expect(supabase.rpc).toHaveBeenCalledWith('remove_provider_connection', {
+            p_user_id: 'user-1',
+            p_provider: 'stellar',
+        });
     });
 
     // ── getConnectionStatus ───────────────────────────────────────────────────

--- a/apps/backend/src/services/multi-provider-auth.service.ts
+++ b/apps/backend/src/services/multi-provider-auth.service.ts
@@ -91,32 +91,22 @@ export class MultiProviderAuthService {
      * Connect a Stellar wallet to the platform identity.
      * Only the public key is stored — the platform never holds the private key.
      * Idempotent — re-connecting replaces the existing public key.
+     *
+     * Uses the set_provider_connection RPC to merge into provider_connections
+     * atomically (single row-locked UPDATE) instead of a client-side
+     * read-modify-write, which would let a concurrent request (e.g. a second
+     * browser tab, or a retried request) silently clobber this change.
      */
     async connectStellar(
         supabase: SupabaseClient,
         userId: string,
         publicKey: string,
     ): Promise<ExchangeResult> {
-        // Read existing provider_connections to merge
-        const { data } = await supabase
-            .from('profiles')
-            .select('provider_connections')
-            .eq('id', userId)
-            .single();
-
-        const existing = (data?.provider_connections as Record<string, unknown>) ?? {};
-        const updated = {
-            ...existing,
-            stellar: { publicKey, connectedAt: new Date().toISOString() },
-        };
-
-        const { error } = await supabase
-            .from('profiles')
-            .update({
-                provider_connections: updated,
-                updated_at: new Date().toISOString(),
-            })
-            .eq('id', userId);
+        const { error } = await supabase.rpc('set_provider_connection', {
+            p_user_id: userId,
+            p_provider: 'stellar',
+            p_value: { publicKey, connectedAt: new Date().toISOString() },
+        });
 
         if (error) throw new Error(`Failed to connect Stellar wallet: ${error.message}`);
 
@@ -146,22 +136,14 @@ export class MultiProviderAuthService {
 
             if (error) throw new Error(`Failed to disconnect GitHub: ${error.message}`);
         } else {
-            const { data } = await supabase
-                .from('profiles')
-                .select('provider_connections')
-                .eq('id', userId)
-                .single();
-
-            const existing = (data?.provider_connections as Record<string, unknown>) ?? {};
-            const { stellar: _removed, ...rest } = existing as any;
-
-            const { error } = await supabase
-                .from('profiles')
-                .update({
-                    provider_connections: rest,
-                    updated_at: new Date().toISOString(),
-                })
-                .eq('id', userId);
+            // Uses the remove_provider_connection RPC for the same reason
+            // connectStellar uses set_provider_connection: a client-side
+            // read-modify-write here would race with a concurrent connect/
+            // disconnect and silently drop whichever change lost the race.
+            const { error } = await supabase.rpc('remove_provider_connection', {
+                p_user_id: userId,
+                p_provider: 'stellar',
+            });
 
             if (error) throw new Error(`Failed to disconnect Stellar: ${error.message}`);
         }

--- a/apps/backend/src/services/supabase-realtime-subscription.service.ts
+++ b/apps/backend/src/services/supabase-realtime-subscription.service.ts
@@ -51,6 +51,7 @@ export class SupabaseRealtimeSubscriptionService {
     private connectionState: ConnectionState = 'disconnected';
     private reconnectAttempts = 0;
     private pollingHandle: NodeJS.Timeout | null = null;
+    private reconnectTimeout: NodeJS.Timeout | null = null;
 
     constructor(
         private readonly realtime: RealtimeClient,
@@ -93,7 +94,7 @@ export class SupabaseRealtimeSubscriptionService {
                     // Retry with exponential backoff
                     this.connectionState = 'reconnecting';
                     const delayMs = this.reconnectDelayMs * Math.pow(2, this.reconnectAttempts - 1);
-                    setTimeout(attemptConnect, delayMs);
+                    this.reconnectTimeout = setTimeout(attemptConnect, delayMs);
                 }
             }
         };
@@ -103,6 +104,10 @@ export class SupabaseRealtimeSubscriptionService {
         // Return unsubscribe function
         return () => {
             this.connectionState = 'disconnected';
+            if (this.reconnectTimeout) {
+                clearTimeout(this.reconnectTimeout);
+                this.reconnectTimeout = null;
+            }
             this.realtime.unsubscribe().catch(() => {
                 /* ignore */
             });

--- a/apps/backend/src/services/vercel.service.ts
+++ b/apps/backend/src/services/vercel.service.ts
@@ -652,8 +652,12 @@ export class VercelService {
      * added. The caller should poll `getCertificate` to track progress.
      *
      * Throws DOMAIN_EXISTS (409) if the domain is already attached.
+     *
+     * Named distinctly from the addDomain(request: AddDomainRequest) overload
+     * below — a same-named second method would silently replace this one on
+     * the class prototype, which is exactly the bug this rename fixes.
      */
-    async addDomain(projectId: string, domain: string): Promise<void> {
+    async addProjectDomain(projectId: string, domain: string): Promise<void> {
         await this.request(`/v10/projects/${projectId}/domains`, {
             method: 'POST',
             body: JSON.stringify({ name: domain }),

--- a/supabase/migrations/017_provider_connections_atomic_rpc.sql
+++ b/supabase/migrations/017_provider_connections_atomic_rpc.sql
@@ -1,0 +1,68 @@
+-- Migration: 017_provider_connections_atomic_rpc.sql
+-- Atomic read-modify-write for profiles.provider_connections.
+--
+-- MultiProviderAuthService.connectStellar()/disconnectProvider() previously
+-- read provider_connections into application memory, merged the change, and
+-- wrote the whole JSONB object back with a plain .update(). Two concurrent
+-- requests (e.g. two browser tabs, or a retried request) could both read the
+-- same snapshot and the second write would silently clobber the first,
+-- dropping whichever provider connection change happened first.
+--
+-- These functions perform the read-modify-write inside a single row-locked
+-- UPDATE statement so concurrent callers serialize instead of racing.
+
+CREATE OR REPLACE FUNCTION set_provider_connection(
+    p_user_id UUID,
+    p_provider TEXT,
+    p_value JSONB
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+    v_result JSONB;
+BEGIN
+    UPDATE profiles
+    SET
+        provider_connections = jsonb_set(
+            COALESCE(provider_connections, '{}'::jsonb),
+            ARRAY[p_provider],
+            p_value,
+            true
+        ),
+        updated_at = NOW()
+    WHERE id = p_user_id
+    RETURNING provider_connections INTO v_result;
+
+    RETURN v_result;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION remove_provider_connection(
+    p_user_id UUID,
+    p_provider TEXT
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+    v_result JSONB;
+BEGIN
+    UPDATE profiles
+    SET
+        provider_connections = COALESCE(provider_connections, '{}'::jsonb) - p_provider,
+        updated_at = NOW()
+    WHERE id = p_user_id
+    RETURNING provider_connections INTO v_result;
+
+    RETURN v_result;
+END;
+$$;
+
+-- Grant execute to the service role only
+GRANT EXECUTE ON FUNCTION set_provider_connection(UUID, TEXT, JSONB) TO service_role;
+GRANT EXECUTE ON FUNCTION remove_provider_connection(UUID, TEXT) TO service_role;
+
+-- rollback: DROP FUNCTION IF EXISTS set_provider_connection(UUID, TEXT, JSONB); DROP FUNCTION IF EXISTS remove_provider_connection(UUID, TEXT);


### PR DESCRIPTION
this pr closes #884 
this pr closes #885 
this pr closes #890 
this pr closes #891 
1. multi-provider-auth.service.ts: connectStellar() and disconnectProvider() did a client-side read-modify-write of profiles.provider_connections (SELECT, merge in application memory, then UPDATE the whole JSONB column). Two concurrent requests for the same user — e.g. two browser tabs, or a client retry after a network blip — could both read the same snapshot; whichever write landed second would silently overwrite the first, dropping that provider's connection change with no error surfaced anywhere. Fixed by adding set_provider_connection and remove_provider_connection Postgres functions (migration 017_provider_connections_atomic_rpc.sql) that perform the jsonb_set / key-removal inside a single row-locked UPDATE, and switching both service methods to call them via supabase.rpc() instead of doing the merge in JS. Concurrent callers now serialize on the row lock instead of racing.

2. supabase-realtime-subscription.service.ts: attemptConnect() schedules its own retry via setTimeout on failure, but the unsubscribe function returned from subscribe() never tracked or cancelled that timeout — it only called realtime.unsubscribe() and cleared the polling interval. If a caller unsubscribed while a reconnect was still scheduled (before reconnectAttemptsMax was reached), the stale timeout would still fire later, re-invoking realtime.subscribe() and potentially flipping connectionState back to 'connected' (or starting polling) after the caller believed the subscription was fully torn down. Fixed by storing the timeout handle in a new reconnectTimeout field and clearing it in the returned unsubscribe function.

3. deployment.service.ts: redeployDeployment() moves a deployment to 'deploying' before attempting a plain redeploy (no newCustomization). If that attempt threw, the catch block only restored the row to 'completed' when the original status was 'completed' — but redeployableStatuses explicitly allows 'failed' as a starting state too, so a failed redeploy of an already-'failed' deployment left the row stuck at status = 'deploying' forever with no work actually in flight. Fixed by restoring whatever the pre-redeploy status actually was, not a hardcoded 'completed'.

4. vercel.service.ts: VercelService declared two methods named addDomain — a (projectId, domain) throwing form and a (request: AddDomainRequest) result-returning form. The second definition silently overwrote the first on the class prototype, so the two-arg call site in app/api/deployments/[id]/https/route.ts was actually invoking the object-based implementation with projectId bound to the `request` parameter position, producing a malformed Vercel API payload. Fixed by renaming the two-arg throwing variant to addProjectDomain and updating its only call site; the object-based addDomain (used by vercel-domain-lifecycle.service.ts) is unchanged.

Updated multi-provider-auth.service.test.ts and the https route test to match the new RPC-based / renamed-method behavior. No node_modules were installed in this environment, so tests were verified by manual tracing of every mock and call site rather than by running the suite.