### PR TITLE
Multi-resilience improvements: jitter, backoff, caching, and parsing

### DIFF
--- a/apps/backend/src/lib/dns/domain-verification.test.ts
+++ b/apps/backend/src/lib/dns/domain-verification.test.ts
@@ -148,3 +148,141 @@ describe('verifyViaCname', () => {
         expect(result.errorCode).toBe('TIMEOUT');
     });
 });
+
+// ---------------------------------------------------------------------------
+// Retry backoff behavior
+// ---------------------------------------------------------------------------
+describe('verifyViaTxt retry backoff', () => {
+    it('calls sleep with increasing delays on ESERVFAIL retries', async () => {
+        const mockSleep = vi.fn().mockResolvedValue(undefined);
+
+        mockDns.resolveTxt.mockRejectedValue(
+            Object.assign(new Error('ESERVFAIL'), { code: 'ESERVFAIL' })
+        );
+        mockDns.resolveTxt.mockRejectedValueOnce(
+            Object.assign(new Error('ESERVFAIL'), { code: 'ESERVFAIL' })
+        );
+        mockDns.resolveTxt.mockRejectedValueOnce(
+            Object.assign(new Error('ESERVFAIL'), { code: 'ESERVFAIL' })
+        );
+
+        await verifyViaTxt('example.com', 'token', {
+            retries: 2,
+            sleep: mockSleep,
+        });
+
+        // Should have slept twice (between attempts 0->1 and 1->2)
+        expect(mockSleep).toHaveBeenCalledTimes(2);
+        const delays = mockSleep.mock.calls.map(call => call[0]);
+        // Delays should be increasing (with jitter, may not be strictly increasing)
+        expect(delays[0]).toBeGreaterThan(0);
+        expect(delays[1]).toBeGreaterThan(0);
+    });
+
+    it('calls sleep with increasing delays on DNS_TIMEOUT retries', async () => {
+        const mockSleep = vi.fn().mockResolvedValue(undefined);
+
+        mockDns.resolveTxt.mockImplementation(
+            () => new Promise((_, reject) => setTimeout(() => reject(new Error('DNS_TIMEOUT')), 10)),
+        );
+
+        await verifyViaTxt('example.com', 'token', {
+            timeout: 1,
+            retries: 2,
+            sleep: mockSleep,
+        });
+
+        // Should have slept twice for retries
+        expect(mockSleep).toHaveBeenCalledTimes(2);
+    });
+
+    it('respects custom retry delay options', async () => {
+        const mockSleep = vi.fn().mockResolvedValue(undefined);
+
+        mockDns.resolveTxt.mockRejectedValue(
+            Object.assign(new Error('ESERVFAIL'), { code: 'ESERVFAIL' })
+        );
+
+        await verifyViaTxt('example.com', 'token', {
+            retries: 1,
+            retryDelayBaseMs: 100,
+            retryDelayMaxMs: 200,
+            sleep: mockSleep,
+        });
+
+        expect(mockSleep).toHaveBeenCalledTimes(1);
+        const delay = mockSleep.mock.calls[0][0];
+        // Delay should be between 100 and 200 (with jitter)
+        expect(delay).toBeGreaterThanOrEqual(90); // 100 - 10% jitter
+        expect(delay).toBeLessThanOrEqual(220); // 200 + 10% jitter
+    });
+
+    it('does not sleep on ENOTFOUND (non-retryable)', async () => {
+        const mockSleep = vi.fn().mockResolvedValue(undefined);
+
+        mockDns.resolveTxt.mockRejectedValue(
+            Object.assign(new Error('ENOTFOUND'), { code: 'ENOTFOUND' })
+        );
+
+        await verifyViaTxt('example.com', 'token', {
+            retries: 2,
+            sleep: mockSleep,
+        });
+
+        expect(mockSleep).not.toHaveBeenCalled();
+    });
+});
+
+describe('verifyViaCname retry backoff', () => {
+    it('calls sleep with increasing delays on ESERVFAIL retries', async () => {
+        const mockSleep = vi.fn().mockResolvedValue(undefined);
+
+        mockDns.resolveCname.mockRejectedValue(
+            Object.assign(new Error('ESERVFAIL'), { code: 'ESERVFAIL' })
+        );
+
+        await verifyViaCname('www.example.com', {
+            retries: 2,
+            sleep: mockSleep,
+        });
+
+        expect(mockSleep).toHaveBeenCalledTimes(2);
+    });
+
+    it('calls sleep with increasing delays on DNS_TIMEOUT retries', async () => {
+        const mockSleep = vi.fn().mockResolvedValue(undefined);
+
+        mockDns.resolveCname.mockImplementation(
+            () => new Promise((_, reject) => setTimeout(() => reject(new Error('DNS_TIMEOUT')), 10)),
+        );
+
+        await verifyViaCname('www.example.com', {
+            timeout: 1,
+            retries: 2,
+            sleep: mockSleep,
+        });
+
+        expect(mockSleep).toHaveBeenCalledTimes(2);
+    });
+
+    it('respects custom retry delay options', async () => {
+        const mockSleep = vi.fn().mockResolvedValue(undefined);
+
+        mockDns.resolveCname.mockRejectedValue(
+            Object.assign(new Error('ESERVFAIL'), { code: 'ESERVFAIL' })
+        );
+
+        await verifyViaCname('www.example.com', {
+            retries: 1,
+            retryDelayBaseMs: 200,
+            retryDelayMaxMs: 400,
+            sleep: mockSleep,
+        });
+
+        expect(mockSleep).toHaveBeenCalledTimes(1);
+        const delay = mockSleep.mock.calls[0][0];
+        // Delay should be between 200 and 400 (with jitter)
+        expect(delay).toBeGreaterThanOrEqual(180); // 200 - 10% jitter
+        expect(delay).toBeLessThanOrEqual(440); // 400 + 10% jitter
+    });
+});

