### PR TITLE
Fix branding submit stale save, add GitHub push/auth logging, correct router docs

### DIFF
--- a/apps/backend/src/lib/github/app-auth.ts
+++ b/apps/backend/src/lib/github/app-auth.ts
@@ -5,6 +5,9 @@ import type {
     GitHubInstallationAuthContext,
 } from '@craft/types';
 import { getGitHubAppConfig, type GitHubAppConfig } from './config';
+import { createLogger } from '@/lib/api/logger';
+
+const log = createLogger({ service: 'github-app-auth' });
 
 type FetchFn = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
 
@@ -71,11 +74,21 @@ export class GitHubAppAuthClient {
 
     async getInstallationAuthContext(params: { forceRefresh?: boolean } = {}): Promise<GitHubInstallationAuthContext> {
         const forceRefresh = params.forceRefresh ?? false;
-        const cached = this.cache.get(this.config.installationId);
+        const installationId = this.config.installationId;
+        const cached = this.cache.get(installationId);
+        const nearExpiry = cached ? this.isNearExpiry(cached.expiresAt) : true;
 
-        if (!forceRefresh && cached && !this.isNearExpiry(cached.expiresAt)) {
+        if (!forceRefresh && cached && !nearExpiry) {
+            log.info('Installation token cache hit', { installationId, isNearExpiry: nearExpiry });
             return this.toAuthContext(cached);
         }
+
+        log.info('Installation token refresh triggered', {
+            installationId,
+            forceRefresh,
+            hadCachedToken: Boolean(cached),
+            isNearExpiry: nearExpiry,
+        });
 
         // De-duplicate concurrent fetches:
         //   - Non-forced callers share whichever fetch is already in flight.
@@ -121,6 +134,11 @@ export class GitHubAppAuthClient {
         this.invalidateCachedToken();
 
         const refreshedAuth = await this.getInstallationAuthContext({ forceRefresh: true });
+        log.warn('Cached installation token invalidated and refreshed after 401', {
+            installationId: this.config.installationId,
+            url: this.resolveUrl(input),
+        });
+
         return this.fetchFn(this.resolveUrl(input), {
             ...init,
             headers: this.mergeHeaders(init.headers, refreshedAuth.authorizationHeader),
@@ -138,6 +156,15 @@ export class GitHubAppAuthClient {
 
     private isNearExpiry(expiresAt: Date): boolean {
         return expiresAt.getTime() - this.now() <= this.tokenSkewMs;
+    }
+
+    private logAuthError(error: GitHubAppAuthError): void {
+        log.error('GitHub App auth error', error, {
+            installationId: this.config.installationId,
+            code: error.code,
+            retryable: error.retryable,
+            status: error.status,
+        });
     }
 
     private toAuthContext(token: CachedInstallationToken): GitHubInstallationAuthContext {
@@ -173,35 +200,43 @@ export class GitHubAppAuthClient {
                 },
             });
         } catch (error: unknown) {
-            throw new GitHubAppAuthError({
+            const authError = new GitHubAppAuthError({
                 code: 'NETWORK_ERROR',
                 message: 'Unable to reach GitHub token endpoint',
                 retryable: true,
             });
+            this.logAuthError(authError);
+            throw authError;
         }
 
         if (!response.ok) {
-            throw await this.buildHttpError(response);
+            const authError = await this.buildHttpError(response);
+            this.logAuthError(authError);
+            throw authError;
         }
 
         const payload = (await response.json()) as TokenResponse;
         if (!payload.token || !payload.expires_at) {
-            throw new GitHubAppAuthError({
+            const authError = new GitHubAppAuthError({
                 code: 'INVALID_RESPONSE',
                 message: 'GitHub token response missing required fields',
                 retryable: false,
                 status: response.status,
             });
+            this.logAuthError(authError);
+            throw authError;
         }
 
         const expiresAt = new Date(payload.expires_at);
         if (Number.isNaN(expiresAt.getTime())) {
-            throw new GitHubAppAuthError({
+            const authError = new GitHubAppAuthError({
                 code: 'INVALID_RESPONSE',
                 message: 'GitHub token response contains invalid expires_at value',
                 retryable: false,
                 status: response.status,
             });
+            this.logAuthError(authError);
+            throw authError;
         }
 
         return {

--- a/apps/backend/src/services/github-push.service.ts
+++ b/apps/backend/src/services/github-push.service.ts
@@ -1,4 +1,7 @@
 import type { GeneratedFile } from '@craft/types';
+import { createLogger } from '@/lib/api/logger';
+
+const log = createLogger({ service: 'github-push' });
 
 const GITHUB_API_BASE = 'https://api.github.com';
 const MAX_FILE_COUNT = 5000;
@@ -38,6 +41,8 @@ export interface GitHubPushRequest {
     commitMessage: string;
     authorName?: string;
     authorEmail?: string;
+    /** Correlation ID from an existing trace (e.g. GitHubToVercelDeploymentService). Generated when absent. */
+    traceId?: string;
 }
 
 export interface GitHubCommitReference {
@@ -84,18 +89,23 @@ export class GitHubPushService {
     constructor(private readonly _fetch: FetchLike = fetch) {}
 
     async pushGeneratedCode(request: GitHubPushRequest): Promise<GitHubCommitReference> {
+        const traceId = request.traceId ?? crypto.randomUUID();
         const owner = request.owner.trim();
         const repo = request.repo.trim();
         const branch = request.branch.trim();
         const baseBranch = (request.baseBranch ?? 'main').trim();
         const commitMessage = request.commitMessage.trim();
 
+        log.info('Stage: validate-request', { traceId, owner, repo, branch, baseBranch });
+
         if (!owner || !repo || !branch || !baseBranch || !commitMessage) {
+            log.error('Validation failed: missing required fields', undefined, { traceId, owner, repo, branch, baseBranch });
             throw new GitHubPushValidationError('owner, repo, branch, baseBranch, and commitMessage are required');
         }
 
         const token = request.token.trim();
         if (!token) {
+            log.error('Validation failed: missing GitHub token', undefined, { traceId, owner, repo });
             throw new GitHubPushAuthError('GitHub token is required for repository updates');
         }
 
@@ -108,104 +118,119 @@ export class GitHubPushService {
 
         const files = this.prepareFiles(request.files);
 
-        let createdBranch = false;
-        let currentHeadSha: string;
+        try {
+            let createdBranch = false;
+            let currentHeadSha: string;
 
-        const branchRef = await this.getRef(owner, repo, branch, headers);
-        if (branchRef) {
-            currentHeadSha = branchRef.object.sha;
-        } else {
-            const baseRef = await this.getRef(owner, repo, baseBranch, headers);
-            if (!baseRef) {
-                throw new GitHubPushApiError(`Base branch not found: ${baseBranch}`, 404);
+            log.info('Stage: resolve-ref start', { traceId, owner, repo, branch });
+            const branchRef = await this.getRef(owner, repo, branch, headers);
+            if (branchRef) {
+                currentHeadSha = branchRef.object.sha;
+            } else {
+                const baseRef = await this.getRef(owner, repo, baseBranch, headers);
+                if (!baseRef) {
+                    throw new GitHubPushApiError(`Base branch not found: ${baseBranch}`, 404);
+                }
+
+                currentHeadSha = baseRef.object.sha;
+                await this.requestJson(
+                    `${GITHUB_API_BASE}/repos/${owner}/${repo}/git/refs`,
+                    {
+                        method: 'POST',
+                        headers,
+                        body: JSON.stringify({
+                            ref: `refs/heads/${branch}`,
+                            sha: currentHeadSha,
+                        }),
+                    },
+                    'Failed to create branch',
+                    true
+                );
+                createdBranch = true;
             }
+            log.info('Stage: resolve-ref done', { traceId, owner, repo, branch, currentHeadSha, createdBranch });
 
-            currentHeadSha = baseRef.object.sha;
-            await this.requestJson(
-                `${GITHUB_API_BASE}/repos/${owner}/${repo}/git/refs`,
+            log.info('Stage: read-base-commit start', { traceId, owner, repo, currentHeadSha });
+            const baseCommit = await this.requestJson<GitHubCommitResponse>(
+                `${GITHUB_API_BASE}/repos/${owner}/${repo}/git/commits/${currentHeadSha}`,
+                { method: 'GET', headers },
+                'Failed to load base commit'
+            );
+            log.info('Stage: read-base-commit done', { traceId, owner, repo, baseTreeSha: baseCommit.tree.sha });
+
+            const treeItems = await this.createTreeItems(owner, repo, files, headers, traceId);
+
+            log.info('Stage: create-tree start', { traceId, owner, repo, itemCount: treeItems.length });
+            const tree = await this.requestJson<GitHubTreeResponse>(
+                `${GITHUB_API_BASE}/repos/${owner}/${repo}/git/trees`,
                 {
                     method: 'POST',
                     headers,
                     body: JSON.stringify({
-                        ref: `refs/heads/${branch}`,
-                        sha: currentHeadSha,
+                        base_tree: baseCommit.tree.sha,
+                        tree: treeItems,
                     }),
                 },
-                'Failed to create branch',
+                'Failed to create git tree'
+            );
+            log.info('Stage: create-tree done', { traceId, owner, repo, treeSha: tree.sha });
+
+            const commitPayload: Record<string, unknown> = {
+                message: commitMessage,
+                tree: tree.sha,
+                parents: [currentHeadSha],
+            };
+
+            if (request.authorName && request.authorEmail) {
+                commitPayload.author = {
+                    name: request.authorName,
+                    email: request.authorEmail,
+                };
+            }
+
+            log.info('Stage: create-commit start', { traceId, owner, repo, treeSha: tree.sha });
+            const commit = await this.requestJson<GitHubCreateCommitResponse>(
+                `${GITHUB_API_BASE}/repos/${owner}/${repo}/git/commits`,
+                {
+                    method: 'POST',
+                    headers,
+                    body: JSON.stringify(commitPayload),
+                },
+                'Failed to create commit'
+            );
+            log.info('Stage: create-commit done', { traceId, owner, repo, commitSha: commit.sha });
+
+            log.info('Stage: update-branch-ref start', { traceId, owner, repo, branch, commitSha: commit.sha });
+            await this.requestJson(
+                `${GITHUB_API_BASE}/repos/${owner}/${repo}/git/refs/heads/${branch}`,
+                {
+                    method: 'PATCH',
+                    headers,
+                    body: JSON.stringify({
+                        sha: commit.sha,
+                        force: false,
+                    }),
+                },
+                'Failed to update branch ref',
                 true
             );
-            createdBranch = true;
-        }
+            log.info('Stage: update-branch-ref done', { traceId, owner, repo, branch, commitSha: commit.sha });
 
-        const baseCommit = await this.requestJson<GitHubCommitResponse>(
-            `${GITHUB_API_BASE}/repos/${owner}/${repo}/git/commits/${currentHeadSha}`,
-            { method: 'GET', headers },
-            'Failed to load base commit'
-        );
-
-        const treeItems = await this.createTreeItems(owner, repo, files, headers);
-
-        const tree = await this.requestJson<GitHubTreeResponse>(
-            `${GITHUB_API_BASE}/repos/${owner}/${repo}/git/trees`,
-            {
-                method: 'POST',
-                headers,
-                body: JSON.stringify({
-                    base_tree: baseCommit.tree.sha,
-                    tree: treeItems,
-                }),
-            },
-            'Failed to create git tree'
-        );
-
-        const commitPayload: Record<string, unknown> = {
-            message: commitMessage,
-            tree: tree.sha,
-            parents: [currentHeadSha],
-        };
-
-        if (request.authorName && request.authorEmail) {
-            commitPayload.author = {
-                name: request.authorName,
-                email: request.authorEmail,
+            return {
+                owner,
+                repo,
+                branch,
+                commitSha: commit.sha,
+                treeSha: commit.tree.sha,
+                commitUrl: `https://github.com/${owner}/${repo}/commit/${commit.sha}`,
+                previousCommitSha: currentHeadSha,
+                createdBranch,
+                fileCount: files.length,
             };
+        } catch (error) {
+            log.error('Pipeline failed', error, { traceId, owner, repo, branch });
+            throw error;
         }
-
-        const commit = await this.requestJson<GitHubCreateCommitResponse>(
-            `${GITHUB_API_BASE}/repos/${owner}/${repo}/git/commits`,
-            {
-                method: 'POST',
-                headers,
-                body: JSON.stringify(commitPayload),
-            },
-            'Failed to create commit'
-        );
-
-        await this.requestJson(
-            `${GITHUB_API_BASE}/repos/${owner}/${repo}/git/refs/heads/${branch}`,
-            {
-                method: 'PATCH',
-                headers,
-                body: JSON.stringify({
-                    sha: commit.sha,
-                    force: false,
-                }),
-            },
-            'Failed to update branch ref',
-            true
-        );
-
-        return {
-            owner,
-            repo,
-            branch,
-            commitSha: commit.sha,
-            treeSha: commit.tree.sha,
-            commitUrl: `https://github.com/${owner}/${repo}/commit/${commit.sha}`,
-            previousCommitSha: currentHeadSha,
-            createdBranch,
-            fileCount: files.length,
-        };
     }
 
     private prepareFiles(files: GeneratedFile[]): PreparedFile[] {
@@ -288,12 +313,24 @@ export class GitHubPushService {
         owner: string,
         repo: string,
         files: PreparedFile[],
-        headers: HeadersInit
+        headers: HeadersInit,
+        traceId: string
     ): Promise<Array<{ path: string; mode: '100644'; type: 'blob'; sha: string }>> {
         const items: Array<{ path: string; mode: '100644'; type: 'blob'; sha: string }> = [];
+        const totalBatches = Math.ceil(files.length / BLOB_BATCH_SIZE);
 
         for (let i = 0; i < files.length; i += BLOB_BATCH_SIZE) {
             const batch = files.slice(i, i + BLOB_BATCH_SIZE);
+            const batchIndex = i / BLOB_BATCH_SIZE + 1;
+            log.info('Stage: blob-batch start', {
+                traceId,
+                owner,
+                repo,
+                batchIndex,
+                totalBatches,
+                fileCount: files.length,
+                batchFileCount: batch.length,
+            });
             const batchItems = await Promise.all(
                 batch.map(async (file) => {
                     const blob = await this.requestJson<GitHubBlobResponse>(
@@ -319,6 +356,7 @@ export class GitHubPushService {
             );
 
             items.push(...batchItems);
+            log.info('Stage: blob-batch done', { traceId, owner, repo, batchIndex, totalBatches });
         }
 
         return items;

--- a/apps/frontend/src/components/app/CustomizationStudio.tsx
+++ b/apps/frontend/src/components/app/CustomizationStudio.tsx
@@ -134,7 +134,7 @@ export interface CustomizationStudioProps {
   isDirty: boolean;
   saveState: SaveState;
   onChange: (config: CustomizationConfig) => void;
-  onSave: () => void;
+  onSave: (next?: CustomizationConfig) => void;
   onDeploy: () => void;
 }
 
@@ -173,8 +173,9 @@ export function CustomizationStudio({
 
   // Sync branding form changes back to the studio config
   function handleBrandingSubmit() {
-    onChange({ ...config, branding: brandingForm.state.branding, features: brandingForm.state.features });
-    onSave();
+    const next = { ...config, branding: brandingForm.state.branding, features: brandingForm.state.features };
+    onChange(next);
+    onSave(next);
   }
 
   function handleStellarChange(stellar: CustomizationConfig['stellar']) {

--- a/apps/frontend/src/hooks/useCustomizationStudio.ts
+++ b/apps/frontend/src/hooks/useCustomizationStudio.ts
@@ -12,7 +12,7 @@ export interface UseCustomizationStudioReturn {
   loadError: string | null;
   loading: boolean;
   setConfig: (config: CustomizationConfig) => void;
-  save: () => Promise<void>;
+  save: (next?: CustomizationConfig) => Promise<void>;
 }
 
 const DEFAULT_CONFIG: CustomizationConfig = {
@@ -91,28 +91,32 @@ export function useCustomizationStudio(templateId: string): UseCustomizationStud
 
   const isDirty = JSON.stringify(config) !== JSON.stringify(savedSnapshot);
 
-  const save = useCallback(async () => {
-    if (autoSaveTimer.current) clearTimeout(autoSaveTimer.current);
-    setSaveState('saving');
-    try {
-      const res = await fetch(`/api/drafts/${templateId}`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(config),
-      });
-      if (!res.ok) throw new Error(`Save failed (${res.status})`);
-      if (isMounted.current) {
-        setSavedSnapshot(config);
-        setSaveState('saved');
-        // Reset to idle after 2 s so the "Saved" indicator fades
-        setTimeout(() => {
-          if (isMounted.current) setSaveState('idle');
-        }, 2000);
+  const save = useCallback(
+    async (next?: CustomizationConfig) => {
+      const configToSave = next ?? config;
+      if (autoSaveTimer.current) clearTimeout(autoSaveTimer.current);
+      setSaveState('saving');
+      try {
+        const res = await fetch(`/api/drafts/${templateId}`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(configToSave),
+        });
+        if (!res.ok) throw new Error(`Save failed (${res.status})`);
+        if (isMounted.current) {
+          setSavedSnapshot(configToSave);
+          setSaveState('saved');
+          // Reset to idle after 2 s so the "Saved" indicator fades
+          setTimeout(() => {
+            if (isMounted.current) setSaveState('idle');
+          }, 2000);
+        }
+      } catch {
+        if (isMounted.current) setSaveState('error');
       }
-    } catch {
-      if (isMounted.current) setSaveState('error');
-    }
-  }, [config, templateId]);
+    },
+    [config, templateId],
+  );
 
   const setConfig = useCallback(
     (next: CustomizationConfig) => {

--- a/supabase/functions/README.md
+++ b/supabase/functions/README.md
@@ -205,15 +205,35 @@ Monitors regional Supabase instance health and availability.
 
 ### Regional Router (`regional-router/index.ts`)
 
-Intelligently routes auth requests to the nearest healthy region.
+Intelligently routes requests to the nearest healthy region.
 
-**Endpoint**: `POST /router/auth/{operation}`
+**Endpoint**: `POST /router/{service}/{path}`
 
-**Operations**:
-- `/router/auth/sign-in`
-- `/router/auth/sign-up`
-- `/router/auth/token-refresh`
-- `/router/auth?info=true` (get routing decision without forwarding)
+`handleRouting()` treats `pathSegments[1]` (the first segment after `/router`) as the **literal deployed edge function name** and forwards to `/functions/v1/{service}/{path}` — it does not split a generic `auth` service from an operation name. `{service}` must therefore equal a real deployed function such as `regional-auth-sign-in`, not `auth`.
+
+**Worked example** — routing to the `regional-auth-sign-in` function:
+
+Request:
+```
+POST /router/regional-auth-sign-in
+```
+
+`pathSegments` = `['router', 'regional-auth-sign-in']`, so `service = 'regional-auth-sign-in'` and `servicePathSegments = []`. This resolves to the forwarded URL:
+```
+https://<selected-region>.functions.supabase.co/functions/v1/regional-auth-sign-in/
+```
+(the trailing slash comes from joining an empty `servicePathSegments` array; it's harmless since the `regional-auth-*` functions don't expect additional path segments.)
+
+**Operations** — the deployed function names to route to, since there is no generic `auth` service:
+- `POST /router/regional-auth-sign-in`
+- `POST /router/regional-auth-sign-up`
+- `POST /router/regional-auth-token-refresh`
+
+**Info endpoint** (get the routing decision without forwarding): triggered when `pathSegments[2] === 'info'` (i.e. a third path segment after `/router/{service}`) or when the query string includes `?info=true`, e.g.:
+```
+GET /router/regional-auth-sign-in/info
+GET /router/regional-auth-sign-in?info=true
+```
 
 **Request Headers**:
 - `cf-ipcountry`: Cloudflare country code (auto-detected)


### PR DESCRIPTION
## Summary

This PR bundles four related fixes/improvements into one branch and PR:

### 1. Eliminate stale closure between onChange and onSave in Customization Studio branding submit (#999)
- `useCustomizationStudio.ts`: `save()` now accepts an optional `CustomizationConfig` override (`save(next?: CustomizationConfig)`) and posts `next ?? config`, instead of always closing over the hook's last-rendered `config` state.
- `CustomizationStudio.tsx`: `handleBrandingSubmit` now builds the merged config once and passes it explicitly to both `onChange(next)` and `onSave(next)`, so the just-edited branding/features values are guaranteed to be included in the very first save request — no more relying on `onChange` + `onSave` batching order.
- The debounced auto-save timer inside `setConfig` was already correct (closes over `next` directly) and is unaffected by this change.

### 2. Instrument GitHubPushService's git object pipeline with structured logging and trace propagation (#996)
- Added a module-level `createLogger({ service: 'github-push' })` in `apps/backend/src/services/github-push.service.ts`.
- Added info-level stage entry/exit logs across the full pipeline: ref resolution, base commit read, blob-batch creation (including batch index, total batch count, and file counts), tree creation, commit creation, and branch ref update.
- Added an optional `traceId?: string` field on `GitHubPushRequest`; it's threaded through every log line and generated via `crypto.randomUUID()` when the caller doesn't supply one (so callers like `GitHubToVercelDeploymentService` can thread their own trace through).
- Wrapped the pipeline in a try/catch that logs failures at error level and rethrows the original error unchanged — all existing thrown error types/messages (`GitHubPushApiError`, `GitHubPushNetworkError`, etc.) are preserved.

### 3. Instrument GitHubAppAuthClient's installation token lifecycle with structured logging (#997)
- Added a module-level `createLogger({ service: 'github-app-auth' })` in `apps/backend/src/lib/github/app-auth.ts`.
- `getInstallationAuthContext()` now logs cache hits vs. forced/expiry-triggered refreshes, including `installationId` and the computed `isNearExpiry` outcome on every cache check.
- `requestWithInstallationAuth()` logs the 401 → `invalidateCachedToken()` → forced-refresh sequence as a single correlated warn-level event.
- Every `GitHubAppAuthError` thrown from `fetchInstallationToken()`/`buildHttpError()` is now logged with its `code`, `retryable`, and `status` fields via a shared `logAuthError` helper.
- No raw token value or signed JWT is ever logged — only metadata (installation ID, expiry outcome, error code). All existing thrown-error contracts are unchanged.

### 4. Reconcile Regional Router's documented path scheme with actual regional-auth function names (#998)
- Corrected `supabase/functions/README.md`'s Regional Router section: the router forwards `pathSegments[1]` verbatim as the deployed function name (`/functions/v1/{service}/{path}`) — there is no generic `auth` + `{operation}` split.
- Added a worked example tracing `POST /router/regional-auth-sign-in` through `handleRouting()`'s actual segment parsing to the resulting forwarded URL (including the trailing-slash artifact from an empty `servicePathSegments` join).
- Replaced the fictitious `/router/auth/sign-in`, `/router/auth/sign-up`, `/router/auth/token-refresh` operations with the real deployed routes (`regional-auth-sign-in`, `regional-auth-sign-up`, `regional-auth-token-refresh`).
- Corrected the info-endpoint example to match `pathSegments[2] === 'info'` parsing (a third path segment after `/router/{service}`, not after `/router/auth`).

## Test plan
- [ ] `pnpm test --filter=frontend -- CustomizationStudio` / `useCustomizationStudio`
- [ ] `pnpm test -- github-push.service`
- [ ] `pnpm test -- app-auth`
- [ ] `pnpm lint` / `pnpm typecheck`

Closes #999
Closes #996
Closes #997
Closes #998
