### PR TITLE
Multi-issue fix: API docs, validation, CORS, and logging improvements

### DIFF
--- a/apps/backend/src/app/api/admin/webhooks/replay/route.test.ts
+++ b/apps/backend/src/app/api/admin/webhooks/replay/route.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+import { GET, POST, PUT } from './route';
+
+const mockWebhookDeliveryService = {
+    getDeliveriesForReplay: vi.fn(),
+    replayDelivery: vi.fn(),
+};
+
+const mockGithubDeliveryFetcherService = {
+    detectMissedDeliveries: vi.fn(),
+};
+
+vi.mock('@/services/webhook-delivery.service', () => ({
+    webhookDeliveryService: mockWebhookDeliveryService,
+}));
+
+vi.mock('@/services/github-delivery-fetcher.service', () => ({
+    githubDeliveryFetcherService: mockGithubDeliveryFetcherService,
+}));
+
+const mockAuth = (handler: Function) => handler;
+vi.mock('@/lib/github/github-webhook', () => ({
+    withGitHubWebhookAuth: (handler: Function) => handler,
+}));
+
+function makeRequest(method: 'GET' | 'POST' | 'PUT', body?: any) {
+    return new NextRequest('http://localhost/api/admin/webhooks/replay', {
+        method,
+        body: body ? JSON.stringify(body) : undefined,
+        headers: body ? { 'content-type': 'application/json' } : undefined,
+    });
+}
+
+describe('Webhook Replay Route', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    describe('GET /api/admin/webhooks/replay', () => {
+        it('lists deliveries for replay', async () => {
+            const mockDeliveries = [
+                { deliveryId: 'delivery-1', source: 'failed' },
+                { deliveryId: 'delivery-2', source: 'missed' },
+            ];
+
+            mockWebhookDeliveryService.getDeliveriesForReplay.mockResolvedValue({
+                success: true,
+                deliveries: mockDeliveries,
+            });
+
+            const res = await GET(makeRequest('GET'));
+            expect(res.status).toBe(200);
+
+            const body = await res.json();
+            expect(body.count).toBe(2);
+            expect(body.deliveries).toHaveLength(2);
+            expect(res.headers.get('x-correlation-id')).toBeTruthy();
+        });
+
+        it('filters deliveries by type', async () => {
+            const mockDeliveries = [
+                { deliveryId: 'delivery-1', source: 'failed' },
+                { deliveryId: 'delivery-2', source: 'missed' },
+            ];
+
+            mockWebhookDeliveryService.getDeliveriesForReplay.mockResolvedValue({
+                success: true,
+                deliveries: mockDeliveries,
+            });
+
+            const req = new NextRequest('http://localhost/api/admin/webhooks/replay?type=failed');
+            const res = await GET(req);
+            expect(res.status).toBe(200);
+
+            const body = await res.json();
+            expect(body.count).toBe(1);
+            expect(body.deliveries[0].source).toBe('failed');
+        });
+
+        it('returns 500 on service error', async () => {
+            mockWebhookDeliveryService.getDeliveriesForReplay.mockResolvedValue({
+                success: false,
+                error: 'Database error',
+            });
+
+            const res = await GET(makeRequest('GET'));
+            expect(res.status).toBe(500);
+
+            const body = await res.json();
+            expect(body.error).toBe('Database error');
+        });
+    });
+
+    describe('POST /api/admin/webhooks/replay', () => {
+        it('replays a single delivery', async () => {
+            mockWebhookDeliveryService.replayDelivery.mockResolvedValue({
+                success: true,
+                newDeliveryId: 'new-delivery-1',
+            });
+
+            const res = await POST(makeRequest('POST', { deliveryId: 'delivery-1' }));
+            expect(res.status).toBe(200);
+
+            const body = await res.json();
+            expect(body.success).toBe(true);
+            expect(body.replayed).toBe(1);
+            expect(body.newDeliveryId).toBe('new-delivery-1');
+            expect(mockWebhookDeliveryService.replayDelivery).toHaveBeenCalledWith('delivery-1');
+        });
+
+        it('replays all deliveries when replayAll is true', async () => {
+            const mockDeliveries = [
+                { deliveryId: 'delivery-1', source: 'failed' },
+                { deliveryId: 'delivery-2', source: 'failed' },
+            ];
+
+            mockWebhookDeliveryService.getDeliveriesForReplay.mockResolvedValue({
+                success: true,
+                deliveries: mockDeliveries,
+            });
+
+            mockWebhookDeliveryService.replayDelivery
+                .mockResolvedValueOnce({ success: true, newDeliveryId: 'new-1' })
+                .mockResolvedValueOnce({ success: true, newDeliveryId: 'new-2' });
+
+            const res = await POST(makeRequest('POST', { replayAll: true }));
+            expect(res.status).toBe(200);
+
+            const body = await res.json();
+            expect(body.success).toBe(true);
+            expect(body.replayed).toBe(2);
+            expect(body.total).toBe(2);
+            expect(mockWebhookDeliveryService.replayDelivery).toHaveBeenCalledTimes(2);
+        });
+
+        it('returns error when both deliveryId and replayAll are specified', async () => {
+            const res = await POST(makeRequest('POST', { deliveryId: 'delivery-1', replayAll: true }));
+            expect(res.status).toBe(400);
+
+            const body = await res.json();
+            expect(body.error).toContain('Cannot specify both');
+        });
+
+        it('returns error when neither deliveryId nor replayAll are specified', async () => {
+            const res = await POST(makeRequest('POST', {}));
+            expect(res.status).toBe(400);
+
+            const body = await res.json();
+            expect(body.error).toContain('Either deliveryId or replayAll');
+        });
+
+        it('handles partial failures in bulk replay', async () => {
+            const mockDeliveries = [
+                { deliveryId: 'delivery-1', source: 'failed' },
+                { deliveryId: 'delivery-2', source: 'failed' },
+            ];
+
+            mockWebhookDeliveryService.getDeliveriesForReplay.mockResolvedValue({
+                success: true,
+                deliveries: mockDeliveries,
+            });
+
+            mockWebhookDeliveryService.replayDelivery
+                .mockResolvedValueOnce({ success: true, newDeliveryId: 'new-1' })
+                .mockResolvedValueOnce({ success: false, error: 'Delivery not found' });
+
+            const res = await POST(makeRequest('POST', { replayAll: true }));
+            expect(res.status).toBe(200);
+
+            const body = await res.json();
+            expect(body.replayed).toBe(1);
+            expect(body.errors).toHaveLength(1);
+            expect(body.errors[0].error).toBe('Delivery not found');
+        });
+    });
+
+    describe('PUT /api/admin/webhooks/detect-missed', () => {
+        it('detects missed deliveries', async () => {
+            mockGithubDeliveryFetcherService.detectMissedDeliveries.mockResolvedValue({
+                success: true,
+                missedCount: 5,
+            });
+
+            const res = await PUT(makeRequest('PUT', { hookId: 12345 }));
+            expect(res.status).toBe(200);
+
+            const body = await res.json();
+            expect(body.success).toBe(true);
+            expect(body.missedCount).toBe(5);
+            expect(res.headers.get('x-correlation-id')).toBeTruthy();
+        });
+
+        it('returns error when hookId is missing', async () => {
+            const res = await PUT(makeRequest('PUT', {}));
+            expect(res.status).toBe(400);
+
+            const body = await res.json();
+            expect(body.error).toContain('hookId');
+        });
+
+        it('detects missed deliveries with custom lookback hours', async () => {
+            mockGithubDeliveryFetcherService.detectMissedDeliveries.mockResolvedValue({
+                success: true,
+                missedCount: 3,
+            });
+
+            const res = await PUT(makeRequest('PUT', { hookId: 12345, lookbackHours: 72 }));
+            expect(res.status).toBe(200);
+
+            expect(mockGithubDeliveryFetcherService.detectMissedDeliveries).toHaveBeenCalledWith(12345, 72);
+        });
+
+        it('returns 500 on detection error', async () => {
+            mockGithubDeliveryFetcherService.detectMissedDeliveries.mockResolvedValue({
+                success: false,
+                error: 'GitHub API rate limit exceeded',
+            });
+
+            const res = await PUT(makeRequest('PUT', { hookId: 12345 }));
+            expect(res.status).toBe(500);
+
+            const body = await res.json();
+            expect(body.error).toContain('GitHub API');
+        });
+    });
+});

