### PR TITLE
Fix Horizon URL validation bypass, tier price formatting, preview race condition, and drawer focus trap

### DIFF
--- a/apps/frontend/src/app/app/settings/billing/page.tsx
+++ b/apps/frontend/src/app/app/settings/billing/page.tsx
@@ -14,7 +14,7 @@ import React, { useEffect, useState } from 'react';
 import { AppShell } from '@/components/app';
 import { TierUsageIndicators } from '@/components/app/TierUsageIndicators';
 import { UpgradePromptModal } from '@/components/app/UpgradePrompt';
-import { TIER_CONFIGS } from '@/lib/stripe/pricing';
+import { TIER_CONFIGS, formatTierPrice } from '@/lib/stripe/pricing';
 import type { SubscriptionTier } from '@craft/types';
 import type { SubscriptionStatus } from '@craft/types';
 import type { User, NavItem } from '@/types/navigation';
@@ -255,7 +255,7 @@ export default function BillingPage() {
 
                   {tier !== 'free' && (
                     <p className="text-2xl font-bold text-on-surface">
-                      ${(tierConfig.monthlyPriceCents / 100).toFixed(0)}
+                      {formatTierPrice(tierConfig.monthlyPriceCents)}
                       <span className="text-sm font-normal text-on-surface-variant">
                         /mo
                       </span>

--- a/apps/frontend/src/components/app/MobileDrawer.tsx
+++ b/apps/frontend/src/components/app/MobileDrawer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { NavItem } from './NavItem';
@@ -13,8 +13,18 @@ interface MobileDrawerProps {
   navItems: NavItemType[];
 }
 
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])';
+
+function getFocusableElements(container: HTMLElement): HTMLElement[] {
+  return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));
+}
+
 export function MobileDrawer({ open, onClose, user, navItems }: MobileDrawerProps) {
   const pathname = usePathname();
+  const drawerRef = useRef<HTMLElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const triggerRef = useRef<HTMLElement | null>(null);
 
   // Close drawer on route change
   useEffect(() => {
@@ -33,15 +43,48 @@ export function MobileDrawer({ open, onClose, user, navItems }: MobileDrawerProp
     };
   }, [open]);
 
-  // Handle escape key
+  // Move focus into the drawer when it opens; restore it to the trigger on close
   useEffect(() => {
-    const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === 'Escape' && open) {
+    if (open) {
+      triggerRef.current = document.activeElement as HTMLElement | null;
+      closeButtonRef.current?.focus();
+    } else {
+      triggerRef.current?.focus();
+      triggerRef.current = null;
+    }
+  }, [open]);
+
+  // Handle escape key and trap Tab/Shift+Tab within the drawer
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (!open) return;
+
+      if (e.key === 'Escape') {
         onClose();
+        return;
+      }
+
+      if (e.key === 'Tab' && drawerRef.current) {
+        const focusable = getFocusableElements(drawerRef.current);
+        if (focusable.length === 0) return;
+
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        const active = document.activeElement;
+
+        if (e.shiftKey) {
+          if (active === first || !drawerRef.current.contains(active)) {
+            e.preventDefault();
+            last.focus();
+          }
+        } else if (active === last || !drawerRef.current.contains(active)) {
+          e.preventDefault();
+          first.focus();
+        }
       }
     };
