### PR TITLE
fix(backend): harden delivery pagination, idempotency reuse, token de…

### DIFF
--- a/apps/backend/src/lib/github/app-auth.test.ts
+++ b/apps/backend/src/lib/github/app-auth.test.ts
@@ -128,4 +128,66 @@ describe('GitHubAppAuthClient', () => {
             retryable: true,
         } satisfies Partial<GitHubAppAuthError>);
     });
+
+    it('deduplicates concurrent getInstallationAuthContext calls against a cold cache', async () => {
+        // fetchFn is set up to resolve only once — if called more than once the
+        // second call would hang (no additional mock value), surfacing the bug.
+        const fetchFn = vi
+            .fn()
+            .mockResolvedValueOnce(
+                jsonResponse(201, {
+                    token: 'token-deduped',
+                    expires_at: new Date(Date.now() + 10 * 60_000).toISOString(),
+                }),
+            );
+
+        const client = new GitHubAppAuthClient({ config: baseConfig, fetchFn });
+
+        // Fire 5 concurrent calls against an empty cache
+        const results = await Promise.all([
+            client.getInstallationAuthContext(),
+            client.getInstallationAuthContext(),
+            client.getInstallationAuthContext(),
+            client.getInstallationAuthContext(),
+            client.getInstallationAuthContext(),
+        ]);
+
+        // fetchFn must have been called exactly once — all 5 callers shared the in-flight request
+        expect(fetchFn).toHaveBeenCalledTimes(1);
+
+        // All callers must have received the same token
+        for (const ctx of results) {
+            expect(ctx.token).toBe('token-deduped');
+        }
+    });
+
+    it('forceRefresh: true bypasses deduplication and starts its own fresh fetch', async () => {
+        const fetchFn = vi
+            .fn()
+            // First call: primes the cache
+            .mockResolvedValueOnce(
+                jsonResponse(201, {
+                    token: 'token-cached',
+                    expires_at: new Date(Date.now() + 10 * 60_000).toISOString(),
+                }),
+            )
+            // Second call: forced refresh
+            .mockResolvedValueOnce(
+                jsonResponse(201, {
+                    token: 'token-forced',
+                    expires_at: new Date(Date.now() + 10 * 60_000).toISOString(),
+                }),
+            );
+
+        const client = new GitHubAppAuthClient({ config: baseConfig, fetchFn });
+
+        // Prime the cache
+        const cached = await client.getInstallationAuthContext();
+        expect(cached.token).toBe('token-cached');
+
+        // forceRefresh must bypass the cached token and issue a new fetch
+        const forced = await client.getInstallationAuthContext({ forceRefresh: true });
+        expect(forced.token).toBe('token-forced');
+        expect(fetchFn).toHaveBeenCalledTimes(2);
+    });
 });