--- a/apps/backend/src/lib/dns/domain-verification.ts
+++ b/apps/backend/src/lib/dns/domain-verification.ts
@@ -8,10 +8,17 @@
  * 2. CNAME record — user adds a CNAME from their subdomain pointing to
  *    `cname.vercel-dns.com` (reuses the DNS config target).
  *
+ * Retry behavior
+ * ──────────────
+ * On transient errors (ESERVFAIL, DNS_TIMEOUT), retries are scheduled with
+ * exponential backoff (base 500ms, up to 30s) to avoid re-firing the same
+ * query back-to-back within the same timeout window.
+ *
  * Uses Node's built-in `dns.promises` — no extra dependencies.
  */
 
 import dns from 'node:dns/promises';
+import { calculateBackoffDelay, sleep } from '@/lib/retry/exponential-backoff';
 
 export type VerificationMethod = 'txt' | 'cname';
 
@@ -38,6 +45,12 @@ export interface VerifyDomainOptions {
     timeout?: number;
     /** How many times to retry on transient errors. Default: 2 */
     retries?: number;
+    /** Base delay (ms) for exponential backoff between retries. Default: 500 */
+    retryDelayBaseMs?: number;
+    /** Max delay (ms) for exponential backoff between retries. Default: 5000 */
+    retryDelayMaxMs?: number;
+    /** Injectable sleep function for testing. Default: real sleep */
+    sleep?: (ms: number) => Promise<void>;
 }
 
 /** Vercel CNAME target — must match dns-configuration.ts */
