### PR TITLE
fix(webhook-dlq): prevent concurrent double-reprocessing across DLQ r…

### DIFF
--- a/apps/backend/src/lib/webhook-dlq/dead-letter-queue.ts
+++ b/apps/backend/src/lib/webhook-dlq/dead-letter-queue.ts
@@ -58,6 +58,12 @@ const store = new Map<string, DLQEntry>();
 /** Secondary index: stable dedup key → entry id (fixes #926). */
 const dedupIndex = new Map<string, string>();
 const circuitBreakers = new Map<string, CircuitBreakerState>();
+/**
+ * Tracks entry IDs that are currently being reprocessed by any path
+ * (reprocess() or scheduleRetry()). Guards against concurrent double-execution
+ * of the same entry's processor. Fixes #979.
+ */
+const inFlight = new Set<string>();
 
 let _stripeProcessor: ProcessorFn | null = null;
 let _githubProcessor: ProcessorFn | null = null;
@@ -188,11 +194,17 @@ export const webhookDLQ = {
             return { success: false, error: 'Entry already successfully reprocessed' };
         }
 
+        // Guard against concurrent double-reprocessing from any path (#979).
+        if (inFlight.has(id)) {
+            return { success: false, error: 'Entry is already being reprocessed' };
+        }
+
         const processor = entry.source === 'stripe' ? _stripeProcessor : _githubProcessor;
         if (!processor) {
             return { success: false, error: `No processor registered for source: ${entry.source}` };
         }
 
+        inFlight.add(id);
         try {
             await processor(entry);
             entry.reprocessedAt = new Date();
@@ -205,6 +217,8 @@ export const webhookDLQ = {
             entry.failureReason = err?.message ?? 'Reprocessing failed';
             store.set(id, entry);
             return { success: false, error: entry.failureReason };
+        } finally {
+            inFlight.delete(id);
         }
     },
 
@@ -257,6 +271,15 @@ export const webhookDLQ = {
                 return;
             }
 
+            // Guard against concurrent double-reprocessing (#979).
+            // If reprocess() or another scheduleRetry() iteration has this
+            // entry in-flight, skip this attempt to avoid double-execution.
+            if (inFlight.has(id)) {
+                console.warn('[DLQ] scheduleRetry: entry already in-flight, skipping attempt', { id, attempt });
+                continue;
+            }
+
+            inFlight.add(id);
             try {
                 await processor(afterSleep);
                 afterSleep.reprocessedAt = new Date();
@@ -287,6 +310,8 @@ export const webhookDLQ = {
                     error: afterSleep.failureReason,
                     timestamp: new Date().toISOString(),
                 });
+            } finally {
+                inFlight.delete(id);
             }
         }
 
@@ -319,7 +344,16 @@ export const webhookDLQ = {
         store.clear();
         dedupIndex.clear();
         circuitBreakers.clear();
+        inFlight.clear();
         _stripeProcessor = null;
         _githubProcessor = null;
+    },
+
+    /**
+     * Read-only view of entry IDs currently being reprocessed.
+     * Used by DLQAutoRecovery.processDue() to skip in-flight entries (#979).
+     */
+    get inFlight(): ReadonlySet<string> {
+        return inFlight;
     },
 };

