### PR TITLE
Fix job queue DLQ reprocessing, stalled-job fencing, cron failure cou…

### DIFF
--- a/apps/backend/src/services/cron-failure-tracker.service.ts
+++ b/apps/backend/src/services/cron-failure-tracker.service.ts
@@ -43,26 +43,39 @@ export class CronFailureTrackerService {
     async recordFailure(jobName: string, error: string): Promise<void> {
         const supabase = createClient();
 
-        // Fetch current count
-        const { data: existing } = await supabase
-            .from('cron_job_failures')
-            .select('consecutive_failures')
-            .eq('job_name', jobName)
-            .single();
-
-        const newCount = (existing?.consecutive_failures ?? 0) + 1;
-
-        await supabase.from('cron_job_failures').upsert(
-            {
-                job_name: jobName,
-                consecutive_failures: newCount,
-                last_failure_at: new Date().toISOString(),
-                last_error: error,
-                updated_at: new Date().toISOString(),
-            },
-            { onConflict: 'job_name' }
+        // Atomically increment the consecutive failure count via RPC
+        const { data: count, error: rpcError } = await supabase.rpc(
+            'increment_cron_failure',
+            { p_job_name: jobName, p_error: error },
         );
 
+        if (rpcError) {
+            console.error('[cron-failure-tracker] RPC call failed, falling back to upsert', rpcError);
+            // Fallback: read-then-upsert (not atomic, but better than failing)
+            const { data: existing } = await supabase
+                .from('cron_job_failures')
+                .select('consecutive_failures')
+                .eq('job_name', jobName)
+                .single();
+
+            const newCount = (existing?.consecutive_failures ?? 0) + 1;
+
+            await supabase.from('cron_job_failures').upsert(
+                {
+                    job_name: jobName,
+                    consecutive_failures: newCount,
+                    last_failure_at: new Date().toISOString(),
+                    last_error: error,
+                    updated_at: new Date().toISOString(),
+                },
+                { onConflict: 'job_name' }
+            );
+
+            await this._escalate(jobName, newCount, error);
+            return;
+        }
+
+        const newCount = count as number;
         await this._escalate(jobName, newCount, error);
     }
 

--- a/apps/backend/src/services/job-queue.service.test.ts
+++ b/apps/backend/src/services/job-queue.service.test.ts
@@ -88,25 +88,39 @@ function makeSupabaseMock(
         }),
         select: vi.fn().mockReturnThis(),
         update: vi.fn((patch: Partial<JobRecord>) => {
-            const eqChain = (col: string, val: unknown) => {
-                const matchingJobs = jobs.filter((j) => (j as any)[col] === val);
-                matchingJobs.forEach((j) => Object.assign(j, patch));
-                return {
-                    select: vi.fn().mockResolvedValue({ data: matchingJobs, error: null }),
+            // Build a query chain that defers patch application until terminal
+            // .select() so that multiple .eq() filters are ANDed correctly.
+            const makeChain = (sourceJobs: JobRecord[]) => {
+                const filters: Array<(j: JobRecord) => boolean> = [];
+                const apply = () => {
+                    const match = sourceJobs.filter((j) => filters.every((f) => f(j)));
+                    match.forEach((j) => Object.assign(j, patch));
+                    return match;
+                };
+                const chain = {
+                    eq: vi.fn((col: string, val: unknown) => {
+                        filters.push((j: JobRecord) => (j as any)[col] === val);
+                        return chain;
+                    }),
                     lt: vi.fn((col2: string, val2: unknown) => {
-                        const stalledJobs = jobs.filter((j) => {
+                        filters.push((j: JobRecord) => {
                             if (j.status !== 'running') return false;
                             if (!j.started_at) return false;
                             return new Date(j.started_at).getTime() < new Date(val2 as string).getTime();
                         });
-                        stalledJobs.forEach((j) => Object.assign(j, patch));
                         return {
-                            select: vi.fn().mockResolvedValue({ data: stalledJobs, error: null }),
+                            select: vi.fn().mockImplementation(() =>
+                                Promise.resolve({ data: apply(), error: null }),
+                            ),
                         };
                     }),
+                    select: vi.fn().mockImplementation(() =>
+                        Promise.resolve({ data: apply(), error: null }),
+                    ),
                 };
+                return chain;
             };
-            return { eq: vi.fn(eqChain) };
+            return makeChain(jobs);
         }),
         eq: vi.fn().mockReturnThis(),
         order: vi.fn().mockReturnThis(),
@@ -441,6 +455,74 @@ describe('DLQ reprocessing', () => {
 
         await expect(service.reprocessDLQEntry('nonexistent')).rejects.toThrow('not found');
     });
+
+    it('does not mark as succeeded when enqueue fails', async () => {
+        const dlqEntry: DLQRecord = {
+            id: 'dlq-fail',
+            original_job_id: 'job-dead-3',
+            job_type: 'deployment',
+            priority: 'normal',
+            payload: { userId: 'u1' },
+            failure_reason: 'network error',
+            attempts: 3,
+            reprocess_status: 'pending',
+            reprocessed_at: null,
+            created_at: new Date().toISOString(),
+        };
+
+        const supabase = makeSupabaseMock([], [dlqEntry]);
+        // Make job_queue insert fail so enqueue throws
+        supabase.from('job_queue').insert = vi.fn().mockReturnValue({
+            select: vi.fn().mockReturnThis(),
+            single: vi.fn().mockResolvedValue({ data: null, error: { message: 'Supabase transient error' } }),
+        });
+        vi.mocked(createClient).mockReturnValue(supabase as any);
+        const service = new JobQueueService(1);
+
+        await expect(service.reprocessDLQEntry('dlq-fail')).rejects.toThrow('Supabase transient error');
+
+        // DLQ entry must NOT be marked succeeded
+        expect(supabase._dlq[0].reprocess_status).not.toBe('succeeded');
+        // DLQ entry should be pending so it can be retried
+        expect(supabase._dlq[0].reprocess_status).toBe('pending');
+    });
+
+    it('allows retry after a failed reprocess attempt', async () => {
+        const dlqEntry: DLQRecord = {
+            id: 'dlq-retry',
+            original_job_id: 'job-dead-4',
+            job_type: 'deployment',
+            priority: 'high',
+            payload: { userId: 'u2' },
+            failure_reason: 'timeout',
+            attempts: 3,
+            reprocess_status: 'pending',
+            reprocessed_at: null,
+            created_at: new Date().toISOString(),
+        };
+
+        const supabase = makeSupabaseMock([], [dlqEntry]);
+        // First call fails
+        supabase.from('job_queue').insert = vi.fn().mockReturnValue({
+            select: vi.fn().mockReturnThis(),
+            single: vi.fn().mockResolvedValue({ data: null, error: { message: 'DB down' } }),
+        });
+        vi.mocked(createClient).mockReturnValue(supabase as any);
+        const service = new JobQueueService(1);
+
+        await expect(service.reprocessDLQEntry('dlq-retry')).rejects.toThrow('DB down');
+
+        // Now fix the DB and try again
+        supabase.from('job_queue').insert = vi.fn().mockReturnValue({
+            select: vi.fn().mockReturnThis(),
+            single: vi.fn().mockResolvedValue({ data: { id: 'new-job-ok' }, error: null }),
+        });
+
+        const { jobId } = await service.reprocessDLQEntry('dlq-retry');
+        expect(jobId).toBe('new-job-ok');
+        // DLQ entry should now be succeeded
+        expect(supabase._dlq[0].reprocess_status).toBe('succeeded');
+    });
 });
 
 // ── Worker concurrency ────────────────────────────────────────────────────────
@@ -564,6 +646,61 @@ describe('recoverStalledJobs', () => {
 
         // The mock's lt() filter returns the stalled job
         expect(recovered).toBeGreaterThanOrEqual(0); // non-negative
+    });
+
+    it('fencing prevents stale worker completion after recovery and reclaim', async () => {
+        const stalledAt = new Date(Date.now() - STALLED_JOB_TIMEOUT_MS - 1000).toISOString();
+
+        const job: JobRecord = {
+            id: 'job-fencing',
+            job_type: 'test',
+            priority: 'normal',
+            status: 'running',
+            payload: {},
+            attempts: 1,
+            max_attempts: 3,
+            scheduled_at: stalledAt,
+            started_at: stalledAt,
+            worker_id: 'worker-a',
+            created_at: stalledAt,
+            updated_at: stalledAt,
+            result: null,
+            error_message: null,
+            completed_at: null,
+            dead_at: null,
+        };
+
+        const supabase = makeSupabaseMock([job]);
+        vi.mocked(createClient).mockReturnValue(supabase as any);
+        const service = new JobQueueService(1);
+
+        // Step 1: recover the stalled job (sets status back to pending, worker_id to null)
+        await service.recoverStalledJobs();
+        const recoveredJob = supabase._jobs.find((j: JobRecord) => j.id === 'job-fencing');
+        expect(recoveredJob?.status).toBe('pending');
+        expect(recoveredJob?.worker_id).toBeNull();
+
+        // Step 2: worker B claims the recovered job (bumps attempts)
+        // Simulate claim_next_job which increments attempts
+        const { data: claimedData } = await supabase.rpc('claim_next_job', { p_worker_id: 'worker-b' });
+        expect(claimedData).toBeTruthy();
+        const attemptsAfterClaim = claimedData?.[0]?.attempts;
+        // The original worker had attempts=1; claim bumps to 2
+        expect(attemptsAfterClaim).toBe(2);
+
+        // Step 3: worker A (original) tries to complete with its stale attempts value
+        // _executeJob's completion UPDATE now includes .eq('attempts', job.attempts)
+        // where job.attempts is still 1 (the stale value from when worker A claimed it)
+        // The DB row now has attempts=2, so the UPDATE should affect 0 rows
+        // We call _executeJob directly with the original job object (still has attempts=1)
+        await (service as any)._executeJob(job);
+
+        // Verify: the job should still be running (claimed by worker B), not completed
+        const finalJob = supabase._jobs.find((j: JobRecord) => j.id === 'job-fencing');
+        // Worker B claimed it, so it should be running (not completed by stale worker A)
+        expect(finalJob?.status).toBe('running');
+        expect(finalJob?.worker_id).toBe('worker-b');
+        expect(finalJob?.attempts).toBe(2);
     });
 });
 

--- a/apps/backend/src/services/job-queue.service.ts
+++ b/apps/backend/src/services/job-queue.service.ts
@@ -109,6 +109,9 @@ export class JobQueueService {
     /** Active worker loop abort signals. */
     private readonly _workerControllers: AbortController[] = [];
 
+    /** In-memory guard set for DLQ entries currently being reprocessed. */
+    private readonly _reprocessingDlqIds = new Set<string>();
+
     /** Unique prefix for worker IDs created by this instance. */
     private readonly _instanceId: string;
 
@@ -236,10 +239,15 @@ export class JobQueueService {
 
     /**
      * Reprocess a dead-letter entry by re-enqueuing the original payload.
-     * Guards against double-reprocessing.
+     * Guards against double-reprocessing with an in-memory set.
+     * Only marks the entry as succeeded after enqueue actually resolves.
      */
     async reprocessDLQEntry(dlqId: string): Promise<EnqueueResult> {
         const supabase = createClient();
+
+        if (this._reprocessingDlqIds.has(dlqId)) {
+            throw new Error(`DLQ entry ${dlqId} is already being reprocessed`);
+        }
 
         // Load the DLQ entry
         const { data: entry, error: fetchError } = await supabase
@@ -256,20 +264,37 @@ export class JobQueueService {
             throw new Error(`DLQ entry ${dlqId} has already been reprocessed (status: ${entry.reprocess_status})`);
         }
 
-        // Mark as in-flight immediately to prevent duplicate reprocessing
-        await supabase
-            .from('job_dlq')
-            .update({ reprocess_status: 'succeeded', reprocessed_at: new Date().toISOString() })
-            .eq('id', dlqId);
+        this._reprocessingDlqIds.add(dlqId);
 
-        // Re-enqueue with higher max_attempts so the job gets fresh retries
-        const result = await this.enqueue(
-            entry.job_type,
-            entry.payload,
-            { priority: entry.priority, maxAttempts: DEFAULT_MAX_ATTEMPTS },
-        );
+        try {
+            // Re-enqueue with higher max_attempts so the job gets fresh retries
+            const result = await this.enqueue(
+                entry.job_type,
+                entry.payload,
+                { priority: entry.priority, maxAttempts: DEFAULT_MAX_ATTEMPTS },
+            );
 
-        return result;
+            // Only mark succeeded after the enqueue actually succeeds
+            await supabase
+                .from('job_dlq')
+                .update({ reprocess_status: 'succeeded', reprocessed_at: new Date().toISOString() })
+                .eq('id', dlqId);
+
+            return result;
+        } catch (err) {
+            // Revert the entry so it can be retried
+            const message = err instanceof Error ? err.message : String(err);
+            await supabase
+                .from('job_dlq')
+                .update({
+                    reprocess_status: 'pending',
+                    failure_reason: message,
+                })
+                .eq('id', dlqId);
+            throw err;
+        } finally {
+            this._reprocessingDlqIds.delete(dlqId);
+        }
     }
 
     // ── Internal helpers ───────────────────────────────────────────────────────
@@ -341,7 +366,7 @@ export class JobQueueService {
         try {
             const result = await handler(job);
 
-            await supabase
+            const { data: updated } = await supabase
                 .from('job_queue')
                 .update({
                     status: 'completed',
@@ -349,7 +374,16 @@ export class JobQueueService {
                     completed_at: new Date().toISOString(),
                     updated_at: new Date().toISOString(),
                 })
-                .eq('id', job.id);
+                .eq('id', job.id)
+                .eq('attempts', job.attempts)
+                .select('id');
+
+            // If no rows matched, the job was reclaimed by another worker (fencing)
+            if (!updated || updated.length === 0) {
+                console.warn(
+                    `[JobQueueService] Fencing prevented stale completion for job ${job.id} (attempts: ${job.attempts})`,
+                );
+            }
         } catch (err: unknown) {
             const message = err instanceof Error ? err.message : String(err);
             await this._failJob(job, message);
@@ -385,7 +419,8 @@ export class JobQueueService {
                     dead_at: new Date().toISOString(),
                     updated_at: new Date().toISOString(),
                 })
-                .eq('id', job.id);
+                .eq('id', job.id)
+                .eq('attempts', job.attempts);
         } else {
             await supabase
                 .from('job_queue')
@@ -396,7 +431,8 @@ export class JobQueueService {
                     worker_id: null,
                     updated_at: new Date().toISOString(),
                 })
-                .eq('id', job.id);
+                .eq('id', job.id)
+                .eq('attempts', job.attempts);
         }
     }
 

--- a/apps/backend/src/services/stripe-subscription-reconciler.service.test.ts
+++ b/apps/backend/src/services/stripe-subscription-reconciler.service.test.ts
@@ -103,6 +103,49 @@ describe('StripeSubscriptionReconciler — replayed webhook idempotency', () => 
 
         expect(mockGetSubscription).not.toHaveBeenCalled();
     });
+
+    it('dedup by event id: same id replayed is a fast no-op', async () => {
+        // First application
+        const initial = makeState({ event_timestamp: 1_699_000_000 });
+        const event = makeEvent({ id: 'evt_dedup', created: 1_700_000, status: 'active' });
+
+        const first = await reconciler.applyWebhookEvent(initial, event);
+        expect(first.updated).toBe(true);
+        expect(first.state.lastEventId).toBe('evt_dedup');
+
+        // Redelivery of the exact same event id
+        const second = await reconciler.applyWebhookEvent(first.state, event);
+
+        expect(second.updated).toBe(false);
+        expect(second.state).toStrictEqual(first.state);
+        // Stripe API should not be called for the redelivery
+        expect(mockGetSubscription).not.toHaveBeenCalled();
+    });
+
+    it('still reconciles on same-timestamp conflict from a different event id', async () => {
+        const current = makeState({
+            status: 'active',
+            event_timestamp: 1_700_000_000,
+            lastEventId: 'evt_previous',
+        });
+        const conflictEvent = makeEvent({
+            id: 'evt_conflict',
+            created: 1_700_000,
+            status: 'past_due',
+        });
+
+        mockGetSubscription.mockResolvedValueOnce({
+            status: 'past_due',
+            updated: 1_700_000,
+        });
+
+        const { updated, state } = await reconciler.applyWebhookEvent(current, conflictEvent);
+
+        // Different event id → goes through reconciliation
+        expect(mockGetSubscription).toHaveBeenCalledWith('sub_test123');
+        expect(updated).toBe(true);
+        expect(state.lastEventId).toBe('evt_conflict');
+    });
 });
 
 describe('StripeSubscriptionReconciler — out-of-sequence events', () => {

--- a/apps/backend/src/services/stripe-subscription-reconciler.service.ts
+++ b/apps/backend/src/services/stripe-subscription-reconciler.service.ts
@@ -16,6 +16,7 @@ export interface SubscriptionStateRecord {
     subscriptionId: string;
     status: 'active' | 'past_due' | 'canceled' | 'trialing';
     event_timestamp: number; // Unix ms when this state was last updated
+    lastEventId?: string;    // Stripe event id that was last applied
 }
 
 export interface StripeWebhookEvent {
@@ -45,6 +46,11 @@ export class StripeSubscriptionReconciler {
         current: SubscriptionStateRecord,
         event: StripeWebhookEvent,
     ): Promise<{ updated: boolean; state: SubscriptionStateRecord }> {
+        // Dedup by event id: same id already applied → fast no-op
+        if (event.id === current.lastEventId) {
+            return { updated: false, state: current };
+        }
+
         // Convert Stripe timestamp (seconds) to milliseconds
         const eventTimestampMs = event.created * 1000;
 
@@ -63,7 +69,7 @@ export class StripeSubscriptionReconciler {
 
         // If timestamp is equal but status differs, it's a conflict — fetch from Stripe
         if (eventTimestampMs === current.event_timestamp && newStatus !== current.status) {
-            return this.reconcileFromStripe(event.data.object.id, current);
+            return this.reconcileFromStripe(event.data.object.id, current, event.id);
         }
 
         // Normal case: newer timestamp, apply the event
@@ -71,6 +77,7 @@ export class StripeSubscriptionReconciler {
             subscriptionId: current.subscriptionId,
             status: newStatus,
             event_timestamp: eventTimestampMs,
+            lastEventId: event.id,
         };
 
         return { updated: true, state: updated };
@@ -83,6 +90,7 @@ export class StripeSubscriptionReconciler {
     private async reconcileFromStripe(
         subscriptionId: string,
         current: SubscriptionStateRecord,
+        eventId?: string,
     ): Promise<{ updated: boolean; state: SubscriptionStateRecord }> {
         try {
             const stripeData = await this.stripeApi.getSubscription(subscriptionId);
@@ -92,6 +100,7 @@ export class StripeSubscriptionReconciler {
                 subscriptionId,
                 status: stripeData.status as SubscriptionStateRecord['status'],
                 event_timestamp: stripeTimestampMs,
+                lastEventId: eventId,
             };
 
             return { updated: true, state: reconciled };

--- a/apps/backend/tests/monitoring/cron-failure-tracker.test.ts
+++ b/apps/backend/tests/monitoring/cron-failure-tracker.test.ts
@@ -30,6 +30,14 @@ function makeSupabaseMock() {
                 error: null,
             }),
         }),
+        rpc: vi.fn().mockImplementation((fn: string, params: any) => {
+            if (fn === 'increment_cron_failure') {
+                const newCount = mockConsecutiveFailures + 1;
+                mockConsecutiveFailures = newCount;
+                return Promise.resolve({ data: newCount, error: null });
+            }
+            return Promise.resolve({ data: null, error: { message: 'unknown rpc' } });
+        }),
     };
 }
 
@@ -75,7 +83,7 @@ describe('CronFailureTrackerService', () => {
         );
     });
 
-    it('recordFailure increments consecutive_failures', async () => {
+    it('recordFailure increments consecutive_failures via RPC', async () => {
         mockConsecutiveFailures = 2;
         const svc = await load();
         const mock = makeSupabaseMock();
@@ -83,10 +91,9 @@ describe('CronFailureTrackerService', () => {
 
         await svc.recordFailure('sync-status', 'timeout');
 
-        const upsertCall = mock.from().upsert as any;
-        expect(upsertCall).toHaveBeenCalledWith(
-            expect.objectContaining({ consecutive_failures: 3 }),
-            { onConflict: 'job_name' }
+        expect(mock.rpc).toHaveBeenCalledWith(
+            'increment_cron_failure',
+            { p_job_name: 'sync-status', p_error: 'timeout' },
         );
     });
 

--- a/supabase/migrations/017_cron_job_failure_increment_rpc.sql
+++ b/supabase/migrations/017_cron_job_failure_increment_rpc.sql
@@ -1,0 +1,32 @@
+-- Migration: 017_cron_job_failure_increment_rpc.sql
+-- Atomic increment function for cron_job_failures.consecutive_failures.
+-- Replaces the read-then-upsert pattern that could lose increments under
+-- concurrent calls (see issue #986).
+--
+-- Uses INSERT ... ON CONFLICT DO UPDATE so two concurrent calls for the
+-- same job_name both reliably increment the counter.
+
+CREATE OR REPLACE FUNCTION increment_cron_failure(p_job_name TEXT, p_error TEXT)
+RETURNS INTEGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+    v_count INTEGER;
+BEGIN
+    INSERT INTO cron_job_failures (job_name, consecutive_failures, last_failure_at, last_error, updated_at)
+    VALUES (p_job_name, 1, NOW(), p_error, NOW())
+    ON CONFLICT (job_name)
+    DO UPDATE SET
+        consecutive_failures = cron_job_failures.consecutive_failures + 1,
+        last_failure_at      = NOW(),
+        last_error           = p_error,
+        updated_at           = NOW()
+    RETURNING consecutive_failures INTO v_count;
+
+    RETURN v_count;
+END;
+$$;
+
+-- Grant execute to the service role only (matches 015_job_queue_claim_rpc.sql pattern)
+GRANT EXECUTE ON FUNCTION increment_cron_failure(TEXT, TEXT) TO service_role;


### PR DESCRIPTION
…nter race, and Stripe webhook dedup

#984: Fix Mark-Before-Act in DLQ reprocessing
- Replaced DB-level mark-before-enqueue with in-memory Set guard
- Only update reprocess_status to 'succeeded' after enqueue resolves
- On enqueue failure, keep reprocess_status as 'pending' for retry
- Added tests for enqueue-failure path and retry-after-failure scenario

#985: Add fencing token for stalled-job recovery
- Added .eq('attempts', job.attempts) to _executeJob completion UPDATE
- Added .eq('attempts', job.attempts) to _failJob UPDATEs (both DLQ and retry paths)
- Stale worker completion writes become no-ops when attempts have been bumped by reclaim
- Added test simulating claim -> stall -> recover -> reclaim -> stale completion

#986: Fix lost-update race in cron consecutive-failure counter
- Added new migration 017_cron_job_failure_increment_rpc.sql with atomic increment_cron_failure() SQL function using INSERT ... ON CONFLICT DO UPDATE
- Updated recordFailure to call the RPC instead of read-then-upsert pattern
- RPC returns the new count used for escalation decisions
- Updated tests to verify RPC invocation

#987: Add webhook-event replay dedup to Stripe subscription reconciler
- Added optional lastEventId field to SubscriptionStateRecord
- Event with matching id is a fast no-op at the top of applyWebhookEvent
- lastEventId is propagated on all returned state objects
- Added tests for idempotent redelivery and same-timestamp conflict handling

Closes #984
Closes #985
Closes #986
Closes #987