@@ -79,6 +92,9 @@ export async function verifyViaTxt(
 
     const host = txtHostname(domain);
     const retries = options.retries ?? 2;
+    const retryDelayBaseMs = options.retryDelayBaseMs ?? 500;
+    const retryDelayMaxMs = options.retryDelayMaxMs ?? 5000;
+    const sleepFn = options.sleep ?? sleep;
 
     for (let attempt = 0; attempt <= retries; attempt++) {
         try {
@@ -106,7 +122,11 @@ export async function verifyViaTxt(
             const code = (err as NodeJS.ErrnoException).code;
 
             if (code === 'ENOTFOUND' || code === 'ENODATA' || code === 'ESERVFAIL') {
-                if (attempt < retries && code === 'ESERVFAIL') continue; // retry transient
+                if (attempt < retries && code === 'ESERVFAIL') {
+                    const delay = calculateBackoffDelay(attempt, retryDelayBaseMs, retryDelayMaxMs, 2);
+                    await sleepFn(delay);
+                    continue;
+                }
                 return {
                     verified: false,
                     method: 'txt',
@@ -117,7 +137,11 @@ export async function verifyViaTxt(
             }
 
             if ((err as Error).message === 'DNS_TIMEOUT') {
-                if (attempt < retries) continue;
+                if (attempt < retries) {
+                    const delay = calculateBackoffDelay(attempt, retryDelayBaseMs, retryDelayMaxMs, 2);
+                    await sleepFn(delay);
+                    continue;
+                }
                 return {
                     verified: false,
                     method: 'txt',
@@ -173,6 +197,9 @@ export async function verifyViaCname(
     }
 
     const retries = options.retries ?? 2;
+    const retryDelayBaseMs = options.retryDelayBaseMs ?? 500;
+    const retryDelayMaxMs = options.retryDelayMaxMs ?? 5000;
+    const sleepFn = options.sleep ?? sleep;
 
     for (let attempt = 0; attempt <= retries; attempt++) {
         try {
@@ -200,7 +227,11 @@ export async function verifyViaCname(
             const code = (err as NodeJS.ErrnoException).code;
 
             if (code === 'ENOTFOUND' || code === 'ENODATA' || code === 'ESERVFAIL') {
-                if (attempt < retries && code === 'ESERVFAIL') continue;
+                if (attempt < retries && code === 'ESERVFAIL') {
+                    const delay = calculateBackoffDelay(attempt, retryDelayBaseMs, retryDelayMaxMs, 2);
+                    await sleepFn(delay);
+                    continue;
+                }
                 return {
                     verified: false,
                     method: 'cname',
@@ -211,7 +242,11 @@ export async function verifyViaCname(
             }
 
             if ((err as Error).message === 'DNS_TIMEOUT') {
-                if (attempt < retries) continue;
+                if (attempt < retries) {
+                    const delay = calculateBackoffDelay(attempt, retryDelayBaseMs, retryDelayMaxMs, 2);
+                    await sleepFn(delay);
+                    continue;
+                }
                 return {
                     verified: false,
                     method: 'cname',

--- a/apps/backend/src/lib/github/scope-validator.test.ts
+++ b/apps/backend/src/lib/github/scope-validator.test.ts
@@ -1,0 +1,297 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  parseGrantedScopes,
+  validateScopes,
+  fetchAndValidateScopes,
+  clearScopeValidationCache,
+  REQUIRED_SCOPES,
+} from './scope-validator';
+
+vi.stubGlobal('fetch', vi.fn());
+
+describe('scope-validator', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearScopeValidationCache();
+  });
+
+  afterEach(() => {
+    clearScopeValidationCache();
+  });
+
+  describe('parseGrantedScopes', () => {
+    it('parses a comma-separated header value', () => {
+      const result = parseGrantedScopes('repo, read:user');
+      expect(result).toEqual(['repo', 'read:user']);
+    });
+
+    it('handles a single scope', () => {
+      const result = parseGrantedScopes('repo');
+      expect(result).toEqual(['repo']);
+    });
+
+    it('trims whitespace', () => {
+      const result = parseGrantedScopes('  repo  ,  read:user  ');
+      expect(result).toEqual(['repo', 'read:user']);
+    });
+
+    it('returns an empty array for null', () => {
+      const result = parseGrantedScopes(null);
+      expect(result).toEqual([]);
+    });
+
+    it('returns an empty array for empty string', () => {
+      const result = parseGrantedScopes('');
+      expect(result).toEqual([]);
+    });
+
+    it('filters out empty values', () => {
+      const result = parseGrantedScopes('repo,,read:user');
+      expect(result).toEqual(['repo', 'read:user']);
+    });
+  });
+
+  describe('validateScopes', () => {
+    it('returns valid when all required scopes are present', () => {
+      const result = validateScopes(['repo', 'read:user']);
+      expect(result.valid).toBe(true);
+      expect(result.missingScopes).toEqual([]);
+    });
+
+    it('returns invalid with missing scopes', () => {
+      const result = validateScopes(['repo']);
+      expect(result.valid).toBe(false);
+      expect(result.missingScopes).toContain('read:user');
+    });
+
+    it('satisfies child scopes with parent scopes', () => {
+      // 'repo' satisfies 'repo:status', 'public_repo', etc.
+      const result = validateScopes(['repo', 'read:user']);
+      expect(result.valid).toBe(true);
+    });
+
+    it('returns empty granted scopes array when validation fails', () => {
+      const result = validateScopes(['invalid']);
+      expect(result.valid).toBe(false);
+      expect(result.grantedScopes).toEqual(['invalid']);
+    });
+  });
+
+  describe('fetchAndValidateScopes', () => {
+    const mockFetch = fetch as any;
+
+    it('makes a fetch request with correct headers', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        headers: new Map([['X-OAuth-Scopes', 'repo, read:user']]),
+      });
+
+      await fetchAndValidateScopes('token-123');
+
+      expect(mockFetch).toHaveBeenCalledWith('https://api.github.com/user', {
+        headers: {
+          Authorization: 'Bearer token-123',
+          Accept: 'application/vnd.github+json',
+          'X-GitHub-Api-Version': '2022-11-28',
+        },
+      });
+    });
+
+    it('returns valid result when scopes are present', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        headers: new Map([['X-OAuth-Scopes', 'repo, read:user']]),
+      });
+
+      const result = await fetchAndValidateScopes('token-123');
+
+      expect(result.valid).toBe(true);
+      expect(result.grantedScopes).toEqual(['repo', 'read:user']);
+      expect(result.missingScopes).toEqual([]);
+    });
+
+    it('returns invalid result with missing scopes', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        headers: new Map([['X-OAuth-Scopes', 'repo']]),
+      });
+
+      const result = await fetchAndValidateScopes('token-123');
+
+      expect(result.valid).toBe(false);
+      expect(result.missingScopes).toContain('read:user');
+    });
+
+    it('returns error result on network failure', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('Network error'));
+
+      const result = await fetchAndValidateScopes('token-123');
+
+      expect(result.valid).toBe(false);
+      expect(result.fetchError).toBe('Network error');
+      expect(result.grantedScopes).toEqual([]);
+    });
+
+    it('returns error result on API error', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        headers: new Map(),
+      });
+
+      const result = await fetchAndValidateScopes('token-123');
+
+      expect(result.valid).toBe(false);
+      expect(result.fetchError).toContain('401');
+    });
+  });
+
+  describe('scope validation caching', () => {
+    const mockFetch = fetch as any;
+
+    it('caches successful validations', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        headers: new Map([['X-OAuth-Scopes', 'repo, read:user']]),
+      });
+
+      const result1 = await fetchAndValidateScopes('token-123');
+
+      // Reset mock to track subsequent calls
+      mockFetch.mockClear();
+
+      const result2 = await fetchAndValidateScopes('token-123');
+
+      // Should not have made another fetch call due to cache
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(result2).toEqual(result1);
+    });
+
+    it('does not cache failed validations', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('Network error'));
+
+      const result1 = await fetchAndValidateScopes('token-123');
+
+      expect(result1.valid).toBe(false);
+      expect(result1.fetchError).toBe('Network error');
+
+      // Reset mock and retry
+      mockFetch.mockClear();
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        headers: new Map([['X-OAuth-Scopes', 'repo, read:user']]),
+      });
+
+      const result2 = await fetchAndValidateScopes('token-123');
+
+      // Should have made a new fetch call since failures aren't cached
+      expect(mockFetch).toHaveBeenCalledOnce();
+      expect(result2.valid).toBe(true);
+    });
+
+    it('does not cache API error responses', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        headers: new Map(),
+      });
+
+      const result1 = await fetchAndValidateScopes('token-123');
+
+      expect(result1.valid).toBe(false);
+
+      // Reset mock and retry
+      mockFetch.mockClear();
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        headers: new Map([['X-OAuth-Scopes', 'repo, read:user']]),
+      });
+
+      const result2 = await fetchAndValidateScopes('token-123');
+
+      // Should have made a new fetch call since API errors aren't cached
+      expect(mockFetch).toHaveBeenCalledOnce();
+      expect(result2.valid).toBe(true);
+    });
+
+    it('uses different cache entries for different tokens', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          headers: new Map([['X-OAuth-Scopes', 'repo, read:user']]),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          headers: new Map([['X-OAuth-Scopes', 'repo']]),
+        });
+
+      const result1 = await fetchAndValidateScopes('token-123');
+      const result2 = await fetchAndValidateScopes('token-456');
+
+      expect(result1.grantedScopes).toContain('read:user');
+      expect(result2.grantedScopes).not.toContain('read:user');
+
+      // Both tokens should have caused fetch calls
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('clears the cache when clearScopeValidationCache is called', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        headers: new Map([['X-OAuth-Scopes', 'repo, read:user']]),
+      });
+
+      await fetchAndValidateScopes('token-123');
+
+      clearScopeValidationCache();
+
+      mockFetch.mockClear();
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        headers: new Map([['X-OAuth-Scopes', 'repo, read:user']]),
+      });
+
+      await fetchAndValidateScopes('token-123');
+
+      // Should have made a new fetch after clear
+      expect(mockFetch).toHaveBeenCalledOnce();
+    });
+
+    it('respects cache TTL', async () => {
+      vi.useFakeTimers();
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        headers: new Map([['X-OAuth-Scopes', 'repo, read:user']]),
+      });
+
+      await fetchAndValidateScopes('token-123');
+
+      mockFetch.mockClear();
+
+      // Advance time past default TTL (5 minutes)
+      vi.advanceTimersByTime(6 * 60 * 1000);
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        headers: new Map([['X-OAuth-Scopes', 'repo, read:user']]),
+      });
+
+      await fetchAndValidateScopes('token-123');
+
+      // Should have made a new fetch after TTL expired
+      expect(mockFetch).toHaveBeenCalledOnce();
+
+      vi.useRealTimers();
+    });
+  });
+
+  describe('buildMissingScopeMessage', () => {
+    it('is exported as a utility function', async () => {
+      const { buildMissingScopeMessage } = await import('./scope-validator');
+      const message = buildMissingScopeMessage(['repo', 'read:user']);
+      expect(message).toContain('repo');
+      expect(message).toContain('read:user');
+    });
+  });
+});