--- a/apps/backend/src/lib/github/app-auth.ts
+++ b/apps/backend/src/lib/github/app-auth.ts
@@ -53,6 +53,15 @@ export class GitHubAppAuthClient {
     private readonly tokenSkewMs: number;
     private readonly cache = new Map<number, CachedInstallationToken>();
 
+    /**
+     * Tracks an in-flight installation-token fetch so that concurrent callers
+     * can share a single request instead of each issuing their own.
+     * Cleared in a `finally` block after the fetch resolves or rejects.
+     * forceRefresh:true replaces this promise so subsequent non-forced callers
+     * piggyback on the fresh fetch rather than the superseded one.
+     */
+    private pendingFetch: Promise<CachedInstallationToken> | null = null;
+
     constructor(options: GitHubAppAuthClientOptions = {}) {
         this.config = options.config ?? getGitHubAppConfig();
         this.fetchFn = options.fetchFn ?? fetch;
@@ -68,9 +77,29 @@ export class GitHubAppAuthClient {
             return this.toAuthContext(cached);
         }
 
-        const refreshed = await this.fetchInstallationToken();
-        this.cache.set(this.config.installationId, refreshed);
+        // De-duplicate concurrent fetches:
+        //   - Non-forced callers share whichever fetch is already in flight.
+        //   - A forced refresh always starts its own fetch AND replaces
+        //     pendingFetch so subsequent non-forced callers piggyback on it.
+        if (!forceRefresh && this.pendingFetch) {
+            const refreshed = await this.pendingFetch;
+            return this.toAuthContext(refreshed);
+        }
 
+        const fetchPromise = this.fetchInstallationToken().then((token) => {
+            this.cache.set(this.config.installationId, token);
+            return token;
+        }).finally(() => {
+            // Only clear if this is still the active promise (a later forceRefresh
+            // may have already replaced pendingFetch).
+            if (this.pendingFetch === fetchPromise) {
+                this.pendingFetch = null;
+            }
+        });
+
+        this.pendingFetch = fetchPromise;
+
+        const refreshed = await fetchPromise;
         return this.toAuthContext(refreshed);
     }
 

--- a/apps/backend/src/services/github-delivery-fetcher.service.test.ts
+++ b/apps/backend/src/services/github-delivery-fetcher.service.test.ts
@@ -105,6 +105,7 @@ describe('GitHubDeliveryFetcherService', () => {
 
             mockRequestWithInstallationAuth.mockResolvedValue({
                 ok: true,
+                headers: { get: vi.fn().mockReturnValue(null) },
                 json: vi.fn().mockResolvedValue(mockGitHubResponse),
             });
 
@@ -126,21 +127,22 @@ describe('GitHubDeliveryFetcherService', () => {
 
             const mockGitHubResponse = [
                 {
-                    id: 1,
-                    guid: 'del-old',
-                    delivered_at: '2024-01-01T00:00:00Z',
-                    event: 'push',
-                },
-                {
                     id: 2,
                     guid: 'del-new',
                     delivered_at: '2024-01-02T00:00:00Z',
+                    event: 'push',
+                },
+                {
+                    id: 1,
+                    guid: 'del-old',
+                    delivered_at: '2024-01-01T00:00:00Z',
                     event: 'push',
                 },
             ];
 
             mockRequestWithInstallationAuth.mockResolvedValue({
                 ok: true,
+                headers: { get: vi.fn().mockReturnValue(null) },
                 json: vi.fn().mockResolvedValue(mockGitHubResponse),
             });
 
@@ -149,6 +151,88 @@ describe('GitHubDeliveryFetcherService', () => {
             expect(result.success).toBe(true);
             expect(result.deliveries).toHaveLength(1);
             expect(result.deliveries?.[0].guid).toBe('del-new');
+        });
+
+        it('fetches all deliveries across multiple pages (>100 deliveries)', async () => {
+            const service = new GitHubDeliveryFetcherService();
+            const mockRequestWithInstallationAuth = getMockRequestWithInstallationAuth();
+
+            // Page 1: 3 recent deliveries + Link: rel="next" header
+            const page1Items = [
+                { id: 3, guid: 'del-p1-c', delivered_at: '2024-01-03T00:00:00Z', event: 'push' },
+                { id: 2, guid: 'del-p1-b', delivered_at: '2024-01-02T00:00:00Z', event: 'push' },
+                { id: 1, guid: 'del-p1-a', delivered_at: '2024-01-01T12:00:00Z', event: 'push' },
+            ];
+            // Page 2: 2 older deliveries — no next link
+            const page2Items = [
+                { id: -1, guid: 'del-p2-b', delivered_at: '2024-01-01T06:00:00Z', event: 'push' },
+                { id: -2, guid: 'del-p2-a', delivered_at: '2024-01-01T03:00:00Z', event: 'push' },
+            ];
+
+            const page2Url = 'https://api.github.com/app/hooks/1234/deliveries?per_page=100&cursor=abc';
+
+            mockRequestWithInstallationAuth
+                .mockResolvedValueOnce({
+                    ok: true,
+                    headers: {
+                        get: vi.fn().mockReturnValue(
+                            `<${page2Url}>; rel="next", <https://api.github.com/...>; rel="last"`
+                        ),
+                    },
+                    json: vi.fn().mockResolvedValue(page1Items),
+                })
+                .mockResolvedValueOnce({
+                    ok: true,
+                    headers: { get: vi.fn().mockReturnValue(null) },
+                    json: vi.fn().mockResolvedValue(page2Items),
+                });
+
+            const result = await service.fetchDeliveryLog(1234);
+
+            expect(result.success).toBe(true);
+            // All 5 deliveries from both pages should be accumulated
+            expect(result.deliveries).toHaveLength(5);
+            expect(result.deliveries?.map((d) => d.guid)).toEqual([
+                'del-p1-c', 'del-p1-b', 'del-p1-a', 'del-p2-b', 'del-p2-a',
+            ]);
+            // requestWithInstallationAuth must have been called exactly twice (once per page)
+            expect(mockRequestWithInstallationAuth).toHaveBeenCalledTimes(2);
+            expect(mockRequestWithInstallationAuth).toHaveBeenNthCalledWith(
+                2,
+                page2Url,
+                { method: 'GET' },
+            );
+        });
+
+        it('stops pagination at the since boundary without fetching unnecessary pages', async () => {
+            const service = new GitHubDeliveryFetcherService();
+            const mockRequestWithInstallationAuth = getMockRequestWithInstallationAuth();
+
+            const sinceTs = '2024-01-02T00:00:00Z';
+            const page2Url = 'https://api.github.com/app/hooks/1234/deliveries?per_page=100&cursor=xyz';
+
+            // Page 1: first item is within window, second is at/before the since boundary
+            const page1Items = [
+                { id: 2, guid: 'del-within', delivered_at: '2024-01-03T00:00:00Z', event: 'push' },
+                { id: 1, guid: 'del-boundary', delivered_at: '2024-01-01T00:00:00Z', event: 'push' },
+            ];
+
+            mockRequestWithInstallationAuth.mockResolvedValueOnce({
+                ok: true,
+                headers: {
+                    get: vi.fn().mockReturnValue(`<${page2Url}>; rel="next"`),
+                },
+                json: vi.fn().mockResolvedValue(page1Items),
+            });
+
+            const result = await service.fetchDeliveryLog(1234, sinceTs);
+
+            expect(result.success).toBe(true);
+            // Only the delivery within the window should be included
+            expect(result.deliveries).toHaveLength(1);
+            expect(result.deliveries?.[0].guid).toBe('del-within');
+            // Page 2 should NOT have been fetched — the since boundary was crossed on page 1
+            expect(mockRequestWithInstallationAuth).toHaveBeenCalledTimes(1);
         });
 
         it('handles GitHub API error', async () => {
@@ -179,6 +263,7 @@ describe('GitHubDeliveryFetcherService', () => {
             expect(result.error).toBe('Network error');
         });
     });
+
 
     describe('getDeliveryDetail', () => {
         it('fetches detailed delivery information', async () => {
@@ -261,6 +346,7 @@ describe('GitHubDeliveryFetcherService', () => {
 
             mockRequestWithInstallationAuth.mockResolvedValue({
                 ok: true,
+                headers: { get: vi.fn().mockReturnValue(null) },
                 json: vi.fn().mockResolvedValue(mockGitHubResponse),
             });
 
@@ -291,6 +377,7 @@ describe('GitHubDeliveryFetcherService', () => {
 
             mockRequestWithInstallationAuth.mockResolvedValue({
                 ok: true,
+                headers: { get: vi.fn().mockReturnValue(null) },
                 json: vi.fn().mockResolvedValue(mockGitHubResponse),
             });
 
@@ -328,6 +415,7 @@ describe('GitHubDeliveryFetcherService', () => {
 
             mockRequestWithInstallationAuth.mockResolvedValue({
                 ok: true,
+                headers: { get: vi.fn().mockReturnValue(null) },
                 json: vi.fn().mockResolvedValue([]),
             });
 

--- a/apps/backend/src/services/github-delivery-fetcher.service.ts
+++ b/apps/backend/src/services/github-delivery-fetcher.service.ts
@@ -104,73 +104,113 @@ export class GitHubDeliveryFetcherService {
         hookId: number,
         since?: string
     ): Promise<FetchDeliveryLogResult> {
+        /**
+         * GitHub's deliveries endpoint is cursor-paginated (newest-first).
+         * We follow the Link: rel="next" header across pages until:
+         *   a) a delivery older than `since` is encountered, or
+         *   b) MAX_PAGES pages have been fetched (safety cap).
+         */
+        const MAX_PAGES = 10;
+
         try {
-            // Build URL with optional cursor parameter
-            let url = `/app/hooks/${hookId}/deliveries`;
-            const params = new URLSearchParams();
+            const sinceDate = since ? new Date(since) : null;
+            const accumulated: GitHubDelivery[] = [];
+            let reachedSinceBoundary = false;
 
-            if (since) {
-                // GitHub API doesn't support 'since' directly, so we'll fetch all and filter
-                // In production, you might want to implement pagination
-                params.append('per_page', '100');
-            } else {
-                params.append('per_page', '100');
-            }
-
-            if (params.toString()) {
-                url += `?${params.toString()}`;
-            }
+            // Initial URL — per_page=100 is the maximum GitHub allows per request.
+            let nextUrl: string | null =
+                `/app/hooks/${hookId}/deliveries?per_page=100`;
 
             this.log.info('Fetching delivery log from GitHub', { hookId, since });
 
-            const response = await this.authClient.requestWithInstallationAuth(url, {
-                method: 'GET',
-            });
+            for (let page = 0; page < MAX_PAGES && nextUrl !== null; page++) {
+                const response = await this.authClient.requestWithInstallationAuth(
+                    nextUrl,
+                    { method: 'GET' },
+                );
 
-            if (!response.ok) {
-                const errorText = await response.text();
-                this.log.error('Failed to fetch delivery log from GitHub', undefined, {
-                    status: response.status,
-                    error: errorText,
-                });
-                return {
-                    success: false,
-                    error: `GitHub API error: ${response.status} ${errorText}`,
-                };
+                if (!response.ok) {
+                    const errorText = await response.text();
+                    this.log.error('Failed to fetch delivery log from GitHub', undefined, {
+                        status: response.status,
+                        error: errorText,
+                        page,
+                    });
+                    return {
+                        success: false,
+                        error: `GitHub API error: ${response.status} ${errorText}`,
+                    };
+                }
+
+                const data = await response.json();
+                const pageItems: GitHubDelivery[] = (data || []).map((d: any) => ({
+                    id: d.id,
+                    guid: d.guid,
+                    deliveredAt: d.delivered_at,
+                    redelivery: d.redelivery || false,
+                    duration: d.duration || 0,
+                    status: d.status || 'unknown',
+                    statusCode: d.status_code || 0,
+                    event: d.event || 'unknown',
+                    action: d.action || null,
+                    installationId: d.installation_id || null,
+                    repositoryId: d.repository_id || null,
+                }));
+
+                // Deliveries arrive newest-first. Stop as soon as we cross the
+                // since boundary — everything after this will be even older.
+                if (sinceDate) {
+                    for (const delivery of pageItems) {
+                        if (new Date(delivery.deliveredAt) <= sinceDate) {
+                            reachedSinceBoundary = true;
+                            break;
+                        }
+                        accumulated.push(delivery);
+                    }
+                } else {
+                    accumulated.push(...pageItems);
+                }
+
+                if (reachedSinceBoundary) {
+                    break;
+                }
+
+                // Follow the cursor from the Link: <url>; rel="next" header.
+                nextUrl = this.parseLinkNext(response.headers.get('link'));
             }
-
-            const data = await response.json();
-
-            // Map GitHub API response to our format
-            const deliveries: GitHubDelivery[] = (data || []).map((d: any) => ({
-                id: d.id,
-                guid: d.guid,
-                deliveredAt: d.delivered_at,
-                redelivery: d.redelivery || false,
-                duration: d.duration || 0,
-                status: d.status || 'unknown',
-                statusCode: d.status_code || 0,
-                event: d.event || 'unknown',
-                action: d.action || null,
-                installationId: d.installation_id || null,
-                repositoryId: d.repository_id || null,
-            }));
-
-            // Filter by 'since' if provided
-            const filteredDeliveries = since
-                ? deliveries.filter((d) => new Date(d.deliveredAt) > new Date(since))
-                : deliveries;
 
             this.log.info('Fetched delivery log from GitHub', {
                 hookId,
-                count: filteredDeliveries.length,
+                count: accumulated.length,
+                pages: Math.min(MAX_PAGES, accumulated.length > 0 ? MAX_PAGES : 1),
             });
 
-            return { success: true, deliveries: filteredDeliveries };
+            return { success: true, deliveries: accumulated };
         } catch (error: any) {
             this.log.error('Unexpected error fetching delivery log', error);
             return { success: false, error: error.message || 'Unknown error' };
         }
+    }
+
+    /**
+     * Parses the `Link` response header and returns the URL for rel="next",
+     * or null if there is no next page.
+     *
+     * GitHub format: `<https://api.github.com/...?cursor=xxx>; rel="next", <...>; rel="last"`
+     */
+    private parseLinkNext(linkHeader: string | null): string | null {
+        if (!linkHeader) return null;
+
+        for (const part of linkHeader.split(',')) {
+            const [urlPart, relPart] = part.split(';').map((s) => s.trim());
+            if (relPart === 'rel="next"') {
+                // Strip surrounding angle brackets: <url> → url
+                const match = urlPart.match(/^<(.+)>$/);
+                if (match) return match[1];
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/apps/backend/src/services/github-to-vercel-deployment.service.test.ts
+++ b/apps/backend/src/services/github-to-vercel-deployment.service.test.ts
@@ -36,12 +36,14 @@ vi.mock('@/lib/supabase/server', () => ({
     createClient: () => mockSupabase,
 }));
 
+const mockLoggerInstance = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+};
+
 vi.mock('@/lib/api/logger', () => ({
-    createLogger: () => ({
-        info: vi.fn(),
-        warn: vi.fn(),
-        error: vi.fn(),
-    }),
+    createLogger: vi.fn(() => mockLoggerInstance),
 }));
 
 // ── Test setup ─────────────────────────────────────────────────────────────────
@@ -49,6 +51,12 @@ vi.mock('@/lib/api/logger', () => ({
 beforeEach(() => {
     vi.clearAllMocks();
     process.env.VERCEL_PROJECT_ID = 'test-project-id';
+    // Re-configure each fresh logger instance returned by createLogger
+    Object.assign(mockLoggerInstance, {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+    });
 });
 
 describe('GitHubToVercelDeploymentService', () => {
@@ -142,7 +150,7 @@ describe('GitHubToVercelDeploymentService', () => {
             );
         });
 
-        it('handles database insert failure gracefully', async () => {
+        it('returns failure when database insert fails (deployment triggered but metadata lost)', async () => {
             mockVercelService.triggerDeployment.mockResolvedValue({
                 deploymentId: 'dpl_abc123',
                 deploymentUrl: 'https://test.vercel.app',
@@ -151,14 +159,18 @@ describe('GitHubToVercelDeploymentService', () => {
 
             mockSupabase.from.mockReturnValue({
                 insert: vi.fn().mockReturnValue({
-                    error: new Error('Database error'),
+                    error: { message: 'Database error' },
                 }),
             });
 
             const result = await service.triggerDeployment(request);
 
-            // Should still succeed even if database insert fails
-            expect(result.success).toBe(true);
+            // Must NOT report success when metadata could not be persisted
+            expect(result.success).toBe(false);
+            expect(result.metadataPersisted).toBe(false);
+            expect(result.errorMessage).toContain('metadata could not be persisted');
+            expect(result.errorMessage).toContain('Database error');
+            // The Vercel deployment URL is still surfaced so callers can link to it
             expect(result.deploymentUrl).toBe('https://test.vercel.app');
         });
 
@@ -311,6 +323,47 @@ describe('GitHubToVercelDeploymentService', () => {
 
             expect(result).toBeNull();
         });
+
+        it('logs a distinct error when the deployment row is missing (metadata was never persisted)', async () => {
+            // Reset the spy logger for this test
+            mockLoggerInstance.error = vi.fn();
+
+            const freshService = new GitHubToVercelDeploymentService(mockVercelService as any);
+
+            // Vercel API succeeds
+            mockVercelService.getDeploymentStatus.mockResolvedValue({
+                status: 'ready',
+                url: 'https://test.vercel.app',
+                deploymentId: 'dpl_orphaned',
+                createdAt: new Date(),
+            });
+
+            // Supabase returns no data AND no error — row simply doesn't exist
+            mockSupabase.from.mockReturnValue({
+                update: vi.fn().mockReturnValue({
+                    eq: vi.fn().mockReturnValue({
+                        select: vi.fn().mockReturnValue({
+                            single: vi.fn().mockResolvedValue({
+                                data: null,
+                                error: null,
+                            }),
+                        }),
+                    }),
+                }),
+            });
+
+            const result = await freshService.syncDeploymentStatus('dpl_orphaned');
+
+            // Still returns null (sync fails gracefully)
+            expect(result).toBeNull();
+            // The distinct orphaned-row message must have been logged at error level
+            expect(mockLoggerInstance.error).toHaveBeenCalledWith(
+                expect.stringContaining('metadata was never persisted'),
+                undefined,
+                expect.objectContaining({ vercelDeploymentId: 'dpl_orphaned' }),
+            );
+        });
+
     });
 
     describe('getDeploymentByVercelId', () => {

--- a/apps/backend/src/services/github-to-vercel-deployment.service.ts
+++ b/apps/backend/src/services/github-to-vercel-deployment.service.ts
@@ -52,6 +52,12 @@ export interface TriggerDeploymentResult {
     errorMessage?: string;
     /** W3C traceparent identifying this deployment across all pipeline stages. */
     traceId?: string;
+    /**
+     * False when the Vercel deployment was triggered successfully but the
+     * Supabase metadata row could not be persisted. Status sync will not
+     * work for this deployment until the row is recovered.
+     */
+    metadataPersisted?: boolean;
 }
 
 export interface DeploymentMetadata {
@@ -140,6 +146,8 @@ export class GitHubToVercelDeploymentService {
 
             // Stage 3: Persist metadata
             const deploymentId = crypto.randomUUID();
+            let metadataInsertError: { message: string } | null = null;
+
             const { durationMs: storeMs, spanId: storeSpanId } = await withSpan(
                 'store-metadata',
                 trace.traceId,
@@ -162,11 +170,31 @@ export class GitHubToVercelDeploymentService {
                         updated_at: new Date().toISOString(),
                     });
                     if (insertError) {
-                        log.error('Failed to store deployment metadata', insertError, { traceId: trace.traceId });
+                        log.error(
+                            'Failed to persist deployment metadata — status sync will be orphaned',
+                            insertError,
+                            { traceId: trace.traceId, vercelDeploymentId: deployment.deploymentId },
+                        );
+                        metadataInsertError = insertError;
                     }
                     return null;
                 },
             );
+
+            // The Vercel deployment already exists; do not roll it back.
+            // Surface the metadata failure so callers know status sync is broken.
+            if (metadataInsertError) {
+                return {
+                    success: false,
+                    deploymentId: '',
+                    deploymentUrl: deployment.deploymentUrl,
+                    errorMessage: `Deployment triggered on Vercel but metadata could not be persisted: ${
+                        (metadataInsertError as { message: string }).message
+                    }`,
+                    metadataPersisted: false,
+                    traceId: trace.traceId,
+                };
+            }
 
             log.info('Deployment pipeline complete', {
                 traceId: trace.traceId,
@@ -180,6 +208,7 @@ export class GitHubToVercelDeploymentService {
                 deploymentId,
                 deploymentUrl: deployment.deploymentUrl,
                 status: deployment.status,
+                metadataPersisted: true,
                 traceId: trace.traceId,
             };
         } catch (error: any) {
@@ -233,7 +262,17 @@ export class GitHubToVercelDeploymentService {
                 .single();
 
             if (error || !data) {
-                log.error('Failed to update deployment status', error);
+                if (!data && !error) {
+                    // The row was never inserted (metadata persist failed at trigger time).
+                    // This is a distinct error from a transient DB failure.
+                    log.error(
+                        'Deployment row missing from database — metadata was never persisted; status sync is permanently orphaned',
+                        undefined,
+                        { vercelDeploymentId },
+                    );
+                } else {
+                    log.error('Failed to update deployment status', error);
+                }
                 return null;
             }
 

--- a/apps/backend/src/services/payment-idempotency.concurrent-checkout.integration.test.ts
+++ b/apps/backend/src/services/payment-idempotency.concurrent-checkout.integration.test.ts
@@ -99,10 +99,12 @@ describe('PaymentIdempotencyService — concurrent checkout integration (#744)',
             eq: vi.fn().mockResolvedValue({ error: null }),
         });
 
-        // Default chain: select().eq().eq().gt().single() → not found
+        // Default chain: select().eq().eq().gt().order().limit().single() → not found
         mockSelect.mockReturnValue({
             eq: vi.fn().mockReturnThis(),
             gt: vi.fn().mockReturnThis(),
+            order: vi.fn().mockReturnThis(),
+            limit: vi.fn().mockReturnThis(),
             single: vi.fn().mockResolvedValue({ data: null, error: { code: 'PGRST116' } }),
         });
 
@@ -319,6 +321,70 @@ describe('PaymentIdempotencyService — concurrent checkout integration (#744)',
             await expect(
                 service.generateKey(USER_A, 'checkout_session'),
             ).rejects.toThrow('Failed to generate idempotency key');
+        });
+
+        it('returns existing unexpired key for same user/operation without fingerprint', async () => {
+            const existingKey = 'idempotency_existing_abc123_1700000000000';
+
+            // Mock the lookup to return an existing unexpired row
+            mockSelect.mockReturnValue({
+                eq: vi.fn().mockReturnThis(),
+                gt: vi.fn().mockReturnThis(),
+                order: vi.fn().mockReturnThis(),
+                limit: vi.fn().mockReturnThis(),
+                single: vi.fn().mockResolvedValue({
+                    data: { idempotency_key: existingKey },
+                    error: null,
+                }),
+            });
+
+            const key = await service.generateKey(USER_A, 'checkout_session');
+
+            // Must return the existing key — no new insert
+            expect(key).toBe(existingKey);
+            expect(mockInsert).not.toHaveBeenCalled();
+        });
+
+        it('returns existing unexpired key when request fingerprint matches', async () => {
+            const existingKey = 'idempotency_fingerprinted_abc_1700000000000';
+            const fingerprint = 'sha256:cart-abc-xyz';
+
+            mockSelect.mockReturnValue({
+                eq: vi.fn().mockReturnThis(),
+                gt: vi.fn().mockReturnThis(),
+                order: vi.fn().mockReturnThis(),
+                limit: vi.fn().mockReturnThis(),
+                single: vi.fn().mockResolvedValue({
+                    data: { idempotency_key: existingKey },
+                    error: null,
+                }),
+            });
+
+            const key = await service.generateKey(USER_A, 'checkout_session', fingerprint);
+
+            expect(key).toBe(existingKey);
+            expect(mockInsert).not.toHaveBeenCalled();
+        });
+
+        it('mints a new key when the existing row is expired (PGRST116 from lookup)', async () => {
+            // The lookup returns no rows (expired / not found) — insert path must fire
+            mockSelect.mockReturnValue({
+                eq: vi.fn().mockReturnThis(),
+                gt: vi.fn().mockReturnThis(),
+                order: vi.fn().mockReturnThis(),
+                limit: vi.fn().mockReturnThis(),
+                single: vi.fn().mockResolvedValue({
+                    data: null,
+                    error: { code: 'PGRST116', message: 'no rows' },
+                }),
+            });
+
+            const key = await service.generateKey(USER_A, 'checkout_session');
+
+            expect(typeof key).toBe('string');
+            expect(key).toMatch(/^idempotency_[a-f0-9]{32}_\d+$/);
+            // A new row must have been inserted
+            expect(mockInsert).toHaveBeenCalledOnce();
         });
     });
 

--- a/apps/backend/src/services/payment-idempotency.service.ts
+++ b/apps/backend/src/services/payment-idempotency.service.ts
@@ -20,28 +20,76 @@ import { randomBytes } from 'crypto';
 
 export class PaymentIdempotencyService {
   /**
-   * Generate a new idempotency key and store it in the database.
-   * Returns the key to be used with Stripe API.
+   * Return an existing unexpired idempotency key for this logical operation,
+   * or mint and persist a new one if none exists.
+   *
+   * Retried calls for the same (userId, operationType[, requestFingerprint])
+   * within the 24-hour expiry window will receive the same key, allowing
+   * Stripe to short-circuit to its cached response rather than processing a
+   * duplicate charge.
+   *
+   * @param userId           - The user initiating the payment operation.
+   * @param operationType    - The type of payment operation.
+   * @param requestFingerprint - Optional caller-supplied fingerprint that
+   *   further distinguishes otherwise identical operations (e.g. a hash of
+   *   cart contents). When provided, two calls with different fingerprints
+   *   for the same user/operation will each get their own key.
    */
   async generateKey(
     userId: string,
-    operationType: 'checkout_session' | 'subscription' | 'cancel' | 'update'
+    operationType: 'checkout_session' | 'subscription' | 'cancel' | 'update',
+    requestFingerprint?: string,
   ): Promise<string> {
     const supabase = createClient();
+    const now = new Date().toISOString();
+
+    // ── 1. Look up an existing, unexpired key for this logical operation ──────
+    let lookupQuery = supabase
+      .from('payment_idempotency_keys')
+      .select('idempotency_key')
+      .eq('user_id', userId)
+      .eq('operation_type', operationType)
+      .gt('expires_at', now);
+
+    if (requestFingerprint) {
+      lookupQuery = lookupQuery.eq('request_fingerprint', requestFingerprint);
+    }
+
+    const { data: existing, error: lookupError } = await lookupQuery
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .single();
+
+    // PGRST116 = "no rows returned" — that is the expected cache-miss path.
+    if (lookupError && lookupError.code !== 'PGRST116') {
+      throw new Error(`Failed to look up idempotency key: ${lookupError.message}`);
+    }
+
+    if (existing?.idempotency_key) {
+      return existing.idempotency_key;
+    }
+
+    // ── 2. No unexpired key found — mint and persist a new one ────────────────
     const key = this.generateRandomKey();
     const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000); // 24 hours
 
-    const { error } = await supabase
-      .from('payment_idempotency_keys')
-      .insert({
-        user_id: userId,
-        idempotency_key: key,
-        operation_type: operationType,
-        expires_at: expiresAt.toISOString(),
-      });
+    const insertPayload: Record<string, unknown> = {
+      user_id: userId,
+      idempotency_key: key,
+      operation_type: operationType,
+      expires_at: expiresAt.toISOString(),
+    };
 
-    if (error) {
-      throw new Error(`Failed to generate idempotency key: ${error.message}`);
+    if (requestFingerprint) {
+      insertPayload.request_fingerprint = requestFingerprint;
+    }
+
+    const { error: insertError } = await supabase
+      .from('payment_idempotency_keys')
+      .insert(insertPayload);
+
+    if (insertError) {
+      throw new Error(`Failed to generate idempotency key: ${insertError.message}`);
     }
 
     return key;


### PR DESCRIPTION
…dup, and insert error (#980 #981 #982 #983)

#982: fetchDeliveryLog() now follows GitHub Link: rel=next headers across up to 10 pages (1 000 deliveries), stopping early once a delivery older than the since boundary is encountered. Eliminates the silent miss of any deliveries beyond the first 100 that detectMissedDeliveries() relied on.

#983: generateKey() now SELECT-before-INSERT: looks up an existing unexpired row matching (user_id, operation_type[, request_fingerprint]) and returns the existing key on a hit, so Stripe deduplicates retried charges. A new optional requestFingerprint parameter supports finer-grained operation identity.

#980: GitHubAppAuthClient.getInstallationAuthContext() now tracks an in-flight pendingFetch promise so concurrent cold-cache callers share one POST /access_tokens request instead of each issuing their own. forceRefresh: true replaces the in-flight promise so 401-retry paths always get a fresh token.

#981: triggerDeployment() no longer returns { success: true } when the Stage 3 Supabase metadata insert fails. It now returns { success: false, metadataPersisted: false, errorMessage: ... } so callers can distinguish a phantom-success from a real one. syncDeploymentStatus() logs a distinct error when the deployment row is missing, making the orphaned-sync case observable.

Tests: all four suites pass (44 + 16 + delivery fetcher + idempotency tests).


Closes #980 
Closes #981 
Closes #982 
Closes #983 