### PR TITLE
fix: resolve 4 Soroban service regressions

### DIFF
--- a/packages/stellar/src/abi-binding-generator.test.ts
+++ b/packages/stellar/src/abi-binding-generator.test.ts
@@ -86,6 +86,48 @@ function buildCompoundType(
   }
 }
 
+function buildEnumUdt(
+  name: string,
+  cases: { doc?: string; name: string; value: number }[],
+): xdr.ScSpecEntry {
+  return xdr.ScSpecEntry.scSpecEntryUdtEnumV0(
+    new xdr.ScSpecUdtEnumV0({
+      doc: '',
+      lib: '',
+      name,
+      cases: cases.map(
+        (c) =>
+          new xdr.ScSpecUdtEnumCaseV0({
+            doc: c.doc ?? '',
+            name: c.name,
+            discriminant: new xdr.ScVal.scvU32(new xdr.Uint32(c.value)),
+          }),
+      ),
+    }),
+  );
+}
+
+function buildErrorEnumUdt(
+  name: string,
+  cases: { doc?: string; name: string; value: number }[],
+): xdr.ScSpecEntry {
+  return xdr.ScSpecEntry.scSpecEntryUdtErrorEnumV0(
+    new xdr.ScSpecUdtErrorEnumV0({
+      doc: '',
+      lib: '',
+      name,
+      cases: cases.map(
+        (c) =>
+          new xdr.ScSpecUdtErrorEnumCaseV0({
+            doc: c.doc ?? '',
+            name: c.name,
+            discriminant: new xdr.ScVal.scvU32(new xdr.Uint32(c.value)),
+          }),
+      ),
+    }),
+  );
+}
+
 // ---------------------------------------------------------------------------
 // xdrTypeToTypeScript — pure type mapping
 // ---------------------------------------------------------------------------
@@ -482,5 +524,58 @@ describe('generateBinding', () => {
     expect(source).toContain('opt: boolean | undefined');
     expect(source).toContain('async all_types(');
     expect(source).toContain('Promise<bigint>');
+  });
+
+  it('preserves non-sequential enum discriminant values', () => {
+    const entries = [
+      buildEnumUdt('Status', [
+        { name: 'Idle', value: 0 },
+        { name: 'Running', value: 2 },
+        { name: 'Done', value: 5 },
+      ]),
+      ...buildSpecEntries({
+        functions: [
+          {
+            name: 'get_status',
+            inputs: [],
+            outputs: [xdr.ScSpecTypeDef.scSpecTypeUdt(new xdr.ScSpecTypeUdt({ name: 'Status' }))],
+          },
+        ],
+      }),
+    ];
+
+    const source = generateBinding(entries);
+    expect(source).toContain('export enum Status');
+    expect(source).toContain('Idle = 0');
+    expect(source).toContain('Running = 2');
+    expect(source).toContain('Done = 5');
+  });
+
+  it('preserves non-sequential error enum discriminant values', () => {
+    const entries = [
+      buildErrorEnumUdt('ContractError', [
+        { name: 'InvalidAmount', value: 1 },
+        { name: 'InsufficientBalance', value: 3 },
+        { name: 'Unauthorized', value: 7 },
+      ]),
+      ...buildSpecEntries({
+        functions: [
+          {
+            name: 'transfer',
+            inputs: [
+              { name: 'to', type: xdr.ScSpecTypeDef.scSpecTypeAddress() },
+              { name: 'amount', type: xdr.ScSpecTypeDef.scSpecTypeI128() },
+            ],
+            outputs: [xdr.ScSpecTypeDef.scSpecTypeBool()],
+          },
+        ],
+      }),
+    ];
+
+    const source = generateBinding(entries);
+    expect(source).toContain('export enum ContractError');
+    expect(source).toContain('InvalidAmount = 1');
+    expect(source).toContain('InsufficientBalance = 3');
+    expect(source).toContain('Unauthorized = 7');
   });
 });