--- a/apps/backend/src/lib/github/scope-validator.ts
+++ b/apps/backend/src/lib/github/scope-validator.ts
@@ -21,11 +21,35 @@
  * `repo:deployment`, etc. The validator resolves this — if `repo` is granted,
  * narrower `repo:*` sub-scopes are satisfied automatically.
  *
+ * Caching
+ * ───────
+ * Successful validations are cached in-memory with a short TTL (default: 5 minutes,
+ * configurable via SCOPE_VALIDATION_CACHE_TTL_MS env var) keyed by a SHA-256 hash
+ * of the access token to avoid holding plaintext tokens in memory. Failures are
+ * never cached so transient GitHub outages don't get stuck as false negatives.
+ *
  * Feature: github-oauth-scope-validation
- * Issue: #658
+ * Issue: #658, #938
  */
 
+import { createHash } from 'node:crypto';
+
 const GITHUB_USER_URL = 'https://api.github.com/user';
+const SCOPE_VALIDATION_CACHE_TTL_MS = parseInt(
+    process.env.SCOPE_VALIDATION_CACHE_TTL_MS ?? '300000',
+    10,
+); // 5 minutes default
+
+interface CacheEntry {
+    result: ScopeValidationResult;
+    expiresAt: number;
+}
+
+const scopeValidationCache = new Map<string, CacheEntry>();
+
+function hashToken(token: string): string {
+    return createHash('sha256').update(token).digest('hex');
+}
 
 /** All scopes CRAFT requires for deployment operations. */
 export const REQUIRED_SCOPES = ['repo', 'read:user'] as const;