--- a/apps/backend/src/app/api/admin/webhooks/replay/route.ts
+++ b/apps/backend/src/app/api/admin/webhooks/replay/route.ts
@@ -68,6 +68,38 @@ export const GET = withGitHubWebhookAuth(async (req: NextRequest) => {
 });
 
 /**
+ * Replays a single webhook delivery and logs the outcome.
+ * Returns { success: true, newDeliveryId } or { success: false, error }.
+ */
+async function replayOne(
+    deliveryId: string,
+    log: ReturnType<typeof createLogger>,
+): Promise<{ success: boolean; newDeliveryId?: string; error?: string }> {
+    const result = await webhookDeliveryService.replayDelivery(deliveryId);
+
+    if (!result.success) {
+        log.error('Failed to replay delivery', undefined, {
+            deliveryId,
+            error: result.error,
+        });
+        return {
+            success: false,
+            error: result.error || 'Unknown error',
+        };
+    }
+
+    log.info('Delivery replayed', {
+        originalDeliveryId: deliveryId,
+        newDeliveryId: result.newDeliveryId,
+    });
+
+    return {
+        success: true,
+        newDeliveryId: result.newDeliveryId,
+    };
+}
+
+/**
  * POST /api/admin/webhooks/replay
  *
  * Triggers replay of webhook deliveries.
@@ -109,23 +141,14 @@ export const POST = withGitHubWebhookAuth(async (req: NextRequest) => {
 
         // Replay a specific delivery
         if (deliveryId) {
-            const result = await webhookDeliveryService.replayDelivery(deliveryId);
+            const result = await replayOne(deliveryId, log);
 
             if (!result.success) {
-                log.error('Failed to replay delivery', undefined, {
-                    deliveryId,
-                    error: result.error,
-                });
                 return NextResponse.json(
                     { error: result.error || 'Failed to replay delivery' },
                     { status: 500 }
                 );
             }
-
-            log.info('Delivery replayed', {
-                originalDeliveryId: deliveryId,
-                newDeliveryId: result.newDeliveryId,
-            });
 
             const res = NextResponse.json({
                 success: true,
@@ -175,22 +198,13 @@ export const POST = withGitHubWebhookAuth(async (req: NextRequest) => {
                     continue;
                 }
 
-                const result = await webhookDeliveryService.replayDelivery(delivery.deliveryId);
-
+                const result = await replayOne(delivery.deliveryId, log);
                 if (result.success) {
                     replayedCount++;
-                    log.info('Delivery replayed', {
-                        originalDeliveryId: delivery.deliveryId,
-                        newDeliveryId: result.newDeliveryId,
-                    });
                 } else {
                     errors.push({
                         deliveryId: delivery.deliveryId,
                         error: result.error || 'Unknown error',
-                    });
-                    log.error('Failed to replay delivery', undefined, {
-                        deliveryId: delivery.deliveryId,
-                        error: result.error,
                     });
                 }
             }

--- a/apps/backend/src/app/api/cron/rotate-encryption-keys/route.test.ts
+++ b/apps/backend/src/app/api/cron/rotate-encryption-keys/route.test.ts
@@ -5,8 +5,20 @@ const CRON_SECRET = 'test-cron-secret';
 const SUPABASE_URL = 'https://example.supabase.co';
 const SERVICE_KEY = 'service-role-key';
 
+const mockCreateLogger = vi.fn(() => ({
+  info: vi.fn(),
+  error: vi.fn(),
+  warn: vi.fn(),
+}));
+
 vi.mock('../../../../lib/crypto/key-rotation', () => ({
   rotateProfileEncryptedColumns: vi.fn(),
+}));
+
+vi.mock('../../../../lib/api/logger', () => ({
+  createLogger: mockCreateLogger,
+  resolveCorrelationId: vi.fn((req: NextRequest) => 'test-correlation-id-123'),
+  CORRELATION_ID_HEADER: 'X-Correlation-Id',
 }));
 
 function makeRequest(authHeader?: string) {
@@ -80,5 +92,77 @@ describe('GET /api/cron/rotate-encryption-keys', () => {
     expect(res.status).toBe(500);
     expect((await res.json()).error).toContain('DB update failed');
     expect(rotateProfileEncryptedColumns).toHaveBeenCalledTimes(1);
+  });
+
+  it('logs structured info on successful rotation', async () => {
+    const { rotateProfileEncryptedColumns } = await import('../../../../lib/crypto/key-rotation');
+    const mockSummary = {
+      stripe_customer_id_encrypted: { total: 100, rotated: 100 },
+      stripe_subscription_id_encrypted: { total: 100, rotated: 100 },
+    };
+    vi.mocked(rotateProfileEncryptedColumns).mockResolvedValue(mockSummary);
+
+    const { GET } = await import('./route');
+    const res = await GET(makeRequest(`Bearer ${CRON_SECRET}`));
+
+    expect(res.status).toBe(200);
+
+    const mockLogger = mockCreateLogger.mock.results[0].value;
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      'Starting encryption key rotation',
+      expect.objectContaining({ keyName: 'FIELD_ENCRYPTION_KEY' })
+    );
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      'Encryption key rotation completed successfully',
+      expect.objectContaining({ summary: mockSummary })
+    );
+  });
+
+  it('logs error with correlation ID on config validation failure', async () => {
+    delete process.env.FIELD_ENCRYPTION_KEY;
+    const { GET } = await import('./route');
+
+    const res = await GET(makeRequest(`Bearer ${CRON_SECRET}`));
+
+    expect(res.status).toBe(500);
+    expect(res.headers.get('X-Correlation-Id')).toBe('test-correlation-id-123');
+
+    const mockLogger = mockCreateLogger.mock.results[mockCreateLogger.mock.results.length - 1].value;
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      'Invalid or missing encryption key',
+      undefined,
+      expect.any(Object)
+    );
+  });
+
+  it('logs error with correlation ID on rotation failure', async () => {
+    const { rotateProfileEncryptedColumns } = await import('../../../../lib/crypto/key-rotation');
+    vi.mocked(rotateProfileEncryptedColumns).mockRejectedValue(new Error('Database connection failed'));
+
+    const { GET } = await import('./route');
+    const res = await GET(makeRequest(`Bearer ${CRON_SECRET}`));
+
+    expect(res.status).toBe(500);
+    expect(res.headers.get('X-Correlation-Id')).toBe('test-correlation-id-123');
+
+    const mockLogger = mockCreateLogger.mock.results[mockCreateLogger.mock.results.length - 1].value;
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      'Error running rotate-encryption-keys cron',
+      expect.any(Error),
+      expect.any(Object)
+    );
+  });
+
+  it('attaches correlation ID header to success response', async () => {
+    const { rotateProfileEncryptedColumns } = await import('../../../../lib/crypto/key-rotation');
+    vi.mocked(rotateProfileEncryptedColumns).mockResolvedValue({
+      stripe_customer_id_encrypted: { total: 1, rotated: 1 },
+    });
+
+    const { GET } = await import('./route');
+    const res = await GET(makeRequest(`Bearer ${CRON_SECRET}`));
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('X-Correlation-Id')).toBe('test-correlation-id-123');
   });
 });

--- a/apps/backend/src/app/api/cron/rotate-encryption-keys/route.ts
+++ b/apps/backend/src/app/api/cron/rotate-encryption-keys/route.ts
@@ -3,46 +3,74 @@ import { createClient } from '@supabase/supabase-js';
 import { withCronAuth } from '../../../../lib/api/cron-auth';
 import { rotateProfileEncryptedColumns } from '../../../../lib/crypto/key-rotation';
 import { KEY_VERSION } from '../../../../lib/crypto/field-encryption';
+import { createLogger, resolveCorrelationId, CORRELATION_ID_HEADER } from '../../../../lib/api/logger';
 
 const currentEncryptionKeyName = KEY_VERSION === 1
   ? 'FIELD_ENCRYPTION_KEY'
   : `FIELD_ENCRYPTION_KEY_${KEY_VERSION}`;
 
 async function handleRotateEncryptionKeys(req: NextRequest) {
+  const correlationId = resolveCorrelationId(req);
+  const log = createLogger({ correlationId, service: 'key-rotation-cron' });
+
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
   const currentEncryptionKey = process.env[currentEncryptionKeyName];
 
   if (!supabaseUrl || !serviceRoleKey) {
+    log.error('Missing Supabase service role configuration', undefined, {
+      missingVars: ['NEXT_PUBLIC_SUPABASE_URL', 'SUPABASE_SERVICE_ROLE_KEY'].filter(
+        (v) => !process.env[v]
+      ),
+    });
     return NextResponse.json(
       {
         error:
           'Missing Supabase service role configuration. Set NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY.',
       },
-      { status: 500 },
+      { status: 500, headers: { [CORRELATION_ID_HEADER]: correlationId } },
     );
   }
 
   if (!currentEncryptionKey || currentEncryptionKey.length !== 64) {
+    log.error('Invalid or missing encryption key', undefined, {
+      keyName: currentEncryptionKeyName,
+      keyLength: currentEncryptionKey?.length,
+      expectedLength: 64,
+    });
     return NextResponse.json(
       {
         error: `${currentEncryptionKeyName} must be set to a 64-character hex key before rotating encrypted profile fields.`,
       },
-      { status: 500 },
+      { status: 500, headers: { [CORRELATION_ID_HEADER]: correlationId } },
     );
   }
 
   const supabase = createClient(supabaseUrl, serviceRoleKey);
 
   try {
+    log.info('Starting encryption key rotation', { keyName: currentEncryptionKeyName });
+
     const summary = await rotateProfileEncryptedColumns(supabase);
-    return NextResponse.json({ rotated: summary });
+
+    log.info('Encryption key rotation completed successfully', {
+      keyName: currentEncryptionKeyName,
+      summary,
+    });
+
+    const res = NextResponse.json({ rotated: summary });
+    res.headers.set(CORRELATION_ID_HEADER, correlationId);
+    return res;
   } catch (error: any) {
-    console.error('Error running rotate-encryption-keys cron:', error);
-    return NextResponse.json(
+    log.error('Error running rotate-encryption-keys cron', error, {
+      keyName: currentEncryptionKeyName,
+    });
+    const res = NextResponse.json(
       { error: error.message || 'Rotation failed' },
       { status: 500 },
     );
+    res.headers.set(CORRELATION_ID_HEADER, correlationId);
+    return res;
   }
 }
 
@@ -52,5 +80,10 @@ async function handleRotateEncryptionKeys(req: NextRequest) {
  * This endpoint re-encrypts profile-level Stripe fields using the current
  * active FIELD_ENCRYPTION_KEY (or FIELD_ENCRYPTION_KEY_<N> when KEY_VERSION > 1).
  * It is guarded by CRON_SECRET and intended to run on a weekly schedule.
+ *
+ * Logging: emits structured logs with correlation ID and detailed metadata:
+ *   - On success: rotation summary (counts of rows rotated per column)
+ *   - On error: error details and configuration issues (missing env vars, invalid keys)
+ *   All logs include the X-Correlation-Id header for tracing across systems.
  */
 export const GET = withCronAuth(handleRotateEncryptionKeys);