-    document.addEventListener('keydown', handleEscape);
-    return () => document.removeEventListener('keydown', handleEscape);
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
   }, [open, onClose]);
 
   const isActive = (itemPath: string): boolean => {
@@ -73,6 +116,9 @@ export function MobileDrawer({ open, onClose, user, navItems }: MobileDrawerProp
 
       {/* Drawer */}
       <aside
+        ref={drawerRef}
+        role="dialog"
+        aria-modal={open}
         className={`fixed top-0 left-0 h-full w-72 bg-surface-container-low z-50 md:hidden transform transition-transform duration-300 ease-in-out ${
           open ? 'translate-x-0' : '-translate-x-full'
         }`}
@@ -87,6 +133,7 @@ export function MobileDrawer({ open, onClose, user, navItems }: MobileDrawerProp
             CRAFT
           </Link>
           <button
+            ref={closeButtonRef}
             onClick={onClose}
             className="p-2 -mr-2 text-on-surface-variant hover:text-on-surface hover:bg-surface-container rounded-lg transition-colors"
             aria-label="Close menu"

--- a/apps/frontend/src/components/app/SubscriptionComparison.tsx
+++ b/apps/frontend/src/components/app/SubscriptionComparison.tsx
@@ -11,7 +11,7 @@
 
 import React from 'react';
 import Link from 'next/link';
-import { TIER_CONFIGS } from '@/lib/stripe/pricing';
+import { TIER_CONFIGS, formatTierPrice } from '@/lib/stripe/pricing';
 import { MATRIX_FEATURES, MatrixCell } from '@/components/marketing/FeatureMatrix';
 import type { SubscriptionTier } from '@craft/types';
 
@@ -49,8 +49,7 @@ export function SubscriptionComparison({ currentTier }: { currentTier: Subscript
           const isCurrent = tier === currentTier;
           const ctaHref = buildCtaHref(tier);
           const ctaLabel = buildCtaLabel(tier, isCurrent);
-          const priceDisplay =
-            config.monthlyPriceCents === 0 ? '$0' : `$${config.monthlyPriceCents / 100}`;
+          const priceDisplay = formatTierPrice(config.monthlyPriceCents);
 
           return (
             <div

--- a/apps/frontend/src/components/app/UpgradeFlow.tsx
+++ b/apps/frontend/src/components/app/UpgradeFlow.tsx
@@ -15,7 +15,7 @@
 
 import React from 'react';
 import Link from 'next/link';
-import { TIER_CONFIGS } from '@/lib/stripe/pricing';
+import { TIER_CONFIGS, formatTierPrice } from '@/lib/stripe/pricing';
 import { MATRIX_FEATURES, MatrixCell } from '@/components/marketing/FeatureMatrix';
 import type { SubscriptionTier } from '@craft/types';
 
@@ -37,7 +37,7 @@ export function UpgradeFlow({ currentTier, targetTier, onConfirm, loading, error
   const currentConfig = TIER_CONFIGS[currentTier];
   const targetConfig = TIER_CONFIGS[targetTier];
   const upgrade = isUpgrade(currentTier, targetTier);
-  const priceDisplay = `$${targetConfig.monthlyPriceCents / 100}/month`;
+  const priceDisplay = `${formatTierPrice(targetConfig.monthlyPriceCents)}/month`;
 
   return (
     <section

--- a/apps/frontend/src/components/app/UpgradePrompt.tsx
+++ b/apps/frontend/src/components/app/UpgradePrompt.tsx
@@ -10,7 +10,7 @@
 
 import React from 'react';
 import type { SubscriptionTier } from '@craft/types';
-import { TIER_CONFIGS } from '@/lib/stripe/pricing';
+import { TIER_CONFIGS, formatTierPrice } from '@/lib/stripe/pricing';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -136,7 +136,7 @@ export function UpgradePromptModal({
           className="block w-full rounded-lg bg-indigo-600 py-2 text-center font-medium text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-400"
           aria-label={`Upgrade to ${config.displayName}`}
         >
-          Upgrade to {config.displayName} — ${(config.monthlyPriceCents / 100).toFixed(0)}/mo
+          Upgrade to {config.displayName} — {formatTierPrice(config.monthlyPriceCents)}/mo
         </a>
 
         <button

--- a/apps/frontend/src/components/app/preview/PreviewWorkspace.tsx
+++ b/apps/frontend/src/components/app/preview/PreviewWorkspace.tsx
@@ -25,6 +25,7 @@ export function PreviewWorkspace({
   const [isRefreshing, setIsRefreshing] = useState(false);
   
   const iframeRef = useRef<HTMLIFrameElement>(null);
+  const sequenceRef = useRef(0);
   const { generatePreview, refreshPreview } = usePreviewService();
 
   const handleViewportChange = useCallback((viewport: ViewportClass) => {
@@ -34,18 +35,25 @@ export function PreviewWorkspace({
 
   const handleRefresh = useCallback(async () => {
     if (!customization) return;
-    
+
+    const requestId = ++sequenceRef.current;
+
     setIsRefreshing(true);
     setError(null);
-    
+
     try {
       await refreshPreview(customization, activeViewport);
+      if (requestId !== sequenceRef.current) return;
       setPreviewStatus('ready');
     } catch (err) {
+      if (requestId !== sequenceRef.current) return;
+      if (err instanceof Error && err.name === 'AbortError') return;
       setError(err instanceof Error ? err.message : 'Failed to refresh preview');
       setPreviewStatus('error');
     } finally {
-      setIsRefreshing(false);
+      if (requestId === sequenceRef.current) {
+        setIsRefreshing(false);
+      }
     }
   }, [customization, activeViewport, refreshPreview]);
 
@@ -59,7 +67,10 @@ export function PreviewWorkspace({
     if (customization) {
       handleRefresh();
     }
-  }, [customization, activeViewport]);
+    return () => {
+      sequenceRef.current += 1;
+    };
+  }, [customization, activeViewport, handleRefresh]);
 
   const renderPreviewContent = () => {
     switch (previewStatus) {

--- a/apps/frontend/src/hooks/usePreviewService.ts
+++ b/apps/frontend/src/hooks/usePreviewService.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { ViewportClass, CustomizationConfig, PreviewData } from '@craft/types';
 import { previewService } from '@/services/preview.service';
 
@@ -14,6 +14,7 @@ interface UsePreviewServiceReturn {
 export function usePreviewService(): UsePreviewServiceReturn {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
 
   const generatePreview = useCallback(
     async (customization: CustomizationConfig, viewport: ViewportClass): Promise<PreviewData> => {
@@ -36,7 +37,19 @@ export function usePreviewService(): UsePreviewServiceReturn {
 
   const refreshPreview = useCallback(
     async (customization: CustomizationConfig, viewport: ViewportClass): Promise<PreviewData> => {
-      return generatePreview(customization, viewport);
+      abortRef.current?.abort();
+      const controller = new AbortController();
+      abortRef.current = controller;
+
+      const result = await generatePreview(customization, viewport);
+
+      if (controller.signal.aborted) {
+        const abortError = new Error('Preview refresh superseded by a newer request');
+        abortError.name = 'AbortError';
+        throw abortError;
+      }
+
+      return result;
     },
     [generatePreview]
   );

--- a/apps/frontend/src/lib/customization/validate-stellar.ts
+++ b/apps/frontend/src/lib/customization/validate-stellar.ts
@@ -15,6 +15,22 @@ const ACCOUNT_ID_RE = /^G[A-Z2-7]{55}$/;
 const TESTNET_HORIZON = 'https://horizon-testnet.stellar.org';
 const MAINNET_HORIZON = 'https://horizon.stellar.org';
 
+const TESTNET_HORIZON_HOST = 'horizon-testnet.stellar.org';
+const MAINNET_HORIZON_HOST = 'horizon.stellar.org';
+
+/**
+ * Extracts the lowercased hostname from a Horizon URL for comparison.
+ * Returns null for unparseable URLs so callers can skip the check
+ * (format is already validated upstream by `.url()`).
+ */
+function getHorizonHost(horizonUrl: string): string | null {
+    try {
+        return new URL(horizonUrl).hostname.toLowerCase();
+    } catch {
+        return null;
+    }
+}
+
 // ── Sub-schemas ───────────────────────────────────────────────────────────────
 
 /**
@@ -80,15 +96,16 @@ export const stellarConfigSchema = z
             .optional(),
     })
     .superRefine((cfg, ctx) => {
-        // Horizon URL / network mismatch
-        if (cfg.network === 'mainnet' && cfg.horizonUrl === TESTNET_HORIZON) {
+        // Horizon URL / network mismatch (compared by normalized host, not raw string)
+        const horizonHost = getHorizonHost(cfg.horizonUrl);
+        if (cfg.network === 'mainnet' && horizonHost === TESTNET_HORIZON_HOST) {
             ctx.addIssue({
                 code: z.ZodIssueCode.custom,
                 message: 'Horizon URL points to testnet but network is set to mainnet',
                 path: ['horizonUrl'],
             });
         }
-        if (cfg.network === 'testnet' && cfg.horizonUrl === MAINNET_HORIZON) {
+        if (cfg.network === 'testnet' && horizonHost === MAINNET_HORIZON_HOST) {
             ctx.addIssue({
                 code: z.ZodIssueCode.custom,
                 message: 'Horizon URL points to mainnet but network is set to testnet',

--- a/apps/frontend/src/lib/stripe/pricing.ts
+++ b/apps/frontend/src/lib/stripe/pricing.ts
@@ -95,6 +95,24 @@ export const TIER_CONFIGS: Record<SubscriptionTier, TierConfig> = {
   },
 };
 
+// ── Display helpers ───────────────────────────────────────────────────────────
+
+const currencyFormatter = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+});
+
+/**
+ * Formats a tier price in cents as a locale-aware USD currency string
+ * (e.g. 1950 -> "$19.50", 100000 -> "$1,000.00"). Renders "$0" for the
+ * free tier instead of "$0.00". Callers append their own "/mo" or
+ * "/month" suffix.
+ */
+export function formatTierPrice(cents: number): string {
+  if (cents === 0) return '$0';
+  return currencyFormatter.format(cents / 100);
+}
+
 // ── Lookup helpers ────────────────────────────────────────────────────────────
 
 /**


### PR DESCRIPTION
## Summary

Four independent bug fixes bundled into one PR per request:

- **#1003** — `stellarConfigSchema.superRefine` in `validate-stellar.ts` compared `horizonUrl` against the testnet/mainnet Horizon constants with strict string equality, so a trailing slash, different scheme, or casing silently bypassed the mainnet/testnet mismatch check. Replaced the raw `===` comparisons with a `getHorizonHost()` helper that parses the URL and compares the lowercased `hostname`, so trailing slashes, path segments, and scheme/case differences can no longer evade the check. Error messages and the `horizonUrl` field path are unchanged.

- **#1002** — `SubscriptionComparison.tsx` and `UpgradeFlow.tsx` (plus `UpgradePrompt.tsx` and the billing settings page) derived tier price strings via `cents / 100` interpolation with no decimal normalization, so a non-round-dollar price (e.g. 1950 cents) would render as `$19.5` instead of `$19.50`, and large prices had no thousands separator. Added a centralized `formatTierPrice(cents)` helper in `pricing.ts` built on `Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' })`, and updated all four consumers to use it instead of ad-hoc math.

- **#1000** — `PreviewWorkspace.tsx`'s refresh effect had no request-identity tracking, so rapidly switching viewports (or editing customization) could let an earlier, slower `refreshPreview` call resolve after a newer one and clobber the current preview state with stale data. Added an `AbortController`-based staleness guard in `usePreviewService.ts` (aborts the previous in-flight call when a new one starts, and throws an `AbortError` if a call turns out to be superseded) plus a request-sequence guard in `PreviewWorkspace.tsx`'s `handleRefresh`/effect, mirroring the existing pattern in `useTemplates.ts`.

- **#1001** — `MobileDrawer.tsx` never moved focus into the drawer on open, never trapped `Tab`/`Shift+Tab` within it, and never restored focus to the triggering element on close, and it lacked `role="dialog"`/`aria-modal`. Added focus-in-on-open (to the close button), a `Tab`/`Shift+Tab` focus trap cycling within the drawer's focusable elements, focus restoration to the previously-focused trigger element on close, and `role="dialog"` + `aria-modal={open}` on the drawer element.

## Changes

- `apps/frontend/src/lib/customization/validate-stellar.ts`
- `apps/frontend/src/lib/stripe/pricing.ts`
- `apps/frontend/src/components/app/SubscriptionComparison.tsx`
- `apps/frontend/src/components/app/UpgradeFlow.tsx`
- `apps/frontend/src/components/app/UpgradePrompt.tsx`
- `apps/frontend/src/app/app/settings/billing/page.tsx`
- `apps/frontend/src/hooks/usePreviewService.ts`
- `apps/frontend/src/components/app/preview/PreviewWorkspace.tsx`
- `apps/frontend/src/components/app/MobileDrawer.tsx`

Closes #1003
Closes #1002
Closes #1000
Closes #1001

## Test plan

- [ ] `pnpm test --filter=frontend -- validate-stellar`
- [ ] `pnpm test --filter=frontend -- pricing`
- [ ] `pnpm test --filter=frontend -- SubscriptionComparison`
- [ ] `pnpm test --filter=frontend -- PreviewWorkspace`
- [ ] `pnpm test --filter=frontend -- usePreviewService`
- [ ] `pnpm test --filter=frontend -- MobileDrawer`
- [ ] `pnpm lint`
- [ ] `pnpm typecheck`

No automated tests were added in this PR per explicit request from the author; the checklist above reflects the tickets' original test requirements and is left for reviewer follow-up.