@@ -89,8 +113,20 @@ export function validateScopes(grantedScopes: string[]): ScopeValidationResult {
 }
 
 /**
+ * Clear the scope validation cache.
+ * Used for test isolation or manual cache flush.
+ */
+export function clearScopeValidationCache(): void {
+    scopeValidationCache.clear();
+}
+
+/**
  * Fetch the X-OAuth-Scopes header from GitHub by making an authenticated
  * request to GET /user and reading the response headers.
+ *
+ * Results are cached (in-memory, short TTL) to avoid redundant API calls.
+ * Only successful validations are cached; failures are never cached to prevent
+ * transient errors from persisting as false negatives.
  *
  * Returns a ScopeValidationResult. Never throws — all error paths return
  * { valid: false } so callers can surface actionable messages.
@@ -98,6 +134,19 @@ export function validateScopes(grantedScopes: string[]): ScopeValidationResult {
 export async function fetchAndValidateScopes(
     accessToken: string,
 ): Promise<ScopeValidationResult & { fetchError?: string }> {
+    const tokenHash = hashToken(accessToken);
+
+    // Check cache
+    const cached = scopeValidationCache.get(tokenHash);
+    if (cached && Date.now() < cached.expiresAt) {
+        return cached.result;
+    }
+
+    // Remove expired entry if present
+    if (cached) {
+        scopeValidationCache.delete(tokenHash);
+    }
+
     let res: Response;
     try {
         res = await fetch(GITHUB_USER_URL, {
@@ -128,7 +177,15 @@ export async function fetchAndValidateScopes(
 
     const scopeHeader = res.headers.get('X-OAuth-Scopes');
     const grantedScopes = parseGrantedScopes(scopeHeader);
-    return validateScopes(grantedScopes);
+    const result = validateScopes(grantedScopes);
+
+    // Cache successful validations
+    scopeValidationCache.set(tokenHash, {
+        result,
+        expiresAt: Date.now() + SCOPE_VALIDATION_CACHE_TTL_MS,
+    });
+
+    return result;
 }
 
 /**

--- a/apps/backend/src/lib/realtime/realtime-status-poller.test.ts
+++ b/apps/backend/src/lib/realtime/realtime-status-poller.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { SupabaseClient, RealtimeChannel } from '@supabase/supabase-js';
+import { RealtimeStatusPoller } from './realtime-status-poller';
+
+// Mock Supabase
+vi.mock('@supabase/supabase-js');
+
+describe('RealtimeStatusPoller', () => {
+  let mockSupabase: Partial<SupabaseClient>;
+  let mockChannel: Partial<RealtimeChannel>;
+
+  beforeEach(() => {
+    mockChannel = {
+      on: vi.fn().mockReturnThis(),
+      subscribe: vi.fn(),
+    };
+
+    mockSupabase = {
+      from: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({
+              data: { user_id: 'user-123' },
+              error: null,
+            }),
+          }),
+        }),
+      }),
+      channel: vi.fn().mockReturnValue(mockChannel),
+      removeChannel: vi.fn().mockResolvedValue(undefined),
+    };
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('constructor', () => {
+    it('creates a poller with default options', () => {
+      const poller = new RealtimeStatusPoller(
+        mockSupabase as SupabaseClient,
+        'deploy-123',
+        'user-123',
+      );
+      expect(poller.connectionState).toBe('disconnected');
+    });
+
+    it('accepts custom backoff options', () => {
+      const poller = new RealtimeStatusPoller(
+        mockSupabase as SupabaseClient,
+        'deploy-123',
+        'user-123',
+        {
+          maxRetries: 3,
+          baseDelayMs: 100,
+          maxDelayMs: 5000,
+        },
+      );
+      expect(poller.connectionState).toBe('disconnected');
+    });
+
+    it('accepts injectable random function', () => {
+      const mockRandom = vi.fn().mockReturnValue(0.5);
+      const poller = new RealtimeStatusPoller(
+        mockSupabase as SupabaseClient,
+        'deploy-123',
+        'user-123',
+        { randomFn: mockRandom },
+      );
+      expect(poller.connectionState).toBe('disconnected');
+    });
+  });
+
+  describe('onStatus', () => {
+    it('registers a status handler', () => {
+      const poller = new RealtimeStatusPoller(
+        mockSupabase as SupabaseClient,
+        'deploy-123',
+        'user-123',
+      );
+      const handler = vi.fn();
+      const unsubscribe = poller.onStatus(handler);
+
+      expect(typeof unsubscribe).toBe('function');
+    });
+
+    it('returns a function that unsubscribes the handler', () => {
+      const poller = new RealtimeStatusPoller(
+        mockSupabase as SupabaseClient,
+        'deploy-123',
+        'user-123',
+      );
+      const handler = vi.fn();
+      const unsubscribe = poller.onStatus(handler);
+
+      unsubscribe();
+      expect(unsubscribe).toBeDefined();
+    });
+  });
+
+  describe('connectionState', () => {
+    it('returns the current connection state', () => {
+      const poller = new RealtimeStatusPoller(
+        mockSupabase as SupabaseClient,
+        'deploy-123',
+        'user-123',
+      );
+      expect(poller.connectionState).toBe('disconnected');
+    });
+  });
+
+  describe('disconnect', () => {
+    it('sets state to closed', async () => {
+      const poller = new RealtimeStatusPoller(
+        mockSupabase as SupabaseClient,
+        'deploy-123',
+        'user-123',
+      );
+      await poller.disconnect();
+      expect(poller.connectionState).toBe('closed');
+    });
+  });
+
+  describe('backoff with jitter', () => {
+    it('applies jitter to reconnect delays using injectable random', async () => {
+      vi.useFakeTimers();
+
+      // Track delays applied to setTimeout
+      const delays: number[] = [];
+      const originalSetTimeout = setTimeout;
+      vi.stubGlobal('setTimeout', vi.fn((cb: any, delay: number) => {
+        delays.push(delay);
+        return originalSetTimeout(cb, 0); // Run immediately for test
+      }));
+
+      const mockRandom = vi.fn()
+        .mockReturnValueOnce(0.5) // First retry
+        .mockReturnValueOnce(0.5); // Second retry
+
+      const poller = new RealtimeStatusPoller(
+        mockSupabase as SupabaseClient,
+        'deploy-123',
+        'user-123',
+        {
+          baseDelayMs: 100,
+          maxDelayMs: 10000,
+          maxRetries: 5,
+          randomFn: mockRandom,
+        },
+      );
+
+      await poller.connect();
+
+      // Simulate disconnect by calling subscribe callback
+      const subscribeCallback = (mockChannel.subscribe as any).mock.calls[0][0];
+      subscribeCallback('CHANNEL_ERROR');
+
+      vi.runAllTimers();
+      vi.useRealTimers();
+
+      // Should have at least one delay (from first reconnect attempt)
+      expect(delays.length).toBeGreaterThan(0);
+    });
+
+    it('respects max retry count', async () => {
+      vi.useFakeTimers();
+
+      const mockRandom = vi.fn().mockReturnValue(0.5);
+      const poller = new RealtimeStatusPoller(
+        mockSupabase as SupabaseClient,
+        'deploy-123',
+        'user-123',
+        {
+          maxRetries: 2,
+          baseDelayMs: 100,
+          randomFn: mockRandom,
+        },
+      );
+
+      await poller.connect();
+
+      const subscribeCallback = (mockChannel.subscribe as any).mock.calls[0][0];
+
+      // Trigger disconnects up to max retries
+      subscribeCallback('CHANNEL_ERROR');
+      vi.runAllTimers();
+
+      subscribeCallback('CHANNEL_ERROR');
+      vi.runAllTimers();
+
+      // After max retries, should transition to closed
+      expect(poller.connectionState).toBe('closed');
+
+      vi.useRealTimers();
+    });
+
+    it('calculates delays with exponential backoff', async () => {
+      const delays: number[] = [];
+
+      // Mock calculateBackoffDelay to capture arguments
+      vi.stubGlobal('setTimeout', vi.fn((cb: any, delay: number) => {
+        delays.push(delay);
+        return 0;
+      }));
+
+      const mockRandom = vi.fn().mockReturnValue(0.5);
+      const poller = new RealtimeStatusPoller(
+        mockSupabase as SupabaseClient,
+        'deploy-123',
+        'user-123',
+        {
+          baseDelayMs: 100,
+          maxDelayMs: 10000,
+          randomFn: mockRandom,
+        },
+      );
+
+      await poller.connect();
+
+      const subscribeCallback = (mockChannel.subscribe as any).mock.calls[0][0];
+
+      // First disconnect: attempt 0, delay ≈ 100ms (with jitter)
+      subscribeCallback('CHANNEL_ERROR');
+      const firstDelay = delays[delays.length - 1];
+
+      // Second disconnect: attempt 1, delay ≈ 200ms (with jitter)
+      subscribeCallback('CHANNEL_ERROR');
+      const secondDelay = delays[delays.length - 1];
+
+      // Second delay should generally be >= first delay (exponential)
+      // Note: due to jitter, this isn't always true, but with controlled random it should be
+      expect(secondDelay).toBeGreaterThanOrEqual(firstDelay * 0.8); // Allow for jitter variance
+    });
+  });
+});

--- a/apps/backend/src/lib/realtime/realtime-status-poller.ts
+++ b/apps/backend/src/lib/realtime/realtime-status-poller.ts
@@ -5,7 +5,10 @@
  * updates to subscribers. This is the platform's "WebSocket" layer: Supabase
  * Realtime uses WebSocket transport under the hood, and this utility provides
  * the connection lifecycle, message ordering, reconnection with exponential
- * backoff, and authentication that the issue requires.
+ * backoff with jitter, and authentication that the issue requires.
+ *
+ * Reconnection backoff uses exponential delay (baseDelayMs * 2^(attempt))
+ * with ±10% jitter to prevent thundering herd during mass reconnections.
  *
  * Architecture note:
  *   There is no custom WebSocket server in this codebase. Real-time updates
@@ -14,6 +17,7 @@
  */
 
 import type { SupabaseClient, RealtimeChannel } from '@supabase/supabase-js';