--- a/apps/backend/src/app/api/deployments/[id]/estimate-cost/route.test.ts
+++ b/apps/backend/src/app/api/deployments/[id]/estimate-cost/route.test.ts
@@ -91,4 +91,114 @@ describe('GET /api/deployments/[id]/estimate-cost', () => {
         const res = await GET(makeGetRequest(), { params });
         expect(res.status).toBe(404);
     });
+
+    it('returns 400 if sorobanInvocations is not a non-negative number', async () => {
+        const res = await GET(makeGetRequest('?sorobanInvocations=abc'), { params });
+        expect(res.status).toBe(400);
+
+        const body = await res.json();
+        expect(body.error).toContain('sorobanInvocations');
+        expect(body.error).toContain('non-negative number');
+    });
+
+    it('returns 400 if vercelComputeUsageSeconds is not a non-negative number', async () => {
+        const res = await GET(makeGetRequest('?vercelComputeUsageSeconds=xyz'), { params });
+        expect(res.status).toBe(400);
+
+        const body = await res.json();
+        expect(body.error).toContain('vercelComputeUsageSeconds');
+        expect(body.error).toContain('non-negative number');
+    });
+
+    it('returns 400 if sorobanInvocations is negative', async () => {
+        const res = await GET(makeGetRequest('?sorobanInvocations=-5'), { params });
+        expect(res.status).toBe(400);
+
+        const body = await res.json();
+        expect(body.error).toContain('sorobanInvocations');
+    });
+
+    it('accepts valid positive sorobanInvocations value', async () => {
+        // mock deployments fetch
+        mockFrom.mockReturnValueOnce({
+            select: vi.fn(() => ({
+                eq: vi.fn(() => ({
+                    is: vi.fn(() => ({
+                        single: vi.fn().mockResolvedValue({ data: mockDeployment, error: null })
+                    }))
+                }))
+            }))
+        });
+
+        // mock profiles fetch
+        mockFrom.mockReturnValueOnce({
+            select: vi.fn(() => ({
+                eq: vi.fn(() => ({
+                    single: vi.fn().mockResolvedValue({ data: mockProfile, error: null })
+                }))
+            }))
+        });
+
+        const res = await GET(makeGetRequest('?sorobanInvocations=1000'), { params });
+        expect(res.status).toBe(200);
+
+        const body = await res.json();
+        expect(body.estimatedCost).toBeDefined();
+    });
+
+    it('accepts valid positive vercelComputeUsageSeconds value', async () => {
+        // mock deployments fetch
+        mockFrom.mockReturnValueOnce({
+            select: vi.fn(() => ({
+                eq: vi.fn(() => ({
+                    is: vi.fn(() => ({
+                        single: vi.fn().mockResolvedValue({ data: mockDeployment, error: null })
+                    }))
+                }))
+            }))
+        });
+
+        // mock profiles fetch
+        mockFrom.mockReturnValueOnce({
+            select: vi.fn(() => ({
+                eq: vi.fn(() => ({
+                    single: vi.fn().mockResolvedValue({ data: mockProfile, error: null })
+                }))
+            }))
+        });
+
+        const res = await GET(makeGetRequest('?vercelComputeUsageSeconds=3600'), { params });
+        expect(res.status).toBe(200);
+
+        const body = await res.json();
+        expect(body.estimatedCost).toBeDefined();
+    });
+
+    it('accepts both valid parameters', async () => {
+        // mock deployments fetch
+        mockFrom.mockReturnValueOnce({
+            select: vi.fn(() => ({
+                eq: vi.fn(() => ({
+                    is: vi.fn(() => ({
+                        single: vi.fn().mockResolvedValue({ data: mockDeployment, error: null })
+                    }))
+                }))
+            }))
+        });
+
+        // mock profiles fetch
+        mockFrom.mockReturnValueOnce({
+            select: vi.fn(() => ({
+                eq: vi.fn(() => ({
+                    single: vi.fn().mockResolvedValue({ data: mockProfile, error: null })
+                }))
+            }))
+        });
+
+        const res = await GET(makeGetRequest('?sorobanInvocations=500&vercelComputeUsageSeconds=2000'), { params });
+        expect(res.status).toBe(200);
+
+        const body = await res.json();
+        expect(body.estimatedCost).toBeDefined();
+    });
 });

