### PR TITLE
fix: close 4 security validation gaps in stellar package

### DIFF
--- a/packages/stellar/src/fee-bump-orchestrator.test.ts
+++ b/packages/stellar/src/fee-bump-orchestrator.test.ts
@@ -50,6 +50,40 @@ function makeMockBuildFeeBump(feeCharged: number) {
     });
 }
 
+function buildAlreadyFeeBumpedTxXdr(): string {
+    const account = {
+        accountId: () => SOURCE_KEYPAIR.publicKey(),
+        sequenceNumber: () => '100',
+        incrementSequenceNumber: () => {},
+    } as any;
+
+    const innerTx = new TransactionBuilder(account, {
+        fee: BASE_FEE,
+        networkPassphrase: NETWORK_PASSPHRASE,
+    })
+        .addOperation(
+            Operation.payment({
+                destination: Keypair.random().publicKey(),
+                asset: Asset.native(),
+                amount: '1',
+            }),
+        )
+        .setTimeout(30)
+        .build();
+
+    innerTx.sign(SOURCE_KEYPAIR);
+
+    // Wrap in a fee-bump envelope
+    const feeBumpTx = TransactionBuilder.buildFeeBumpTransaction(
+        FEE_SOURCE_PUBKEY,
+        '1000',
+        innerTx,
+        NETWORK_PASSPHRASE,
+    );
+
+    return feeBumpTx.toXDR();
+}
+
 beforeEach(() => {
     clearFeeBumpUsage();
 });
@@ -107,6 +141,25 @@ describe('orchestrateFeeBump – invalid inner transaction rejection', () => {
         expect(result.ok).toBe(false);
         if (result.ok) return;
         expect(result.error).toMatch(/Invalid inner transaction XDR/);
+        expect(mockBuild).not.toHaveBeenCalled();
+    });
+
+    it('returns ok:false for an already fee-bumped transaction without calling buildFeeBumpTransaction', async () => {
+        const feeBumpXdr = buildAlreadyFeeBumpedTxXdr();
+        const mockBuild = makeMockBuildFeeBump(300);
+
+        const result = await orchestrateFeeBump(
+            feeBumpXdr,
+            FEE_SOURCE_PUBKEY,
+            USER_ID,
+            {} as any,
+            NETWORK_PASSPHRASE,
+            mockBuild,
+        );
+
+        expect(result.ok).toBe(false);
+        if (result.ok) return;
+        expect(result.error).toMatch(/Cannot fee-bump an already fee-bumped transaction/);
         expect(mockBuild).not.toHaveBeenCalled();
     });
 

--- a/packages/stellar/src/fee-bump-orchestrator.ts
+++ b/packages/stellar/src/fee-bump-orchestrator.ts
@@ -18,7 +18,7 @@
  * without a live database.
  */
 
-import { TransactionBuilder } from 'stellar-sdk';
+import { TransactionBuilder, Transaction } from 'stellar-sdk';
 import type { SorobanRpc } from 'stellar-sdk';
 import { buildFeeBumpTransaction } from './soroban';
 import type { FeeBumpResult } from './soroban';
@@ -80,10 +80,16 @@ export async function orchestrateFeeBump(
     _buildFeeBump: typeof buildFeeBumpTransaction = buildFeeBumpTransaction,
 ): Promise<OrchestrateFeeBumpResult> {
     // Validate the inner transaction XDR before attempting to wrap it.
+    let innerTx: any;
     try {
-        TransactionBuilder.fromXDR(innerTxXdr, networkPassphrase);
+        innerTx = TransactionBuilder.fromXDR(innerTxXdr, networkPassphrase);
     } catch {
         return { ok: false, error: 'Invalid inner transaction XDR: unable to parse' };
+    }
+
+    // Reject if the inner transaction is already a fee-bump (cannot nest fee-bumps).
+    if (!(innerTx instanceof Transaction)) {
+        return { ok: false, error: 'Cannot fee-bump an already fee-bumped transaction' };
     }
 
     // Construct the fee-bump envelope.

--- a/packages/stellar/src/multi-party-issuance.test.ts
+++ b/packages/stellar/src/multi-party-issuance.test.ts
@@ -293,4 +293,29 @@ describe('error handling', () => {
         if (result.ok) return;
         expect(result.error).toMatch(/Invalid signed transaction XDR/);
     });
+
+    it('rejects a transaction signed by a different keypair than the claimed signer', () => {
+        const baseTxXdr = buildBaseTxXdr();
+        const session = createIssuanceSession({ required: 2, total: 3 }, baseTxXdr);
+
+        // Sign with SIGNER_B but claim it's from SIGNER_A
+        const signedByB = signTxXdr(baseTxXdr, SIGNER_B);
+        const result = addCoSignerSignature(session.id, SIGNER_A.publicKey(), signedByB, NETWORK);
+
+        expect(result.ok).toBe(false);
+        if (result.ok) return;
+        expect(result.error).toMatch(/Signature does not match claimed co-signer/);
+    });
+
+    it('rejects an unsigned transaction', () => {
+        const baseTxXdr = buildBaseTxXdr();
+        const session = createIssuanceSession({ required: 2, total: 3 }, baseTxXdr);
+
+        // Submit the base (unsigned) transaction
+        const result = addCoSignerSignature(session.id, SIGNER_A.publicKey(), baseTxXdr, NETWORK);
+
+        expect(result.ok).toBe(false);
+        if (result.ok) return;
+        expect(result.error).toMatch(/Signature does not match claimed co-signer/);
+    });
 });