--- a/packages/stellar/src/abi-binding-generator.ts
+++ b/packages/stellar/src/abi-binding-generator.ts
@@ -239,10 +239,10 @@ export function parseAbi(
         name: e.name().toString(),
         doc: e.doc().toString(),
         cases: Array.from(e.cases() as xdr.ScSpecUdtEnumCaseV0[]).map(
-          (c, idx) => ({
+          (c) => ({
             name: c.name().toString(),
             doc: c.doc().toString(),
-            value: idx,
+            value: c.value(),
           }),
         ),
       });
@@ -253,10 +253,10 @@ export function parseAbi(
         name: e.name().toString(),
         doc: e.doc().toString(),
         cases: Array.from(e.cases() as xdr.ScSpecUdtErrorEnumCaseV0[]).map(
-          (c, idx) => ({
+          (c) => ({
             name: c.name().toString(),
             doc: c.doc().toString(),
-            value: idx,
+            value: c.value(),
           }),
         ),
       });

--- a/packages/stellar/src/contract-state-snapshot.test.ts
+++ b/packages/stellar/src/contract-state-snapshot.test.ts
@@ -188,6 +188,65 @@ describe('ContractStateSnapshotService.snapshot()', () => {
 
         await expect(svc.snapshot(CONTRACT_ID, LEDGER_SEQ)).rejects.toThrow(/constraint violation/);
     });
+
+    it('includes additional keys in getLedgerEntries call', async () => {
+        const rpc = makeRpc([
+            makeXdrEntry('AAAAA==', 'BBBBB=='),
+            makeXdrEntry('KEY01==', 'VAL01=='),
+            makeXdrEntry('KEY02==', 'VAL02=='),
+        ]);
+        const svc = new ContractStateSnapshotService(rpc, makeStorage(), makeDb());
+
+        // Create mock additional keys
+        const additionalKey1 = { toXDR: () => 'KEY01==' } as any;
+        const additionalKey2 = { toXDR: () => 'KEY02==' } as any;
+
+        await svc.snapshot(CONTRACT_ID, LEDGER_SEQ, [additionalKey1, additionalKey2]);
+
+        // Verify getLedgerEntries was called with 3 keys (instance + 2 additional)
+        expect(rpc.getLedgerEntries).toHaveBeenCalledOnce();
+        const callArgs = (rpc.getLedgerEntries as ReturnType<typeof vi.fn>).mock.calls[0];
+        expect(callArgs).toHaveLength(3);
+    });
+
+    it('captures multiple keys in snapshot round-trip', async () => {
+        const multiEntries: LedgerEntryRecord[] = [
+            { keyXdr: 'KEY01==', valueXdr: 'VAL01==', liveUntilLedgerSeq: LEDGER_SEQ + 100 },
+            { keyXdr: 'KEY02==', valueXdr: 'VAL02==', liveUntilLedgerSeq: LEDGER_SEQ + 200 },
+            { keyXdr: 'KEY03==', valueXdr: 'VAL03==', liveUntilLedgerSeq: LEDGER_SEQ + 300 },
+        ];
+        const rpcEntries = multiEntries.map((e) => makeXdrEntry(e.keyXdr, e.valueXdr, e.liveUntilLedgerSeq));
+        const rpc = makeRpc(rpcEntries);
+
+        let capturedBlob: Buffer | null = null;
+        const storage = makeStorage({
+            upload: vi.fn().mockImplementation(async (_path: string, data: Buffer) => {
+                capturedBlob = data;
+                return { error: null };
+            }),
+            download: vi.fn().mockImplementation(async () => {
+                return { data: new Blob([capturedBlob!]), error: null };
+            }),
+        });
+
+        const svc = new ContractStateSnapshotService(rpc, storage, makeDb());
+
+        // Snapshot with additional keys
+        const additionalKeys = [{} as any, {} as any];
+        const snap = await svc.snapshot(CONTRACT_ID, LEDGER_SEQ, additionalKeys);
+
+        expect(snap.entryCount).toBe(3);
+        expect(capturedBlob).not.toBeNull();
+
+        // Restore and verify all entries are preserved
+        const restored = await svc.restore(snap.id);
+        expect(restored.entries).toHaveLength(3);
+        for (let i = 0; i < multiEntries.length; i++) {
+            expect(restored.entries[i].keyXdr).toBe(multiEntries[i].keyXdr);
+            expect(restored.entries[i].valueXdr).toBe(multiEntries[i].valueXdr);
+            expect(restored.entries[i].liveUntilLedgerSeq).toBe(multiEntries[i].liveUntilLedgerSeq);
+        }
+    });
 });
 
 // ── restore() tests ────────────────────────────────────────────────────────────

