### PR TITLE
fix: resolve 4 critical correctness defects in stellar package

### DIFF
--- a/packages/stellar/src/account-merge-protection.test.ts
+++ b/packages/stellar/src/account-merge-protection.test.ts
@@ -258,6 +258,7 @@ describe('protectAgainstMerge', () => {
     });
 
     it('records blocked merges in the audit log', async () => {
+        registerManagedAccount(SOURCE_KP.publicKey());
         const txXdr = buildMergeTxXdr(SOURCE_KP, DEST_KP.publicKey());
         const getState = vi.fn().mockResolvedValue(
             makeAccountState({
@@ -270,6 +271,60 @@ describe('protectAgainstMerge', () => {
         expect(decisions.get(SOURCE_KP.publicKey())?.allowed).toBe(false);
         const log = getMergeAuditLog();
         expect(log[0].decision.allowed).toBe(false);
+    });
+
+    it('allows unmanaged account merges even with open trustlines (#956)', async () => {
+        const unregisteredKp = Keypair.random();
+        const txXdr = buildMergeTxXdr(unregisteredKp, DEST_KP.publicKey());
+        const getState = vi.fn().mockResolvedValue(
+            makeAccountState({
+                trustlines: [{ assetCode: 'USDC', assetIssuer: 'GABC', balance: '50', limit: '1000' }],
+            }),
+        );
+
+        const decisions = await protectAgainstMerge(txXdr, NETWORK, getState);
+
+        expect(decisions.get(unregisteredKp.publicKey())?.allowed).toBe(true);
+        expect(getState).not.toHaveBeenCalled();
+        const log = getMergeAuditLog();
+        expect(log[0].decision.allowed).toBe(true);
+    });
+
+    it('blocks managed account merges with open trustlines (#956)', async () => {
+        registerManagedAccount(SOURCE_KP.publicKey());
+        const txXdr = buildMergeTxXdr(SOURCE_KP, DEST_KP.publicKey());
+        const getState = vi.fn().mockResolvedValue(
+            makeAccountState({
+                trustlines: [{ assetCode: 'USDC', assetIssuer: 'GABC', balance: '50', limit: '1000' }],
+            }),
+        );
+
+        const decisions = await protectAgainstMerge(txXdr, NETWORK, getState);
+
+        expect(decisions.get(SOURCE_KP.publicKey())?.allowed).toBe(false);
+        expect(getState).toHaveBeenCalledOnce();
+        const log = getMergeAuditLog();
+        expect(log[0].decision.allowed).toBe(false);
+    });
+
+    it('emits audit entries for both managed and unmanaged account merges (#956)', async () => {
+        const managedKp = SOURCE_KP;
+        const unmanagedKp = Keypair.random();
+
+        registerManagedAccount(managedKp.publicKey());
+
+        const managedTxXdr = buildMergeTxXdr(managedKp, DEST_KP.publicKey());
+        const unmanagedTxXdr = buildMergeTxXdr(unmanagedKp, DEST_KP.publicKey());
+
+        const getState = vi.fn().mockResolvedValue(makeAccountState());
+
+        await protectAgainstMerge(managedTxXdr, NETWORK, getState);
+        await protectAgainstMerge(unmanagedTxXdr, NETWORK, getState);
+
+        const log = getMergeAuditLog();
+        expect(log).toHaveLength(2);
+        expect(log[0].sourceAccount).toBe(managedKp.publicKey());
+        expect(log[1].sourceAccount).toBe(unmanagedKp.publicKey());
     });
 });
 

--- a/packages/stellar/src/account-merge-protection.ts
+++ b/packages/stellar/src/account-merge-protection.ts
@@ -223,8 +223,18 @@ export async function protectAgainstMerge(
     const decisions = new Map<string, MergeDecision>();
 
     for (const merge of merges) {
-        const state = await getAccountState(merge.sourceAccount);
-        const decision = checkMergeAllowed(merge, state, expectedDestination);
+        let decision: MergeDecision;
+
+        // Only apply merge protection rules to registered managed accounts
+        if (!isManagedAccount(merge.sourceAccount)) {
+            decision = {
+                allowed: true,
+                residualXlmStroops: '0',
+            };
+        } else {
+            const state = await getAccountState(merge.sourceAccount);
+            decision = checkMergeAllowed(merge, state, expectedDestination);
+        }
 
         const entry: MergeAuditEntry = {
             timestamp: Date.now(),

--- a/packages/stellar/src/config.test.ts
+++ b/packages/stellar/src/config.test.ts
@@ -8,7 +8,7 @@
  * Issue: #540
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { getNetworkConfig, NETWORK_PASSPHRASES, HORIZON_URLS, SOROBAN_RPC_URLS } from './config';
 
 describe('Stellar Config — Snapshot Regression Tests (#540)', () => {
@@ -190,6 +190,71 @@ describe('Stellar Config — Snapshot Regression Tests (#540)', () => {
             const passphrases = Object.values(NETWORK_PASSPHRASES);
             const uniquePassphrases = new Set(passphrases);
             expect(uniquePassphrases.size).toBe(passphrases.length);
+        });
+    });
+
+    describe('resolveNetwork — unrecognized value handling (#958)', () => {
+        beforeEach(() => {
+            delete process.env.STELLAR_NETWORK;
+            delete process.env.NEXT_PUBLIC_STELLAR_NETWORK;
+            vi.spyOn(console, 'warn').mockImplementation(() => {});
+        });
+
+        afterEach(() => {
+            vi.restoreAllMocks();
+        });
+
+        it('should silently default to testnet when STELLAR_NETWORK is unset', () => {
+            delete process.env.STELLAR_NETWORK;
+            delete process.env.NEXT_PUBLIC_STELLAR_NETWORK;
+            const config = getNetworkConfig();
+            expect(config.network).toBe('testnet');
+            expect(console.warn).not.toHaveBeenCalled();
+        });
+
+        it('should resolve mainnet when STELLAR_NETWORK=mainnet', () => {
+            process.env.STELLAR_NETWORK = 'mainnet';
+            const config = getNetworkConfig();
+            expect(config.network).toBe('mainnet');
+            expect(console.warn).not.toHaveBeenCalled();
+        });
+
+        it('should resolve testnet when STELLAR_NETWORK=testnet', () => {
+            process.env.STELLAR_NETWORK = 'testnet';
+            const config = getNetworkConfig();
+            expect(config.network).toBe('testnet');
+            expect(console.warn).not.toHaveBeenCalled();
+        });
+
+        it('should warn and default to testnet for unrecognized STELLAR_NETWORK', () => {
+            process.env.STELLAR_NETWORK = 'production';
+            const config = getNetworkConfig();
+            expect(config.network).toBe('testnet');
+            expect(console.warn).toHaveBeenCalled();
+            expect(console.warn).toHaveBeenCalledWith(
+                expect.stringContaining('Unrecognized STELLAR_NETWORK value')
+            );
+        });
+
+        it('should warn for capitalization typos like Mainnet', () => {
+            process.env.STELLAR_NETWORK = 'Mainnet';
+            const config = getNetworkConfig();
+            expect(config.network).toBe('testnet');
+            expect(console.warn).toHaveBeenCalled();
+        });
+
+        it('should trim whitespace before validation', () => {
+            process.env.STELLAR_NETWORK = '  mainnet  ';
+            const config = getNetworkConfig();
+            expect(config.network).toBe('mainnet');
+            expect(console.warn).not.toHaveBeenCalled();
+        });
+
+        it('should trim whitespace and still warn for unrecognized values', () => {
+            process.env.STELLAR_NETWORK = '  production  ';
+            const config = getNetworkConfig();
+            expect(config.network).toBe('testnet');
+            expect(console.warn).toHaveBeenCalled();
         });
     });
 });

--- a/packages/stellar/src/config.ts
+++ b/packages/stellar/src/config.ts
@@ -21,7 +21,18 @@ type Network = 'mainnet' | 'testnet';
 
 function resolveNetwork(): Network {
   const raw = process.env.STELLAR_NETWORK ?? process.env.NEXT_PUBLIC_STELLAR_NETWORK;
-  return raw === 'mainnet' ? 'mainnet' : 'testnet';
+  if (raw === undefined) {
+    return 'testnet';
+  }
+  const trimmed = raw.trim();
+  if (trimmed === 'mainnet') {
+    return 'mainnet';
+  }
+  if (trimmed === 'testnet') {
+    return 'testnet';
+  }
+  console.warn(`Unrecognized STELLAR_NETWORK value: "${raw}". Expected 'mainnet' or 'testnet'. Defaulting to 'testnet'.`);
+  return 'testnet';
 }
 
 export function getNetworkConfig(network?: Network): StellarNetworkConfig {

--- a/packages/stellar/src/horizon-client.test.ts
+++ b/packages/stellar/src/horizon-client.test.ts
@@ -101,6 +101,20 @@ describe('CircuitBreaker', () => {
     vi.useRealTimers();
   });
 
+  it('reopens immediately on failure while half-open', () => {
+    vi.useFakeTimers();
+    const cb = new CircuitBreaker(5, 30_000, 60_000);
+    for (let i = 0; i < 5; i++) cb.recordFailure();
+    expect(cb.getState()).toBe('open');
+
+    vi.advanceTimersByTime(60_001);
+    expect(cb.getState()).toBe('half-open');
+
+    cb.recordFailure();
+    expect(cb.getState()).toBe('open');
+    vi.useRealTimers();
+  });
+
   it('does not open when failures are outside the window', () => {
     vi.useFakeTimers();
     const cb = new CircuitBreaker(5, 30_000, 60_000);

--- a/packages/stellar/src/horizon-client.ts
+++ b/packages/stellar/src/horizon-client.ts
@@ -71,6 +71,14 @@ export class CircuitBreaker {
   /** Call after a failed request. Opens circuit when threshold is reached. */
   recordFailure(): void {
     const now = Date.now();
+
+    // If half-open, immediately trip back to open on any failure
+    if (this.state === 'half-open') {
+      this.state = 'open';
+      this.openedAt = now;
+      return;
+    }
+
     this.failureTimes = this.failureTimes.filter((t) => now - t < this.windowMs);
     this.failureTimes.push(now);
 

--- a/packages/stellar/src/index.ts
+++ b/packages/stellar/src/index.ts
@@ -4,6 +4,7 @@ export * from './config';
 export * from './mock';
 export * from './errors';
 export * from './soroban';
+export * from './storage-namespace';
 export * from './soroban-migration';
 export * from './soroban-event-relay';
 export * from './trustline-validation';

--- a/packages/stellar/src/soroban-storage-collision.test.ts
+++ b/packages/stellar/src/soroban-storage-collision.test.ts
@@ -6,7 +6,7 @@ import {
     detectStorageKeyCollisions,
     assertNoStorageKeyCollisions,
     StorageKeyCollisionError,
-} from './soroban';
+} from './storage-namespace';
 
 describe('detectStorageKeyCollisions (#616)', () => {
     it('returns empty array when no collisions exist', () => {
@@ -49,6 +49,28 @@ describe('detectStorageKeyCollisions (#616)', () => {
 
     it('returns empty array for empty input', () => {
         expect(detectStorageKeyCollisions([])).toHaveLength(0);
+    });
+
+    it('does not report false collision for duplicate same-owner entries', () => {
+        const result = detectStorageKeyCollisions([
+            { owner: 'TokenA', key: 'balance' },
+            { owner: 'TokenA', key: 'balance' },
+        ]);
+        expect(result).toHaveLength(0);
+    });
+
+    it('correctly deduplicates owners and reports only distinct cross-owner collisions', () => {
+        const result = detectStorageKeyCollisions([
+            { owner: 'TokenA', key: 'balance' },
+            { owner: 'TokenA', key: 'balance' },
+            { owner: 'TokenB', key: 'balance' },
+            { owner: 'TokenB', key: 'balance' },
+        ]);
+        expect(result).toHaveLength(1);
+        expect(result[0].key).toBe('balance');
+        expect(result[0].owners).toHaveLength(2);
+        expect(result[0].owners).toContain('TokenA');
+        expect(result[0].owners).toContain('TokenB');
     });
 });
 

--- a/packages/stellar/src/storage-namespace.ts
+++ b/packages/stellar/src/storage-namespace.ts
@@ -76,7 +76,9 @@ export function detectStorageKeyCollisions(entries: StorageKeyEntry[]): StorageK
 
   for (const { owner, key } of entries) {
     const owners = keyMap.get(key) ?? [];
-    owners.push(owner);
+    if (!owners.includes(owner)) {
+      owners.push(owner);
+    }
     keyMap.set(key, owners);
   }
 


### PR DESCRIPTION
## Summary

This PR fixes four critical correctness defects in the Stellar package that affect storage collision detection, network configuration safety, circuit breaker resilience, and account merge protection:

1. **#959** - Storage key collision false positives: Deduplicate owners before flagging collisions so duplicate owner entries don't block valid deployments
2. **#958** - Network configuration silent fallback: Surface unrecognized STELLAR_NETWORK values with warnings instead of silently defaulting to testnet
3. **#957** - Circuit breaker half-open probe failure: Immediately reopen circuit on failed half-open probes instead of staying stuck
4. **#956** - Managed-account registry bypass: Gate merge protection rules on registry check so unmanaged accounts aren't unnecessarily blocked

## Test Plan

- All new tests pass: storage collision deduplication, network config warnings, circuit breaker half-open recovery, and merge protection registry gating
- Existing tests updated to account for new managed-account registry requirement in merge protection
- No regressions in related tests

Closes #959
Closes #958
Closes #957
Closes #956