--- a/apps/backend/src/lib/webhook-dlq/dlq-auto-recovery.ts
+++ b/apps/backend/src/lib/webhook-dlq/dlq-auto-recovery.ts
@@ -78,7 +78,15 @@ export class DLQAutoRecovery {
      * Exposed for direct invocation in tests / cron jobs.
      */
     async processDue(): Promise<void> {
-        const pending = webhookDLQ.list().filter((e) => e.reprocessStatus === 'pending');
+        const pending = webhookDLQ
+            .list()
+            .filter(
+                (e) =>
+                    e.reprocessStatus === 'pending' &&
+                    // Skip entries already being retried by scheduleRetry() or a
+                    // concurrent processDue() invocation to prevent double-execution (#979).
+                    !webhookDLQ.inFlight.has(e.id),
+            );
 
         await Promise.all(pending.map((entry) => this._processEntry(entry)));
     }


### PR DESCRIPTION
  PR Description:
  
  ## Overview
  
  Closes #979
  
  Eliminates a race condition where two independent retry mechanisms —
  `webhookDLQ.scheduleRetry()` and `DLQAutoRecovery.processDue()` — could
  simultaneously invoke the registered processor for the same DLQ entry,
  causing duplicate side effects such as replaying a Stripe payment or
  GitHub webhook event twice.
  
  ---
  
  ## Problem
  
  `scheduleRetry()` runs its own sleep-and-retry loop. While it is sleeping
  between attempts, the entry's `reprocessStatus` remains `'pending'`.
  `DLQAutoRecovery.processDue()` independently polls `webhookDLQ.list()`
  every `pollIntervalMs` and dispatches every entry with
  `reprocessStatus === 'pending'` — with no awareness that `scheduleRetry()`
  already has that entry mid-flight. Both paths then call
  `webhookDLQ.reprocess(entry.id)` concurrently, executing the processor
  twice for the same event.
  
  ---
  
  ## Solution
  
  Introduced a module-level `inFlight: Set<string>` inside `webhookDLQ` that
  acts as a mutex — an entry's ID is present in the set for the entire
  duration its processor is executing, and removed unconditionally in a
  `finally` block.
  
  The guard is applied at three layers (defence-in-depth):
  
  1. **`webhookDLQ.reprocess()`** — innermost gate. Returns a no-op error
     immediately if the ID is already in `inFlight`. This is the last line of
     defence regardless of which caller reaches it.
  
  2. **`webhookDLQ.scheduleRetry()`** — checks `inFlight` after each backoff
     sleep, before touching the processor. If another path grabbed the lock,
     the current iteration is skipped with a warning log rather than
     double-firing.
  
  3. **`DLQAutoRecovery.processDue()`** — filters out any entry present in
     `webhookDLQ.inFlight` before building the batch, so it never even
     dispatches `_processEntry` for an already-running entry.
  
  ---
  
  ## Files Changed
  
  ### `apps/backend/src/lib/webhook-dlq/dead-letter-queue.ts`
  - Added `const inFlight = new Set<string>()` at module scope.
  - `reprocess()`: early return `{ success: false, error: 'Entry is already
    being reprocessed' }` when `inFlight.has(id)`; wraps processor call in
    `inFlight.add(id)` / `finally { inFlight.delete(id) }`.
  - `scheduleRetry()`: per-iteration `inFlight` check after sleep; processor
    call wrapped in `try/finally` with `inFlight.add/delete`.
  - `_reset()`: now calls `inFlight.clear()` to prevent test state leakage.
  - Added `get inFlight(): ReadonlySet<string>` getter — exposes a read-only
    view for `DLQAutoRecovery` without allowing external mutation.
  
  ### `apps/backend/src/lib/webhook-dlq/dlq-auto-recovery.ts`
  - `processDue()` filter updated from:
    ```ts
    .filter((e) => e.reprocessStatus === 'pending')
  
    to:
  
    .filter(
      (e) =>
        e.reprocessStatus === 'pending' &&
        !webhookDLQ.inFlight.has(e.id),
    )
  
  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  
  What Is Not Changed
  
  - Circuit-breaker logic in both scheduleRetry() and
  
    DLQAutoRecovery._processEntry() is fully preserved.
  
  - Retry schedule (1 min → 2 min → 4 min → 8 min → 16 min → 32 min →
  
    permanent failure) is unchanged.
  
  - All existing public API surface of webhookDLQ is backward-compatible.
  
  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  
  How to Verify
  
  Run the existing test suite against the two modified modules:
  
  pnpm test --filter=backend -- dead-letter-queue dlq-auto-recovery
  
  To fully validate the race fix, a concurrent test should:
  
  1. Register a mocked processor that records its call count.
  2. Call webhookDLQ.scheduleRetry(id) and
  
     DLQAutoRecovery.processDue() concurrently against the same entry ID.
  
  3. Assert the processor was called exactly once.
  
  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  
  Checklist
  
  - [x] pnpm lint — no errors on modified files
  - [x] pnpm typecheck — zero new errors introduced
  - [x] Circuit-breaker behaviour preserved in both retry paths
  - [x] _reset() clears inFlight for clean test isolation between runs
  - [x] No live HTTP calls required to reproduce or test the fix
  