--- a/packages/stellar/src/multi-party-issuance.ts
+++ b/packages/stellar/src/multi-party-issuance.ts
@@ -33,7 +33,7 @@
  * multi-instance deployments.
  */
 
-import { TransactionBuilder, Transaction } from 'stellar-sdk';
+import { TransactionBuilder, Transaction, Keypair } from 'stellar-sdk';
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -171,10 +171,26 @@ export function addCoSignerSignature(
     }
 
     // Validate the signed XDR
+    let parsedTx: Transaction;
     try {
-        TransactionBuilder.fromXDR(signedTxXdr, networkPassphrase);
+        parsedTx = TransactionBuilder.fromXDR(signedTxXdr, networkPassphrase) as Transaction;
     } catch {
         return { ok: false, error: 'Invalid signed transaction XDR' };
+    }
+
+    // Verify that at least one signature matches the claimed co-signer's public key
+    const signerKeypair = Keypair.fromPublicKey(signerPublicKey);
+    const txHash = parsedTx.hash();
+    const hasValidSignature = parsedTx.signatures.some((sig) => {
+        try {
+            return signerKeypair.verify(txHash, sig.signature());
+        } catch {
+            return false;
+        }
+    });
+
+    if (!hasValidSignature) {
+        return { ok: false, error: 'Signature does not match claimed co-signer public key' };
     }
 
     // Store the signed XDR alongside the signer key (we embed it in the session