+import { calculateBackoffDelay } from '@/lib/retry/exponential-backoff';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -35,6 +39,8 @@ export interface PollerOptions {
   baseDelayMs?: number;
   /** Maximum backoff delay in ms. Default: 30_000 */
   maxDelayMs?: number;
+  /** Injectable random function for testing. Default: Math.random */
+  randomFn?: () => number;
 }
 
 // ── RealtimeStatusPoller ──────────────────────────────────────────────────────
@@ -46,7 +52,7 @@ export class RealtimeStatusPoller {
   private retryCount = 0;
   private retryTimer: ReturnType<typeof setTimeout> | null = null;
   private sequenceCounter = 0;
-  private readonly opts: Required<PollerOptions>;
+  private readonly opts: Required<Omit<PollerOptions, 'randomFn'>> & { randomFn: () => number };
 
   constructor(
     private readonly supabase: SupabaseClient,
@@ -58,6 +64,7 @@ export class RealtimeStatusPoller {
       maxRetries: opts.maxRetries ?? 5,
       baseDelayMs: opts.baseDelayMs ?? 500,
       maxDelayMs: opts.maxDelayMs ?? 30_000,
+      randomFn: opts.randomFn ?? Math.random,
     };
   }
 
@@ -162,9 +169,12 @@ export class RealtimeStatusPoller {
     this.setState('reconnecting');
     this.retryCount += 1;
 
-    const delay = Math.min(
-      this.opts.baseDelayMs * 2 ** (this.retryCount - 1),
+    const delay = calculateBackoffDelay(
+      this.retryCount - 1,
+      this.opts.baseDelayMs,
       this.opts.maxDelayMs,
+      2,
+      this.opts.randomFn,
     );
 
     this.retryTimer = setTimeout(() => {

--- a/apps/backend/src/lib/retry/exponential-backoff.ts
+++ b/apps/backend/src/lib/retry/exponential-backoff.ts
@@ -75,7 +75,9 @@ export function calculateBackoffDelay(
     initialDelayMs: number,
     maxDelayMs: number,
     multiplier: number,
+    randomFn?: () => number,
 ): number {
+    const random = randomFn ?? Math.random;
     // Exponential backoff: initial * (multiplier ^ attempt)
     let delay = initialDelayMs * Math.pow(multiplier, attempt);
 
@@ -83,7 +85,7 @@ export function calculateBackoffDelay(
     delay = Math.min(delay, maxDelayMs);
 
     // Add jitter: ±10% of the delay
-    const jitter = delay * 0.1 * (Math.random() - 0.5) * 2;
+    const jitter = delay * 0.1 * (random() - 0.5) * 2;
     return Math.max(0, delay + jitter);
 }
 

--- a/apps/backend/src/lib/stripe/tax.test.ts
+++ b/apps/backend/src/lib/stripe/tax.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseTaxExemptStatus,
+  isTaxExempt,
+  buildTaxExemptUpdate,
+  getTaxConfiguration,
+  buildCheckoutTaxParams,
+} from './tax';
+
+describe('tax', () => {
+  describe('parseTaxExemptStatus', () => {
+    it('returns "none" for a null value', () => {
+      expect(parseTaxExemptStatus(null)).toBe('none');
+    });
+
+    it('returns "none" for an undefined value', () => {
+      expect(parseTaxExemptStatus(undefined)).toBe('none');
+    });
+
+    it('returns "exempt" for an "exempt" value', () => {
+      expect(parseTaxExemptStatus('exempt')).toBe('exempt');
+    });
+
+    it('returns "reverse" for a "reverse" value', () => {
+      expect(parseTaxExemptStatus('reverse')).toBe('reverse');
+    });
+
+    it('returns "none" for an "none" value', () => {
+      expect(parseTaxExemptStatus('none')).toBe('none');
+    });
+
+    it('returns "none" for an unrecognized string value', () => {
+      expect(parseTaxExemptStatus('unknown')).toBe('none');
+      expect(parseTaxExemptStatus('invalid')).toBe('none');
+    });
+
+    it('handles empty string as "none"', () => {
+      expect(parseTaxExemptStatus('')).toBe('none');
+    });
+  });
+
+  describe('isTaxExempt', () => {
+    it('returns true for "exempt" status', () => {
+      expect(isTaxExempt('exempt')).toBe(true);
+    });
+
+    it('returns true for "reverse" status', () => {
+      expect(isTaxExempt('reverse')).toBe(true);
+    });
+
+    it('returns false for "none" status', () => {
+      expect(isTaxExempt('none')).toBe(false);
+    });
+  });
+
+  describe('buildTaxExemptUpdate', () => {
+    it('returns the correct update payload for "exempt" status', () => {
+      const result = buildTaxExemptUpdate('exempt');
+      expect(result).toEqual({ tax_exempt: 'exempt' });
+    });
+
+    it('returns the correct update payload for "reverse" status', () => {
+      const result = buildTaxExemptUpdate('reverse');
+      expect(result).toEqual({ tax_exempt: 'reverse' });
+    });
+
+    it('returns the correct update payload for "none" status', () => {
+      const result = buildTaxExemptUpdate('none');
+      expect(result).toEqual({ tax_exempt: 'none' });
+    });
+  });
+
+  describe('getTaxConfiguration', () => {
+    it('returns configuration based on environment variables', () => {
+      const config = getTaxConfiguration();
+      expect(config).toHaveProperty('enabled');
+      expect(config).toHaveProperty('collectTaxId');
+    });
+  });
+
+  describe('buildCheckoutTaxParams', () => {
+    it('returns empty object when tax is disabled', () => {
+      const result = buildCheckoutTaxParams({ enabled: false, collectTaxId: false });
+      expect(result).toEqual({});
+    });
+
+    it('returns automatic_tax when tax is enabled', () => {
+      const result = buildCheckoutTaxParams({ enabled: true, collectTaxId: false });
+      expect(result).toHaveProperty('automatic_tax');
+      expect(result.automatic_tax).toEqual({ enabled: true });
+    });
+
+    it('includes tax_id_collection when collectTaxId is true', () => {
+      const result = buildCheckoutTaxParams({ enabled: true, collectTaxId: true });
+      expect(result).toHaveProperty('tax_id_collection');
+      expect(result.tax_id_collection).toEqual({ enabled: true });
+    });
+  });
+
+  describe('integration: parsing and using tax status', () => {
+    it('safely handles null tax_exempt from Stripe API', () => {
+      const rawTaxExempt = null;
+      const parsed = parseTaxExemptStatus(rawTaxExempt);
+      const isExempt = isTaxExempt(parsed);
+      expect(isExempt).toBe(false);
+    });
+
+    it('preserves "exempt" status through parse and check', () => {
+      const rawTaxExempt = 'exempt';
+      const parsed = parseTaxExemptStatus(rawTaxExempt);
+      const isExempt = isTaxExempt(parsed);
+      const update = buildTaxExemptUpdate(parsed);
+      expect(isExempt).toBe(true);
+      expect(update.tax_exempt).toBe('exempt');
+    });
+
+    it('safely transitions from undefined to "none" and back', () => {
+      const rawTaxExempt = undefined;
+      const parsed = parseTaxExemptStatus(rawTaxExempt);
+      const update = buildTaxExemptUpdate(parsed);
+      expect(update).toEqual({ tax_exempt: 'none' });
+    });
+  });
+});

--- a/apps/backend/src/lib/stripe/tax.ts
+++ b/apps/backend/src/lib/stripe/tax.ts
@@ -18,8 +18,18 @@
  * exempt   : Tax-exempt organisations (e.g. non-profits, governments).
  * reverse  : B2B customers in eligible regions (VAT reverse charge).
  *
+ * Asymmetry: Nullable on read, non-nullable on write
+ * ──────────────────────────────────────────────────
+ * When reading from Stripe's API, the tax_exempt field can be null (for customers
+ * predating tax configuration or created outside this code path). Always route raw
+ * Stripe API responses through parseTaxExemptStatus() before passing to isTaxExempt()
+ * or buildTaxExemptUpdate().
+ *
+ * When writing, buildTaxExemptUpdate() only accepts the three valid TaxExemptStatus
+ * values — the type system enforces that invariant.
+ *
  * Feature: stripe-tax-rate-configuration
- * Issue: #655
+ * Issue: #655, #937
  */
 
 export type TaxExemptStatus = 'none' | 'exempt' | 'reverse';
@@ -61,6 +71,20 @@ export function buildCheckoutTaxParams(config: TaxConfiguration): {
  */
 export function buildTaxExemptUpdate(status: TaxExemptStatus): { tax_exempt: TaxExemptStatus } {
     return { tax_exempt: status };
+}
+
+/**
+ * Parse a raw Stripe tax_exempt value (which may be null) into a safe TaxExemptStatus.
+ * Handles nulls, undefineds, and unrecognized values by defaulting to 'none'.
+ *
+ * @param raw - The value from Stripe's Customer.tax_exempt field
+ * @returns A valid TaxExemptStatus, never null or undefined
+ */
+export function parseTaxExemptStatus(raw: string | null | undefined): TaxExemptStatus {
+    if (raw === 'exempt' || raw === 'reverse' || raw === 'none') {
+        return raw;
+    }
+    return 'none';
 }
 
 /**


### PR DESCRIPTION
## Summary

This PR implements four resilience and efficiency improvements across the backend:

1. **Realtime Status Poller Jitter (#939)**: Add jitter to reconnection backoff to prevent thundering herd during mass reconnections
2. **Stripe Tax Parsing (#937)**: Normalize nullable tax_exempt values from Stripe API to prevent runtime errors
3. **DNS Verification Backoff (#936)**: Implement exponential backoff between DNS verification retries for transient resolver issues
4. **GitHub Scope Cache (#938)**: Cache OAuth scope validation results with short TTL to reduce unnecessary API calls

## Changes

### #939: Realtime Status Poller Jitter
- Modified `calculateBackoffDelay()` to accept optional injectable `randomFn` parameter
- Updated `RealtimeStatusPoller.handleDisconnect()` to use jittered backoff via `calculateBackoffDelay()`
- Added `randomFn` to `PollerOptions` for testability
- Updated JSDoc to document jitter behavior
- Added comprehensive unit tests

### #937: Stripe Tax Exemption Parsing
- Added `parseTaxExemptStatus()` helper to safely handle null/undefined values from Stripe API
- Defaults unrecognized values to 'none' (regular taxable customer)
- Updated module JSDoc to document nullable-on-read vs. non-nullable-on-write asymmetry
- Added comprehensive unit tests for parser and integration scenarios

### #936: DNS Verification Backoff
- Imported `calculateBackoffDelay` and `sleep` from `lib/retry/exponential-backoff`
- Added `retryDelayBaseMs`, `retryDelayMaxMs`, and injectable `sleep` to `VerifyDomainOptions`
- Updated both `verifyViaTxt()` and `verifyViaCname()` to apply backoff between retries
- Base delay: 500ms, max delay: 5s, exponential multiplier: 2
- Updated module JSDoc to document retry behavior
- Added unit tests for backoff delays

### #938: GitHub Scope Validation Cache
- Implemented in-memory cache using Map, keyed by SHA-256 hash of token
- Short TTL default: 5 minutes (configurable via `SCOPE_VALIDATION_CACHE_TTL_MS` env var)
- Only successful validations are cached; failures never cached to prevent false negatives
- Added `clearScopeValidationCache()` export for test isolation
- Reduces GitHub API rate-limit consumption
- Added comprehensive unit tests for caching, TTL expiration, and cache isolation

## Testing

All changes include unit tests following existing patterns in the codebase:
- Use vitest with `describe/it/expect` patterns
- Mock external dependencies (fetch, dns promises, etc.)
- Test both happy path and error scenarios
- Include injectable dependencies for deterministic testing

Closes #939
Closes #937
Closes #936
Closes #938