### PR TITLE
Fix preview typing, add test coverage, dedupe initials, fix billing cancel dialog

### DIFF
--- a/apps/frontend/src/app/app/settings/billing/page.test.tsx
+++ b/apps/frontend/src/app/app/settings/billing/page.test.tsx
@@ -242,6 +242,35 @@ describe('BillingPage', () => {
       await waitFor(() => screen.getByTestId('cancellation-notice'));
       expect(fetchSpy).toHaveBeenCalledWith('/api/payments/cancel', expect.objectContaining({ method: 'POST' }));
     });
+
+    it('keeps the confirm dialog open with an inline error when cancellation fails', async () => {
+      vi.spyOn(global, 'fetch').mockImplementation(async (input) => {
+        const url = typeof input === 'string' ? input : (input as Request).url;
+        if (url.includes('/api/payments/cancel')) {
+          return { ok: false } as Response;
+        }
+        return {
+          ok: true,
+          json: async () => ({
+            tier: 'pro',
+            status: 'active',
+            currentPeriodEnd: PERIOD_END,
+            cancelAtPeriodEnd: false,
+          }),
+        } as Response;
+      });
+
+      render(<BillingPage />);
+      await waitFor(() => screen.getByTestId('cancel-subscription-btn'));
+      fireEvent.click(screen.getByTestId('cancel-subscription-btn'));
+      fireEvent.click(screen.getByTestId('confirm-cancel-btn'));
+
+      await waitFor(() => screen.getByTestId('cancel-error'));
+      expect(screen.getByTestId('cancel-confirm-dialog')).toBeDefined();
+      expect(screen.getByTestId('cancel-error').textContent).toContain('Failed to cancel subscription');
+      expect(screen.getByTestId('confirm-cancel-btn').hasAttribute('disabled')).toBe(false);
+      expect(screen.queryByTestId('cancellation-notice')).toBeNull();
+    });
   });
 
   describe('cancelled subscription', () => {

--- a/apps/frontend/src/app/app/settings/billing/page.tsx
+++ b/apps/frontend/src/app/app/settings/billing/page.tsx
@@ -117,6 +117,7 @@ export default function BillingPage() {
   const [cancelling, setCancelling] = useState(false);
   const [upgradeModalOpen, setUpgradeModalOpen] = useState(false);
   const [cancelConfirmOpen, setCancelConfirmOpen] = useState(false);
+  const [cancelError, setCancelError] = useState<string | null>(null);
 
   // Fetch subscription on mount
   useEffect(() => {
@@ -137,6 +138,7 @@ export default function BillingPage() {
 
   async function handleCancel() {
     setCancelling(true);
+    setCancelError(null);
     try {
       const res = await fetch('/api/payments/cancel', { method: 'POST' });
       if (!res.ok) throw new Error('Failed to cancel subscription');
@@ -150,11 +152,11 @@ export default function BillingPage() {
             }
           : prev
       );
+      setCancelConfirmOpen(false);
     } catch (e: unknown) {
-      setError(e instanceof Error ? e.message : 'Unknown error');
+      setCancelError(e instanceof Error ? e.message : 'Unknown error');
     } finally {
       setCancelling(false);
-      setCancelConfirmOpen(false);
     }
   }
 
@@ -398,6 +400,15 @@ export default function BillingPage() {
               Your plan will remain active until the end of the current billing
               period. After that, you&apos;ll be moved to the Free tier.
             </p>
+            {cancelError && (
+              <p
+                role="alert"
+                data-testid="cancel-error"
+                className="mb-4 rounded-lg border border-red-300 bg-red-50 px-4 py-3 text-sm text-red-800"
+              >
+                {cancelError}
+              </p>
+            )}
             <div className="flex gap-3">
               <button
                 data-testid="confirm-cancel-btn"
@@ -409,7 +420,10 @@ export default function BillingPage() {
               </button>
               <button
                 data-testid="dismiss-cancel-btn"
-                onClick={() => setCancelConfirmOpen(false)}
+                onClick={() => {
+                  setCancelConfirmOpen(false);
+                  setCancelError(null);
+                }}
                 className="flex-1 rounded-lg border border-gray-200 py-2 text-sm text-gray-600 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-gray-300"
               >
                 Keep plan

--- a/apps/frontend/src/components/app/MobileDrawer.tsx
+++ b/apps/frontend/src/components/app/MobileDrawer.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { NavItem } from './NavItem';
 import { User, NavItem as NavItemType } from '@/types/navigation';
+import { getInitials } from '@/lib/format/initials';
 
 interface MobileDrawerProps {
   open: boolean;
@@ -49,15 +50,6 @@ export function MobileDrawer({ open, onClose, user, navItems }: MobileDrawerProp
       return pathname === '/app';
     }
     return pathname.startsWith(itemPath);
-  };
-
-  const getInitials = (name: string) => {
-    return name
-      .split(' ')
-      .map(n => n[0])
-      .join('')
-      .toUpperCase()
-      .slice(0, 2);
   };
 
   return (

--- a/apps/frontend/src/components/app/UserMenu.tsx
+++ b/apps/frontend/src/components/app/UserMenu.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useRef, useEffect } from 'react';
 import { User } from '@/types/navigation';
+import { getInitials } from '@/lib/format/initials';
 
 interface UserMenuProps {
   user: User;
@@ -44,15 +45,6 @@ export function UserMenu({
       document.removeEventListener('keydown', handleEscape);
     };
   }, [isOpen]);
-
-  const getInitials = (name: string) => {
-    return name
-      .split(' ')
-      .map(n => n[0])
-      .join('')
-      .toUpperCase()
-      .slice(0, 2);
-  };
 
   const menuItems = [
     { label: 'Profile', onClick: onProfileClick, icon: '👤' },

--- a/apps/frontend/src/components/app/preview/PreviewIframe.test.tsx
+++ b/apps/frontend/src/components/app/preview/PreviewIframe.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { CustomizationConfig } from '@craft/types';
+import { PreviewIframe } from './PreviewIframe';
+
+const customization: CustomizationConfig = {
+  branding: {
+    appName: 'Test App',
+    primaryColor: '#000000',
+    secondaryColor: '#ffffff',
+    fontFamily: 'Inter',
+  },
+  features: {
+    enableCharts: true,
+    enableTransactionHistory: true,
+    enableAnalytics: false,
+    enableNotifications: false,
+  },
+  stellar: {
+    network: 'testnet',
+    horizonUrl: 'https://horizon-testnet.stellar.org',
+  },
+};
+
+describe('PreviewIframe', () => {
+  it('includes the serialized customization in the generated src URL', async () => {
+    render(
+      <PreviewIframe
+        templateId="template-1"
+        customization={customization}
+        viewport="desktop"
+      />
+    );
+
+    const iframe = await waitFor(() => screen.getByTitle('Preview for desktop viewport'));
+
+    await waitFor(() => {
+      expect(iframe.getAttribute('src')).toContain('customization=');
+    });
+
+    const src = iframe.getAttribute('src') || '';
+    const params = new URLSearchParams(src.split('?')[1]);
+    expect(params.get('customization')).toBe(JSON.stringify(customization));
+  });
+});

--- a/apps/frontend/src/components/app/preview/PreviewIframe.tsx
+++ b/apps/frontend/src/components/app/preview/PreviewIframe.tsx
@@ -1,11 +1,11 @@
 'use client';
 
 import React, { forwardRef, useEffect, useState } from 'react';
-import { ViewportClass, VIEWPORT_DIMENSIONS } from '@craft/types';
+import { ViewportClass, VIEWPORT_DIMENSIONS, CustomizationConfig } from '@craft/types';
 
 interface PreviewIframeProps {
   readonly templateId?: string;
-  readonly customization?: any;
+  readonly customization?: CustomizationConfig;
   readonly viewport: ViewportClass;
   readonly onLoad?: () => void;
   readonly onError?: (error: Error) => void;

--- a/apps/frontend/src/hooks/usePreviewService.test.ts
+++ b/apps/frontend/src/hooks/usePreviewService.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { CustomizationConfig, PreviewData } from '@craft/types';
+import { usePreviewService } from './usePreviewService';
+import { previewService } from '@/services/preview.service';
+
+const customization: CustomizationConfig = {
+  branding: {
+    appName: 'Test App',
+    primaryColor: '#000000',
+    secondaryColor: '#ffffff',
+    fontFamily: 'Inter',
+  },
+  features: {
+    enableCharts: true,
+    enableTransactionHistory: true,
+    enableAnalytics: false,
+    enableNotifications: false,
+  },
+  stellar: {
+    network: 'testnet',
+    horizonUrl: 'https://horizon-testnet.stellar.org',
+  },
+};
+
+const previewData: PreviewData = {
+  html: '<html></html>',
+  css: '',
+  assets: [],
+  branding: customization.branding,
+  features: customization.features,
+  mockData: { accountBalance: '0', recentTransactions: [], assetPrices: {} },
+  viewport: { width: 1440, height: 900, class: 'desktop' },
+};
+
+describe('usePreviewService', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('toggles isLoading and resolves with PreviewData on success', async () => {
+    vi.spyOn(previewService, 'generatePreview').mockReturnValue(previewData);
+
+    const { result } = renderHook(() => usePreviewService());
+
+    expect(result.current.isLoading).toBe(false);
+
+    let promise: Promise<PreviewData>;
+    act(() => {
+      promise = result.current.generatePreview(customization, 'desktop');
+    });
+
+    expect(result.current.isLoading).toBe(true);
+
+    await act(async () => {
+      await expect(promise).resolves.toEqual(previewData);
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('sets error to the thrown Error message and re-throws on failure', async () => {
+    vi.spyOn(previewService, 'generatePreview').mockImplementation(() => {
+      throw new Error('boom');
+    });
+
+    const { result } = renderHook(() => usePreviewService());
+
+    await act(async () => {
+      await expect(result.current.generatePreview(customization, 'desktop')).rejects.toThrow('boom');
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBe('boom');
+  });
+
+  it('falls back to a default message when a non-Error is thrown', async () => {
+    vi.spyOn(previewService, 'generatePreview').mockImplementation(() => {
+      throw 'not an error';
+    });
+
+    const { result } = renderHook(() => usePreviewService());
+
+    await act(async () => {
+      await expect(result.current.generatePreview(customization, 'desktop')).rejects.toThrow(
+        'Failed to generate preview'
+      );
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBe('Failed to generate preview');
+  });
+
+  it('refreshPreview delegates to generatePreview with the same arguments', async () => {
+    const spy = vi.spyOn(previewService, 'generatePreview').mockReturnValue(previewData);
+
+    const { result } = renderHook(() => usePreviewService());
+
+    await act(async () => {
+      await result.current.refreshPreview(customization, 'mobile');
+    });
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(customization, 'mobile');
+  });
+});

--- a/apps/frontend/src/lib/format/initials.test.ts
+++ b/apps/frontend/src/lib/format/initials.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { getInitials } from './initials';
+
+describe('getInitials', () => {
+  it('returns the first letter of each of the first two words, uppercased', () => {
+    expect(getInitials('John Doe')).toBe('JD');
+  });
+
+  it('returns a single initial for a single-word name', () => {
+    expect(getInitials('Madonna')).toBe('M');
+  });
+
+  it('collapses extra internal whitespace between words', () => {
+    expect(getInitials('John   Doe')).toBe('JD');
+  });
+
+  it('ignores leading and trailing whitespace', () => {
+    expect(getInitials('  John Doe  ')).toBe('JD');
+  });
+
+  it('slices to a maximum of two characters for names with more than two words', () => {
+    expect(getInitials('John Fitzgerald Doe')).toBe('JF');
+  });
+
+  it('returns an empty string for empty input', () => {
+    expect(getInitials('')).toBe('');
+  });
+
+  it('returns an empty string for whitespace-only input', () => {
+    expect(getInitials('   ')).toBe('');
+  });
+});

--- a/apps/frontend/src/lib/format/initials.ts
+++ b/apps/frontend/src/lib/format/initials.ts
@@ -1,0 +1,10 @@
+export function getInitials(name: string): string {
+  return name
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+    .map(n => n[0])
+    .join('')
+    .toUpperCase()
+    .slice(0, 2);
+}


### PR DESCRIPTION
## Summary

Bundles four small, independent frontend fixes:

- **PreviewIframe prop typing** (`src/components/app/preview/PreviewIframe.tsx`): replaced `customization?: any` with `customization?: CustomizationConfig`, matching `PreviewWorkspaceProps`. No behavior change. Added `PreviewIframe.test.tsx` since no test file existed, asserting the generated iframe `src` includes the serialized customization.
- **usePreviewService test coverage** (`src/hooks/usePreviewService.test.ts`, new): covers `isLoading` toggling across success/failure, `error` being set to the thrown `Error`'s message (with `'Failed to generate preview'` fallback for non-Error throws) and re-thrown to the caller, and `refreshPreview` delegating to `generatePreview` with the same arguments via a spy on `previewService.generatePreview`.
- **Shared `getInitials` helper**: extracted the duplicated initials logic out of `UserMenu.tsx` and `MobileDrawer.tsx` into `src/lib/format/initials.ts`, updated both components to import it, and added `src/lib/format/initials.test.ts` covering single-word names, extra internal whitespace, leading/trailing whitespace, >2 word names, and empty/whitespace-only input.
- **Billing cancel-failure dialog state** (`src/app/app/settings/billing/page.tsx`): `handleCancel` no longer unconditionally closes the confirm dialog and clears state in `finally`. On failure the dialog now stays open with an inline `role="alert"` error message (`cancelError` state), and `cancelling` still resets so the retry button re-enables. The dialog only closes on success. Added a failure-path test in `page.test.tsx` mocking a non-ok `/api/payments/cancel` response and asserting the dialog stays open with the inline error and no cancellation notice.

## Issues closed

Closes #1007
Closes #1006
Closes #1005
Closes #1004

## Test plan

- [ ] `pnpm typecheck` — confirm `CustomizationConfig` typing compiles cleanly at all call sites
- [ ] `pnpm lint`
- [ ] `pnpm test --filter=frontend -- PreviewIframe`
- [ ] `pnpm test --filter=frontend -- usePreviewService`
- [ ] `pnpm test --filter=frontend -- initials`
- [ ] `pnpm test --filter=frontend -- billing`