--- a/packages/stellar/src/soroban.ts
+++ b/packages/stellar/src/soroban.ts
@@ -466,10 +466,15 @@ export async function buildFeeBumpTransaction(
 
         const innerTx = TransactionBuilder.fromXDR(innerTxXdr, getNetworkPassphrase());
 
+        // Defensive guard: ensure innerTx is a plain Transaction, not a FeeBumpTransaction.
+        if (!(innerTx instanceof Transaction)) {
+            return { ok: false, error: 'Cannot fee-bump an already fee-bumped transaction' };
+        }
+
         const feeBumpTx = TransactionBuilder.buildFeeBumpTransaction(
             feeSourcePublicKey,
             feeCharged.toString(),
-            innerTx as Transaction,
+            innerTx,
             getNetworkPassphrase(),
         );
 

--- a/packages/stellar/src/trustline-validation.test.ts
+++ b/packages/stellar/src/trustline-validation.test.ts
@@ -281,6 +281,10 @@ describe('Trustline Validation', () => {
   });
 
   describe('validateAssetIssuanceDeployment', () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
     it('should accept valid deployment', async () => {
       const accountData = {
         balances: [
@@ -346,6 +350,125 @@ describe('Trustline Validation', () => {
 
       expect(result.valid).toBe(false);
       expect(result.error).toContain('maximum trustline limit');
+    });
+
+    it('fetches account data from Horizon when accountData is omitted', async () => {
+      const HORIZON = 'https://horizon-testnet.stellar.org';
+      const mockAccountData = {
+        id: accountId,
+        balances: [
+          {
+            asset_type: 'credit_alphanum4',
+            asset_code: 'USD',
+            asset_issuer: issuer1,
+            balance: '100',
+            limit: '1000',
+            is_authorized: true,
+            is_authorized_to_maintain_liabilities: false,
+          },
+        ],
+      } as unknown as Horizon.ServerApi.AccountRecord;
+
+      vi.spyOn(Horizon.Server.prototype, 'loadAccount').mockResolvedValue(mockAccountData);
+
+      const result = await validateAssetIssuanceDeployment(
+        accountId,
+        [{ code: 'USD', issuer: issuer1 }],
+        undefined,
+        HORIZON
+      );
+
+      expect(result.valid).toBe(true);
+    });
+
+    it('returns error when account not found on Horizon', async () => {
+      const HORIZON = 'https://horizon-testnet.stellar.org';
+      vi.spyOn(Horizon.Server.prototype, 'loadAccount').mockRejectedValue({
+        response: { status: 404 },
+      });
+
+      const result = await validateAssetIssuanceDeployment(
+        accountId,
+        [{ code: 'USD', issuer: issuer1 }],
+        undefined,
+        HORIZON
+      );
+
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('Account not found');
+    });
+  });
+
+  describe('validateTrustlines with Horizon fetch', () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('fetches account data from Horizon when accountData is omitted', async () => {
+      const HORIZON = 'https://horizon-testnet.stellar.org';
+      const mockAccountData = {
+        id: accountId,
+        balances: [
+          {
+            asset_type: 'credit_alphanum4',
+            asset_code: 'USD',
+            asset_issuer: issuer1,
+            balance: '100',
+            limit: '1000',
+            is_authorized: true,
+            is_authorized_to_maintain_liabilities: false,
+          },
+        ],
+      } as unknown as Horizon.ServerApi.AccountRecord;
+
+      vi.spyOn(Horizon.Server.prototype, 'loadAccount').mockResolvedValue(mockAccountData);
+
+      const result = await validateTrustlines(
+        accountId,
+        [{ code: 'USD', issuer: issuer1 }],
+        undefined,
+        HORIZON
+      );
+
+      expect(result.valid).toBe(true);
+    });
+
+    it('returns error when account not found on Horizon', async () => {
+      const HORIZON = 'https://horizon-testnet.stellar.org';
+      vi.spyOn(Horizon.Server.prototype, 'loadAccount').mockRejectedValue({
+        response: { status: 404 },
+      });
+
+      const result = await validateTrustlines(
+        accountId,
+        [{ code: 'USD', issuer: issuer1 }],
+        undefined,
+        HORIZON
+      );
+
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('Account not found');
+    });
+
+    it('detects missing trustlines when fetching from Horizon', async () => {
+      const HORIZON = 'https://horizon-testnet.stellar.org';
+      const mockAccountData = {
+        id: accountId,
+        balances: [],
+      } as unknown as Horizon.ServerApi.AccountRecord;
+
+      vi.spyOn(Horizon.Server.prototype, 'loadAccount').mockResolvedValue(mockAccountData);
+
+      const result = await validateTrustlines(
+        accountId,
+        [{ code: 'USD', issuer: issuer1 }],
+        undefined,
+        HORIZON
+      );
+
+      expect(result.valid).toBe(false);
+      expect(result.missingTrustlines).toHaveLength(1);
+      expect(result.missingTrustlines?.[0].asset).toBe('USD');
     });
   });
 

--- a/packages/stellar/src/trustline-validation.ts
+++ b/packages/stellar/src/trustline-validation.ts
@@ -112,6 +112,7 @@ export const MAX_TRUSTLINES_PER_ACCOUNT = 1000;
  * @param accountId - The Stellar account address
  * @param requiredAssets - Array of assets that require trustlines
  * @param accountData - Account data from Horizon (optional, will fetch if not provided)
+ * @param horizonUrl - Horizon base URL (required only if accountData is omitted; used to fetch account details)
  * @returns Validation result with details about missing trustlines
  *
  * @example
@@ -128,7 +129,8 @@ export const MAX_TRUSTLINES_PER_ACCOUNT = 1000;
 export async function validateTrustlines(
   accountId: string,
   requiredAssets: Array<{ code: string; issuer: string }>,
-  accountData?: Horizon.ServerApi.AccountRecord
+  accountData?: Horizon.ServerApi.AccountRecord,
+  horizonUrl?: string,
 ): Promise<TrustlineValidationResult> {
   // Validate account address format
   if (!accountId || accountId.length !== 56 || !accountId.startsWith('G')) {
@@ -147,8 +149,26 @@ export async function validateTrustlines(
     return { valid: true };
   }
 
+  // Fetch account data if not provided
+  let resolvedAccountData = accountData;
+  if (!resolvedAccountData && horizonUrl) {
+    try {
+      const server = new Horizon.Server(horizonUrl);
+      resolvedAccountData = await server.loadAccount(accountId);
+    } catch (err: unknown) {
+      const status = (err as { response?: { status?: number } })?.response?.status;
+      if (status === 404) {
+        return {
+          valid: false,
+          error: 'Account not found on Horizon',
+        };
+      }
+      throw err;
+    }
+  }
+
   // Get account trustlines
-  const trustlines = accountData?.balances || [];
+  const trustlines = resolvedAccountData?.balances || [];
   const missingTrustlines: Array<{
     asset: string;
     issuer: string;
@@ -233,7 +253,8 @@ export function canEstablishTrustlines(
  *
  * @param accountId - The account that will issue the asset
  * @param assets - Assets to be issued
- * @param accountData - Account data from Horizon (optional)
+ * @param accountData - Account data from Horizon (optional, will fetch if not provided)
+ * @param horizonUrl - Horizon base URL (required only if accountData is omitted)
  * @returns Validation result with actionable error messages
  *
  * @example
@@ -250,19 +271,38 @@ export function canEstablishTrustlines(
 export async function validateAssetIssuanceDeployment(
   accountId: string,
   assets: Array<{ code: string; issuer: string }>,
-  accountData?: Horizon.ServerApi.AccountRecord
+  accountData?: Horizon.ServerApi.AccountRecord,
+  horizonUrl?: string,
 ): Promise<TrustlineValidationResult> {
+  // Fetch account data if not provided
+  let resolvedAccountData = accountData;
+  if (!resolvedAccountData && horizonUrl) {
+    try {
+      const server = new Horizon.Server(horizonUrl);
+      resolvedAccountData = await server.loadAccount(accountId);
+    } catch (err: unknown) {
+      const status = (err as { response?: { status?: number } })?.response?.status;
+      if (status === 404) {
+        return {
+          valid: false,
+          error: 'Account not found on Horizon',
+        };
+      }
+      throw err;
+    }
+  }
+
   // Check capacity before validating existing trustlines so the capacity
   // error takes precedence when the account is at max and missing trustlines.
-  if (accountData) {
+  if (resolvedAccountData) {
     const nonNative = assets.filter((a) => a.code !== 'XLM' && a.code !== 'native');
     const missingAssets = nonNative.filter(
       (asset) =>
-        !(accountData.balances as Array<{ asset_type: string; asset_code?: string; asset_issuer?: string }>).some(
+        !(resolvedAccountData.balances as Array<{ asset_type: string; asset_code?: string; asset_issuer?: string }>).some(
           (b) => b.asset_type !== 'native' && b.asset_code === asset.code && b.asset_issuer === asset.issuer,
         ),
     );
-    if (missingAssets.length > 0 && !canEstablishTrustlines(accountData, missingAssets.length)) {
+    if (missingAssets.length > 0 && !canEstablishTrustlines(resolvedAccountData, missingAssets.length)) {
       return {
         valid: false,
         error: `Account has reached maximum trustline limit (${MAX_TRUSTLINES_PER_ACCOUNT})`,
@@ -275,7 +315,7 @@ export async function validateAssetIssuanceDeployment(
     }
   }
 
-  const trustlineResult = await validateTrustlines(accountId, assets, accountData);
+  const trustlineResult = await validateTrustlines(accountId, assets, resolvedAccountData, horizonUrl);
   return trustlineResult;
 }
 

--- a/packages/stellar/src/upgrade-orchestrator.test.ts
+++ b/packages/stellar/src/upgrade-orchestrator.test.ts
@@ -57,7 +57,7 @@ describe('diffAbiSchemas', () => {
     expect(report.breakingChanges).toHaveLength(0);
   });
 
-  it('detects added keys as non-breaking', () => {
+  it('detects added optional keys as non-breaking', () => {
     const next = makeSchema({
       storageKeys: [
         ...currentSchema.storageKeys,
@@ -69,6 +69,22 @@ describe('diffAbiSchemas', () => {
     expect(report.changes).toHaveLength(1);
     expect(report.changes[0].type).toBe('added');
     expect(report.changes[0].key).toBe('new_key');
+  });
+
+  it('flags added required keys as breaking', () => {
+    const next = makeSchema({
+      storageKeys: [
+        ...currentSchema.storageKeys,
+        { key: 'new_required_key', type: 'instance', required: true },
+      ],
+    });
+    const report = diffAbiSchemas(currentSchema, next);
+    expect(report.safe).toBe(false);
+    expect(report.changes).toHaveLength(1);
+    expect(report.changes[0].type).toBe('added');
+    expect(report.breakingChanges).toHaveLength(1);
+    expect(report.breakingChanges[0].type).toBe('added');
+    expect(report.breakingChanges[0].key).toBe('new_required_key');
   });
 
   it('detects removed optional keys as non-breaking', () => {
@@ -145,6 +161,20 @@ describe('diffAbiSchemas', () => {
     const report = diffAbiSchemas(currentSchema, next);
     expect(report.summary).toContain('UNSAFE');
     expect(report.summary).toContain('admin');
+  });
+
+  it('includes newly-required keys in breaking change summary', () => {
+    const next = makeSchema({
+      version: '2.0.0',
+      storageKeys: [
+        ...currentSchema.storageKeys,
+        { key: 'new_required_fee', type: 'persistent', required: true },
+      ],
+    });
+    const report = diffAbiSchemas(currentSchema, next);
+    expect(report.summary).toContain('UNSAFE');
+    expect(report.summary).toContain('new_required_fee');
+    expect(report.summary).toContain('added as REQUIRED');
   });
 
   it('handles empty storage keys', () => {

--- a/packages/stellar/src/upgrade-orchestrator.ts
+++ b/packages/stellar/src/upgrade-orchestrator.ts
@@ -122,6 +122,7 @@ export function diffAbiSchemas(
   const breakingChanges = changes.filter((c) => {
     if (c.type === 'removed' && c.oldEntry?.required) return true;
     if (c.type === 'type_changed') return true;
+    if (c.type === 'added' && c.newEntry?.required) return true;
     return false;
   });
 
@@ -145,6 +146,8 @@ export function diffAbiSchemas(
         summaryLines.push(
           `    - Key "${bc.key}" storage type changed: ${bc.oldEntry?.type} → ${bc.newEntry?.type}`,
         );
+      } else if (bc.type === 'added') {
+        summaryLines.push(`    - Key "${bc.key}" (${bc.newEntry?.type}) was added as REQUIRED`);
       }
     }
   }


### PR DESCRIPTION
## Summary

This PR closes 4 critical security validation gaps in the Stellar package:

- **#953**: Nested fee-bump validation - reject attempts to wrap already fee-bumped transactions
- **#955**: Multi-party signature verification - validate signatures actually match claimed co-signers
- **#952**: Schema diff blind spot - flag newly-required storage keys as breaking changes
- **#954**: Trustline validation gap - implement fetch-on-demand when accountData is omitted

## Changes

### #953: Nested Fee-Bump Validation
- Added `instanceof Transaction` check in `orchestrateFeeBump` to reject FeeBumpTransaction envelopes
- Added defensive guard in `buildFeeBumpTransaction` to prevent SDK-level errors
- Added test fixture for already fee-bumped XDR and rejection test cases

### #955: Multi-Party Signature Verification  
- Implemented Keypair signature verification in `addCoSignerSignature`
- Reject signatures that don't validate against claimed co-signer's public key
- Added test cases for mismatched-signer and unsigned transaction rejection

### #952: Schema Diff Blind Spot
- Extended breaking changes detection to include newly-added required storage keys
- Updated summary output to describe newly-required keys as breaking
- Added test cases for required vs optional key additions

### #954: Trustline Validation Gap
- Added optional `horizonUrl` parameter to enable fetch-on-demand behavior
- Implemented Horizon account fetch when `accountData` is omitted
- Added test cases for successful fetch, 404 handling, and trustline detection

## Test Coverage

All changes include comprehensive test coverage:
- ✅ Unit tests for rejection cases
- ✅ Fixture-based testing (no live RPC/Horizon calls)
- ✅ Error path validation
- ✅ Existing test suites still pass

## Testing

Run the test suites with:
```bash
pnpm test --filter=stellar -- fee-bump
pnpm test --filter=stellar -- multi-party
pnpm test --filter=stellar -- upgrade-orchestrator
pnpm test --filter=stellar -- trustline-validation
```

Closes #953
Closes #955
Closes #952
Closes #954

🤖 Generated with [Claude Code](https://claude.com/claude-code)