--- a/apps/backend/src/app/api/deployments/[id]/estimate-cost/route.ts
+++ b/apps/backend/src/app/api/deployments/[id]/estimate-cost/route.ts
@@ -8,8 +8,47 @@ function mapSubscriptionTier(tier?: string): PricingTier {
     return 'basic';
 }
 
+/**
+ * Parses and validates a positive number query parameter.
+ * Returns the parsed number if valid, undefined if not present, or an error response if invalid.
+ */
+function parsePositiveNumberParam(
+    searchParams: URLSearchParams,
+    paramName: string,
+): { value?: number; error?: NextResponse } {
+    if (!searchParams.has(paramName)) {
+        return { value: undefined };
+    }
+
+    const raw = searchParams.get(paramName);
+    const parsed = Number(raw);
+
+    if (isNaN(parsed) || !isFinite(parsed) || parsed < 0) {
+        return {
+            error: NextResponse.json(
+                { error: `${paramName} must be a non-negative number` },
+                { status: 400 }
+            ),
+        };
+    }
+
+    return { value: parsed };
+}
+
 export const GET = withAuth(async (req: NextRequest, { params, user, supabase, log }) => {
     const deploymentId = (params as { id: string }).id;
+    const searchParams = req.nextUrl.searchParams;
+
+    // Validate query parameters
+    const sorobanResult = parsePositiveNumberParam(searchParams, 'sorobanInvocations');
+    if (sorobanResult.error) {
+        return sorobanResult.error;
+    }
+
+    const vercelResult = parsePositiveNumberParam(searchParams, 'vercelComputeUsageSeconds');
+    if (vercelResult.error) {
+        return vercelResult.error;
+    }
 
     // Fetch deployment
     const { data: deployment, error: fetchError } = await supabase
@@ -41,13 +80,8 @@ export const GET = withAuth(async (req: NextRequest, { params, user, supabase, l
         deployment.customization_config,
         pricingTier,
         {
-            // Optional: read options if passed via query params
-            sorobanInvocations: req.nextUrl.searchParams.has('sorobanInvocations') 
-                ? Number(req.nextUrl.searchParams.get('sorobanInvocations')) 
-                : undefined,
-            vercelComputeUsageSeconds: req.nextUrl.searchParams.has('vercelComputeUsageSeconds')
-                ? Number(req.nextUrl.searchParams.get('vercelComputeUsageSeconds'))
-                : undefined,
+            sorobanInvocations: sorobanResult.value,
+            vercelComputeUsageSeconds: vercelResult.value,
         }
     );
 

--- a/apps/backend/src/app/api/deployments/[id]/logs/stream/route.test.ts
+++ b/apps/backend/src/app/api/deployments/[id]/logs/stream/route.test.ts
@@ -16,6 +16,23 @@ const mockUser = { id: 'test-user' };
 
 const mockDeployment = { user_id: 'test-user', id: 'test-deployment' };
 
+vi.mock('@/lib/api/cors', () => ({
+    corsHeaders: vi.fn((origin: string | null) => {
+        const headers: Record<string, string> = {
+            'Access-Control-Allow-Methods': 'GET, POST, PUT, PATCH, DELETE, OPTIONS',
+            'Access-Control-Allow-Headers': 'Content-Type, Authorization, X-Requested-With',
+            'Access-Control-Max-Age': '86400',
+        };
+
+        if (origin === 'http://localhost:3000' || origin === 'https://allowed-origin.com') {
+            headers['Access-Control-Allow-Origin'] = origin;
+            headers['Vary'] = 'Origin';
+        }
+
+        return headers;
+    }),
+}));
+
 describe('GET /api/deployments/[id]/logs/stream', () => {
     beforeEach(() => {
         vi.clearAllMocks();
@@ -122,13 +139,15 @@ describe('GET /api/deployments/[id]/logs/stream', () => {
         expect(response.headers.get('content-type')).toBe('text/event-stream');
     });
 
-    it('should set proper CORS headers', async () => {
+    it('should set proper CORS headers for allowed origin', async () => {
         mockSupabase.single.mockResolvedValueOnce({
             data: mockDeployment,
             error: null,
         });
 
-        const req = new NextRequest('http://localhost/api/deployments/test-id/logs/stream');
+        const req = new NextRequest('http://localhost/api/deployments/test-id/logs/stream', {
+            headers: { origin: 'http://localhost:3000' },
+        });
 
         const response = await GET(req, {
             params: { id: 'test-id' },
@@ -136,9 +155,29 @@ describe('GET /api/deployments/[id]/logs/stream', () => {
             supabase: mockSupabase,
         } as any);
 
-        expect(response.headers.get('access-control-allow-origin')).toBe('*');
-        expect(response.headers.get('access-control-allow-methods')).toBe('GET');
-        expect(response.headers.get('access-control-allow-headers')).toBe('Content-Type');
+        expect(response.headers.get('access-control-allow-origin')).toBe('http://localhost:3000');
+        expect(response.headers.get('access-control-allow-methods')).toContain('GET');
+        expect(response.headers.get('vary')).toBe('Origin');
+    });
+
+    it('should omit CORS origin header for disallowed origin', async () => {
+        mockSupabase.single.mockResolvedValueOnce({
+            data: mockDeployment,
+            error: null,
+        });
+
+        const req = new NextRequest('http://localhost/api/deployments/test-id/logs/stream', {
+            headers: { origin: 'https://disallowed-origin.com' },
+        });
+
+        const response = await GET(req, {
+            params: { id: 'test-id' },
+            user: mockUser,
+            supabase: mockSupabase,
+        } as any);
+
+        expect(response.headers.get('access-control-allow-origin')).toBeNull();
+        expect(response.headers.get('access-control-allow-methods')).toContain('GET');
     });
 
     it('should handle stream cancellation gracefully', async () => {

--- a/apps/backend/src/app/api/deployments/[id]/logs/stream/route.ts
+++ b/apps/backend/src/app/api/deployments/[id]/logs/stream/route.ts
@@ -8,6 +8,10 @@
  * Ownership: the authenticated user must own the deployment.
  *            Non-owners and missing deployments both return 404.
  *
+ * CORS: uses origin allow-list (see lib/api/cors.ts). Credentialed requests from
+ *       disallowed origins receive no Access-Control-Allow-Origin header, causing
+ *       the browser to block the response.
+ *
  * Query parameters:
  *   since   ISO 8601       Start streaming logs created after this timestamp (optional)
  *   level   log level      Filter by log level (optional)
@@ -36,6 +40,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { withAuth } from '@/lib/api/with-auth';
+import { corsHeaders } from '@/lib/api/cors';
 import {
     deploymentLogsService,
     type ExtendedLogsQueryParams,
@@ -291,14 +296,13 @@ export const GET = withAuth(async (req: NextRequest, { params, user, supabase })
             },
         });
 
+        const origin = req.headers.get('origin');
         return new NextResponse(stream, {
             headers: {
                 'Content-Type': 'text/event-stream',
                 'Cache-Control': 'no-cache',
                 'Connection': 'keep-alive',
-                'Access-Control-Allow-Origin': '*',
-                'Access-Control-Allow-Methods': 'GET',
-                'Access-Control-Allow-Headers': 'Content-Type',
+                ...corsHeaders(origin),
             },
         });
     } catch (err: unknown) {


### PR DESCRIPTION
## Summary

This PR addresses 4 interconnected backend improvements:

1. **#943**: Deduplicate webhook replay logic and formalize API documentation
   - Extract single-delivery replay logic into `replayOne()` helper
   - Use consistent implementation from both single and bulk replay paths
   - Document all three operations (GET, POST, PUT) with JSDoc comments

2. **#942**: Harden deployment cost estimation endpoint validation
   - Add `parsePositiveNumberParam()` helper for consistent query param validation
   - Validate `sorobanInvocations` and `vercelComputeUsageSeconds` as non-negative numbers
   - Return 400 with descriptive errors instead of silent NaN results

3. **#940**: Replace permissive CORS wildcard with origin allow-list
   - Import and use `corsHeaders()` helper from existing CORS configuration
   - Replace hardcoded `Access-Control-Allow-Origin: *` with origin-based headers
   - Clarify that route is authenticated (credentialed requests require proper origin handling)
   - Improves security for sensitive per-user deployment log streaming

4. **#941**: Add structured correlation logging to encryption key rotation
   - Import structured logger with correlation ID support
   - Replace `console.error()` with `log.error()` for consistent log aggregation
   - Log rotation summary on success and configuration issues on error
   - Attach `X-Correlation-Id` header to all responses for cross-system tracing

## Test Plan

- Run: `pnpm --filter backend test app/api/admin/webhooks/replay`
- Run: `pnpm --filter backend test app/api/deployments`
- Run: `pnpm --filter backend test app/api/cron/rotate-encryption-keys`
- Run: `pnpm --filter backend typecheck`
- Run: `pnpm --filter backend lint`

All tests verify:
- Webhook replay deduplication maintains existing behavior
- Query parameter validation catches invalid inputs
- CORS headers respect allow-list for authenticated requests
- Structured logging includes correlation IDs and operational metadata

Closes #943
Closes #942
Closes #940
Closes #941