--- a/packages/stellar/src/contract-state-snapshot.ts
+++ b/packages/stellar/src/contract-state-snapshot.ts
@@ -145,17 +145,25 @@ export class ContractStateSnapshotService {
     ) {}
 
     /**
-     * Capture all persistent ContractData entries for `contractId` at
-     * `ledgerSequence` and persist them compressed in Supabase Storage.
+     * Capture persistent ContractData entries for `contractId` at `ledgerSequence`
+     * and persist them compressed in Supabase Storage.
      *
-     * The service fetches the contract instance ledger key which gives
-     * access to the persistent storage entries via the Soroban RPC.
+     * Captures the contract instance entry by default. To include additional
+     * persistent storage entries, pass `additionalKeys`.
+     *
+     * @param contractId - Contract address string
+     * @param ledgerSequence - Ledger sequence number to capture
+     * @param additionalKeys - Optional array of additional LedgerKey entries to capture
      *
      * @throws SnapshotSizeLimitError  when uncompressed payload exceeds 10 MB
      * @throws SnapshotStorageError    when the upload to Supabase Storage fails
      * @throws Error                   on DB metadata insert failure
      */
-    async snapshot(contractId: string, ledgerSequence: number): Promise<ContractSnapshot> {
+    async snapshot(
+        contractId: string,
+        ledgerSequence: number,
+        additionalKeys: xdr.LedgerKey[] = [],
+    ): Promise<ContractSnapshot> {
         const instanceKey = xdr.LedgerKey.contractData(
             new xdr.LedgerKeyContractData({
                 contract: new Contract(contractId).address().toScAddress(),
@@ -164,7 +172,8 @@ export class ContractStateSnapshotService {
             }),
         );
 
-        const response = await this.rpc.getLedgerEntries(instanceKey);
+        const allKeys = [instanceKey, ...additionalKeys];
+        const response = await this.rpc.getLedgerEntries(...allKeys);
         const rawEntries = response.entries ?? [];
 
         const entries: LedgerEntryRecord[] = rawEntries.map((entry) => ({

--- a/packages/stellar/src/soroban-budget-monitor.test.ts
+++ b/packages/stellar/src/soroban-budget-monitor.test.ts
@@ -94,6 +94,20 @@ describe('trackContractBudget', () => {
         expect(usage).toBeNull();
     });
 
+    it('bypasses cache to get fresh simulation results', async () => {
+        const mockSimulate = vi.fn().mockResolvedValue(makeSimulation('1000000', '512000'));
+
+        await trackContractBudget(CONTRACT_ID, 'transfer', [], SOURCE_KEY, {}, mockSimulate);
+        await trackContractBudget(CONTRACT_ID, 'transfer', [], SOURCE_KEY, {}, mockSimulate);
+
+        // Both calls should invoke the simulate function, not use cache
+        expect(mockSimulate).toHaveBeenCalledTimes(2);
+
+        // Verify skipCache=true was passed both times
+        expect(mockSimulate).toHaveBeenNthCalledWith(1, CONTRACT_ID, 'transfer', [], SOURCE_KEY, { skipCache: true });
+        expect(mockSimulate).toHaveBeenNthCalledWith(2, CONTRACT_ID, 'transfer', [], SOURCE_KEY, { skipCache: true });
+    });
+
     it('stores metric in the metrics store', async () => {
         const mockSimulate = vi.fn().mockResolvedValue(makeSimulation('1000000', '512000'));
         await trackContractBudget(CONTRACT_ID, 'transfer', [], SOURCE_KEY, {}, mockSimulate);

--- a/packages/stellar/src/soroban-budget-monitor.ts
+++ b/packages/stellar/src/soroban-budget-monitor.ts
@@ -177,6 +177,10 @@ export function getBudgetMetrics(): readonly BudgetMetric[] {
  * alert handlers if CPU or memory usage meets or exceeds the configured
  * thresholds.
  *
+ * Always performs a fresh simulation (bypasses the cache) to ensure accurate
+ * budget tracking for every invocation, preventing duplicate metrics from
+ * stale cached results.
+ *
  * @param contractId - The contract address (C...)
  * @param method - Contract method name
  * @param args - XDR-encoded method arguments
@@ -203,7 +207,7 @@ export async function trackContractBudget(
     _simulate: typeof simulateContractCall = simulateContractCall,
 ): Promise<BudgetUsage | null> {
     const resolved = resolveThresholds(thresholds);
-    const simulation = await _simulate(contractId, method, args, sourcePublicKey);
+    const simulation = await _simulate(contractId, method, args, sourcePublicKey, { skipCache: true });
     const usage = extractBudgetUsage(simulation, resolved);
     if (!usage) return null;
 

--- a/packages/stellar/src/soroban-event-relay.test.ts
+++ b/packages/stellar/src/soroban-event-relay.test.ts
@@ -261,6 +261,10 @@ describe('SorobanEventRelay – guaranteed delivery (#780)', () => {
 });
 
 describe('SorobanEventRelay – cleanup on disconnect', () => {
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
     it('cleans up all subscriptions when WebSocket closes', () => {
         const ws = makeMockWs();
         const client = makeMockClient();
@@ -272,5 +276,66 @@ describe('SorobanEventRelay – cleanup on disconnect', () => {
 
         ws._triggerClose();
         expect(relay.subscriptionCount).toBe(0);
+    });
+
+    it('clears staged ACK timers when unsubscribing', async () => {
+        vi.useFakeTimers();
+        const ws = makeMockWs();
+        const events = [makeMockEvent(CONTRACT_A, 'transfer', 101)];
+        const client = makeMockClient(events, 101);
+        const relay = new SorobanEventRelay(ws, client);
+
+        relay.subscribe({ contractId: CONTRACT_A });
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+
+        // Event has been delivered and an ACK timer is set.
+        expect(ws.send).toHaveBeenCalledOnce();
+
+        // Unsubscribe, which should clear the staged event's timer.
+        relay.unsubscribe({ contractId: CONTRACT_A });
+
+        // Advance time past the ACK timeout.
+        vi.advanceTimersByTime(ACK_TIMEOUT_MS + 1);
+
+        // No re-delivery should occur because the timer was cancelled.
+        expect(ws.send).toHaveBeenCalledOnce();
+
+        // Event should not be in dead-letter buffer (it was cleared on unsubscribe).
+        expect(relay.deadLetterBuffer).toHaveLength(0);
+    });
+
+    it('does not re-deliver events after unsubscribe despite pending ACKs', async () => {
+        vi.useFakeTimers();
+        const ws = makeMockWs();
+        const events = [
+            makeMockEvent(CONTRACT_A, 'transfer', 101),
+            makeMockEvent(CONTRACT_A, 'mint', 102),
+        ];
+        const client = makeMockClient(events, 102);
+        const relay = new SorobanEventRelay(ws, client);
+
+        relay.subscribe({ contractId: CONTRACT_A });
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+
+        // Two events delivered.
+        expect(ws.send).toHaveBeenCalledTimes(2);
+
+        // Unsubscribe to clear pending ACK timers.
+        relay.unsubscribe({ contractId: CONTRACT_A });
+
+        // Advance time multiple times past the ACK timeout.
+        for (let i = 0; i < MAX_DELIVERY_ATTEMPTS; i++) {
+            vi.advanceTimersByTime(ACK_TIMEOUT_MS + 1);
+        }
+
+        // No additional deliveries should occur.
+        expect(ws.send).toHaveBeenCalledTimes(2);
+
+        // Dead-letter buffer should be empty (events were cleared, not DLBed).
+        expect(relay.deadLetterBuffer).toHaveLength(0);
     });
 });

--- a/packages/stellar/src/soroban-event-relay.ts
+++ b/packages/stellar/src/soroban-event-relay.ts
@@ -47,6 +47,7 @@ interface StagedEvent {
     event: SorobanEvent;
     attempts: number;
     timer: ReturnType<typeof setTimeout>;
+    subscriptionKey: string;
 }
 
 /** Minimal WebSocket interface — compatible with the browser/Node ws API. */
@@ -128,6 +129,14 @@ export class SorobanEventRelay {
         if (sub) {
             clearInterval(sub.timer);
             this.subscriptions.delete(key);
+
+            // Clean up any staged events belonging to this subscription.
+            for (const [eventId, staged] of this.stagingBuffer.entries()) {
+                if (staged.subscriptionKey === key) {
+                    clearTimeout(staged.timer);
+                    this.stagingBuffer.delete(eventId);
+                }
+            }
         }
     }
 
@@ -207,7 +216,7 @@ export class SorobanEventRelay {
                     value: rpcEvent.value,
                 };
 
-                this.deliverWithAck(eventId, payload, 1);
+                this.deliverWithAck(eventId, payload, 1, key);
             }
         } catch {
             // Polling errors are non-fatal; the next interval will retry.
@@ -221,7 +230,7 @@ export class SorobanEventRelay {
      * {@link MAX_DELIVERY_ATTEMPTS} total attempts) before being moved to the
      * dead-letter buffer.
      */
-    private deliverWithAck(eventId: string, event: SorobanEvent, attempts: number): void {
+    private deliverWithAck(eventId: string, event: SorobanEvent, attempts: number, subKey: string): void {
         if (this.ws.readyState !== WS_OPEN) return;
 
         this.ws.send(JSON.stringify(event));
@@ -229,13 +238,13 @@ export class SorobanEventRelay {
         const timer = setTimeout(() => {
             this.stagingBuffer.delete(eventId);
             if (attempts < MAX_DELIVERY_ATTEMPTS) {
-                this.deliverWithAck(eventId, event, attempts + 1);
+                this.deliverWithAck(eventId, event, attempts + 1, subKey);
             } else {
                 this._deadLetterBuffer.push(event);
             }
         }, ACK_TIMEOUT_MS);
 
-        this.stagingBuffer.set(eventId, { event, attempts, timer });
+        this.stagingBuffer.set(eventId, { event, attempts, timer, subscriptionKey: subKey });
     }
 }
 

--- a/packages/stellar/src/soroban.ts
+++ b/packages/stellar/src/soroban.ts
@@ -129,20 +129,24 @@ export function clearCache(): void {
  * @param method - The contract method name
  * @param args - XDR-encoded method arguments
  * @param sourcePublicKey - The source account public key
+ * @param options.skipCache - When true, bypass the cache and always fetch from RPC
  */
 export async function simulateContractCall(
     contractId: string,
     method: string,
     args: xdr.ScVal[],
-    sourcePublicKey: string
+    sourcePublicKey: string,
+    options: { skipCache?: boolean } = {},
 ): Promise<SorobanRpc.Api.SimulateTransactionResponse> {
     const cacheKey = buildCacheKey(contractId, method, args, sourcePublicKey);
     const now = Date.now();
 
-    // Cache hit – return the stored response if still within TTL.
-    const cached = simulationCache.get(cacheKey);
-    if (cached && now - cached.storedAt < CACHE_TTL_MS) {
-        return cached.response;
+    // Cache hit – return the stored response if still within TTL (unless cache is skipped).
+    if (!options.skipCache) {
+        const cached = simulationCache.get(cacheKey);
+        if (cached && now - cached.storedAt < CACHE_TTL_MS) {
+            return cached.response;
+        }
     }
 
     // Cache miss (or stale) – fetch from RPC.


### PR DESCRIPTION
## Summary

This PR fixes 4 critical issues in Soroban contract integration and event relay services:

1. **Enum Discriminant Value Loss** - ABI generator now uses declared enum case values instead of array indices
2. **Snapshot Partial Capture** - Contract state snapshots can now capture full persistent storage via optional additionalKeys
3. **Budget Monitor Cache Duplication** - Budget metrics no longer duplicate from stale cached simulations
4. **Event Relay ACK Leak** - Staged ACK timers are now properly cleared on unsubscribe

## Changes

### Issue #950: ABI Binding Generator
- Fixed `parseAbi()` to use `c.value()` instead of array index `idx` for enum cases
- Applies to both `ScSpecUdtEnumV0` and `ScSpecUdtErrorEnumV0` entries
- Added test for non-sequential enum discriminant values (0, 2, 5)

### Issue #951: Contract State Snapshot Service
- Added optional `additionalKeys` parameter to `snapshot()` method
- Allows callers to specify additional persistent storage entries beyond instance key
- Updated docstring to clarify capture behavior
- Added test for multi-key snapshot round-trips

### Issue #949: Soroban Budget Monitor
- Added `skipCache` option to `simulateContractCall()` function
- Updated `trackContractBudget()` to bypass cache for fresh simulation results
- Prevents duplicate metrics from same cached simulation within TTL window
- Added test verifying cache bypass on repeated calls

### Issue #948: Soroban Event Relay
- Added `subscriptionKey` field to `StagedEvent` interface
- Updated `unsubscribe()` to clear staged ACK timers for matching subscription
- Prevents redelivery of events after unsubscribe
- Added tests for ACK timer cleanup on unsubscribe

Closes #950
Closes #951
Closes #949
Closes #948