### PR TITLE
fix(backend): DLQ improvements and service unit test coverage

### DIFF
--- a/apps/backend/src/lib/webhook-dlq/dead-letter-queue.test.ts
+++ b/apps/backend/src/lib/webhook-dlq/dead-letter-queue.test.ts
@@ -194,4 +194,15 @@ describe('webhookDLQ.capture()', () => {
         const entry = webhookDLQ.capture('github', 'push', '{}', 'err', 1, 'https://ep.example.com');
         expect(webhookDLQ.get(entry.id)?.endpointUrl).toBe('https://ep.example.com');
     });
+
+    it('generates unique collision-resistant IDs across a large batch of rapidly-generated entries', () => {
+        const count = 1000;
+        const ids = new Set<string>();
+        for (let i = 0; i < count; i++) {
+            const entry = webhookDLQ.capture('stripe', `event.${i}`, `{"payload":${i}}`, 'err', 0);
+            expect(entry.id).toMatch(/^dlq_\d+_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i);
+            ids.add(entry.id);
+        }
+        expect(ids.size).toBe(count);
+    });
 });

--- a/apps/backend/src/lib/webhook-dlq/dead-letter-queue.test.ts
+++ b/apps/backend/src/lib/webhook-dlq/dead-letter-queue.test.ts
@@ -206,3 +206,69 @@ describe('webhookDLQ.capture()', () => {
         expect(ids.size).toBe(count);
     });
 });
+
+describe('webhookDLQ dedup index pruning', () => {
+    it('prunes dedupIndex entry when reprocess() succeeds', async () => {
+        webhookDLQ.registerProcessor('stripe', vi.fn().mockResolvedValue(undefined));
+
+        const entry = webhookDLQ.capture('stripe', 'payment_intent.succeeded', '{"id":"pi_1"}', 'err', 1);
+        expect(webhookDLQ._dedupIndexSize()).toBe(1);
+
+        const result = await webhookDLQ.reprocess(entry.id);
+        expect(result.success).toBe(true);
+        expect(webhookDLQ._dedupIndexSize()).toBe(0);
+    });
+
+    it('prunes dedupIndex entry when scheduleRetry() succeeds', async () => {
+        webhookDLQ.registerProcessor('github', vi.fn().mockResolvedValue(undefined));
+
+        const entry = webhookDLQ.capture('github', 'push', '{"ref":"main"}', 'timeout', 1);
+        expect(webhookDLQ._dedupIndexSize()).toBe(1);
+
+        await webhookDLQ.scheduleRetry(entry.id);
+        expect(webhookDLQ.get(entry.id)?.reprocessStatus).toBe('succeeded');
+        expect(webhookDLQ._dedupIndexSize()).toBe(0);
+    });
+
+    it('retains dedupIndex entry when reprocessing fails so duplicates still merge', async () => {
+        webhookDLQ.registerProcessor('stripe', vi.fn().mockRejectedValue(new Error('fail')));
+
+        const entry1 = webhookDLQ.capture('stripe', 'charge.failed', '{"id":"ch_1"}', 'initial err', 1);
+        expect(webhookDLQ._dedupIndexSize()).toBe(1);
+
+        const result = await webhookDLQ.reprocess(entry1.id);
+        expect(result.success).toBe(false);
+        // dedupIndex should still contain the entry
+        expect(webhookDLQ._dedupIndexSize()).toBe(1);
+
+        // A duplicate capture merges into the existing entry
+        const entry2 = webhookDLQ.capture('stripe', 'charge.failed', '{"id":"ch_1"}', 'second err', 2);
+        expect(entry2.id).toBe(entry1.id);
+        expect(entry2.attempts).toBe(2);
+        expect(entry2.failureReason).toBe('second err');
+        expect(webhookDLQ._dedupIndexSize()).toBe(1);
+    });
+
+    it('does not grow dedupIndex unboundedly across many capture -> succeed cycles', async () => {
+        webhookDLQ.registerProcessor('stripe', vi.fn().mockResolvedValue(undefined));
+
+        const totalCycles = 100;
+        for (let i = 0; i < totalCycles; i++) {
+            const entry = webhookDLQ.capture('stripe', `event.${i}`, `{"payload":${i}}`, 'err', 1);
+            expect(webhookDLQ._dedupIndexSize()).toBe(1);
+            await webhookDLQ.reprocess(entry.id);
+            expect(webhookDLQ._dedupIndexSize()).toBe(0);
+        }
+
+        expect(webhookDLQ._dedupIndexSize()).toBe(0);
+    });
+
+    it('_reset() clears dedupIndex completely', () => {
+        webhookDLQ.capture('stripe', 'e1', '{"a":1}', 'err', 1);
+        webhookDLQ.capture('stripe', 'e2', '{"a":2}', 'err', 1);
+        expect(webhookDLQ._dedupIndexSize()).toBe(2);
+
+        webhookDLQ._reset();
+        expect(webhookDLQ._dedupIndexSize()).toBe(0);
+    });
+});

--- a/apps/backend/src/lib/webhook-dlq/dead-letter-queue.ts
+++ b/apps/backend/src/lib/webhook-dlq/dead-letter-queue.ts
@@ -16,6 +16,7 @@
  * to that endpoint are paused for 1 hour.
  */
 
+import { randomUUID } from 'crypto';
 import { calculateBackoffDelay, sleep } from '../retry/exponential-backoff';
 
 export type WebhookSource = 'stripe' | 'github';
@@ -69,7 +70,7 @@ let _stripeProcessor: ProcessorFn | null = null;
 let _githubProcessor: ProcessorFn | null = null;
 
 function generateId(): string {
-    return `dlq_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`;
+    return `dlq_${Date.now()}_${randomUUID()}`;
 }
 
 /**

--- a/apps/backend/src/lib/webhook-dlq/dead-letter-queue.ts
+++ b/apps/backend/src/lib/webhook-dlq/dead-letter-queue.ts
@@ -211,6 +211,8 @@ export const webhookDLQ = {
             entry.reprocessedAt = new Date();
             entry.reprocessStatus = 'succeeded';
             store.set(id, entry);
+            const dedupKey = deriveDedupKey(entry.source, entry.eventType, entry.payload);
+            dedupIndex.delete(dedupKey);
             return { success: true };
         } catch (err: any) {
             entry.reprocessedAt = new Date();
@@ -287,6 +289,8 @@ export const webhookDLQ = {
                 afterSleep.reprocessStatus = 'succeeded';
                 afterSleep.attempts += 1;
                 store.set(id, afterSleep);
+                const dedupKey = deriveDedupKey(afterSleep.source, afterSleep.eventType, afterSleep.payload);
+                dedupIndex.delete(dedupKey);
                 if (endpoint !== null) recordSuccess(endpoint);
                 console.log('[DLQ] Retry audit', {
                     id,
@@ -333,6 +337,11 @@ export const webhookDLQ = {
 
     size(): number {
         return store.size;
+    },
+
+    /** Exposed for testing only. */
+    _dedupIndexSize(): number {
+        return dedupIndex.size;
     },
 
     /** Exposed for testing only. */

--- a/apps/backend/src/services/analytics-aggregation.service.test.ts
+++ b/apps/backend/src/services/analytics-aggregation.service.test.ts
@@ -1,0 +1,533 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { AnalyticsAggregationService, analyticsAggregationService } from './analytics-aggregation.service';
+
+const mockFrom = vi.fn();
+
+vi.mock('@/lib/supabase/server', () => ({
+    createClient: () => ({
+        from: mockFrom,
+    }),
+}));
+
+describe('AnalyticsAggregationService', () => {
+    let service: AnalyticsAggregationService;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        service = new AnalyticsAggregationService();
+    });
+
+    describe('aggregate() - Happy Paths', () => {
+        it('aggregates 1h raw analytics rows into buckets and advances cursor', async () => {
+            const cursorSelectChain = {
+                select: vi.fn().mockReturnThis(),
+                eq: vi.fn().mockReturnThis(),
+                single: vi.fn().mockResolvedValue({
+                    data: { last_run_at: '2024-01-15T10:00:00.000Z' },
+                    error: null,
+                }),
+            };
+
+            const rowsSelectChain = {
+                select: vi.fn().mockReturnThis(),
+                gte: vi.fn().mockReturnThis(),
+                lt: vi.fn().mockReturnThis(),
+                order: vi.fn().mockResolvedValue({
+                    data: [
+                        {
+                            deployment_id: 'dep-1',
+                            metric_type: 'page_views',
+                            metric_value: 10,
+                            recorded_at: '2024-01-15T10:15:00.000Z',
+                        },
+                        {
+                            deployment_id: 'dep-1',
+                            metric_type: 'page_views',
+                            metric_value: 15,
+                            recorded_at: '2024-01-15T10:45:00.000Z',
+                        },
+                        {
+                            deployment_id: 'dep-1',
+                            metric_type: 'uptime_check',
+                            metric_value: 1,
+                            recorded_at: '2024-01-15T10:20:00.000Z',
+                        },
+                        {
+                            deployment_id: 'dep-1',
+                            metric_type: 'uptime_check',
+                            metric_value: 0,
+                            recorded_at: '2024-01-15T10:50:00.000Z',
+                        },
+                        {
+                            deployment_id: 'dep-2',
+                            metric_type: 'page_views',
+                            metric_value: 5,
+                            recorded_at: '2024-01-15T10:30:00.000Z',
+                        },
+                    ],
+                    error: null,
+                }),
+            };
+
+            const upsertChain = {
+                upsert: vi.fn().mockResolvedValue({ error: null }),
+            };
+
+            const updateCursorChain = {
+                update: vi.fn().mockReturnThis(),
+                eq: vi.fn().mockResolvedValue({ error: null }),
+            };
+
+            mockFrom.mockImplementation((table: string) => {
+                if (table === 'rollup_cursors') {
+                    return {
+                        ...cursorSelectChain,
+                        ...updateCursorChain,
+                    };
+                }
+                if (table === 'deployment_analytics') {
+                    return rowsSelectChain;
+                }
+                if (table === 'analytics_rollups') {
+                    return upsertChain;
+                }
+                throw new Error(`Unexpected table: ${table}`);
+            });
+
+            const result = await service.aggregate('1h');
+
+            expect(result).toEqual({ bucketsWritten: 3 });
+
+            // Verify rollup_cursors query
+            expect(mockFrom).toHaveBeenCalledWith('rollup_cursors');
+            expect(cursorSelectChain.select).toHaveBeenCalledWith('last_run_at');
+            expect(cursorSelectChain.eq).toHaveBeenCalledWith('granularity', '1h');
+
+            // Verify deployment_analytics query
+            expect(mockFrom).toHaveBeenCalledWith('deployment_analytics');
+            expect(rowsSelectChain.select).toHaveBeenCalledWith(
+                'deployment_id, metric_type, metric_value, recorded_at'
+            );
+            expect(rowsSelectChain.gte).toHaveBeenCalledWith(
+                'recorded_at',
+                '2024-01-15T10:00:00.000Z'
+            );
+
+            // Verify analytics_rollups upsert payload
+            expect(mockFrom).toHaveBeenCalledWith('analytics_rollups');
+            expect(upsertChain.upsert).toHaveBeenCalledTimes(1);
+            const [upsertRows, upsertOptions] = upsertChain.upsert.mock.calls[0];
+
+            expect(upsertOptions).toEqual({
+                onConflict: 'deployment_id,metric_type,granularity,bucket_start',
+            });
+
+            expect(upsertRows).toHaveLength(3);
+
+            const dep1PageView = upsertRows.find(
+                (r: any) => r.deployment_id === 'dep-1' && r.metric_type === 'page_views'
+            );
+            expect(dep1PageView).toBeDefined();
+            expect(dep1PageView.total_value).toBe(25);
+            expect(dep1PageView.record_count).toBe(2);
+            expect(dep1PageView.up_count).toBe(0);
+            expect(dep1PageView.granularity).toBe('1h');
+            expect(dep1PageView.bucket_start).toBe('2024-01-15T10:00:00.000Z');
+
+            const dep1Uptime = upsertRows.find(
+                (r: any) => r.deployment_id === 'dep-1' && r.metric_type === 'uptime_check'
+            );
+            expect(dep1Uptime).toBeDefined();
+            expect(dep1Uptime.total_value).toBe(1);
+            expect(dep1Uptime.record_count).toBe(2);
+            expect(dep1Uptime.up_count).toBe(1);
+
+            const dep2PageView = upsertRows.find(
+                (r: any) => r.deployment_id === 'dep-2' && r.metric_type === 'page_views'
+            );
+            expect(dep2PageView).toBeDefined();
+            expect(dep2PageView.total_value).toBe(5);
+            expect(dep2PageView.record_count).toBe(1);
+
+            // Verify cursor updated
+            expect(updateCursorChain.update).toHaveBeenCalledWith(
+                expect.objectContaining({ last_run_at: expect.any(String) })
+            );
+            expect(updateCursorChain.eq).toHaveBeenCalledWith('granularity', '1h');
+        });
+
+        it('aggregates 24h granularity correctly over full day buckets', async () => {
+            const cursorSelectChain = {
+                select: vi.fn().mockReturnThis(),
+                eq: vi.fn().mockReturnThis(),
+                single: vi.fn().mockResolvedValue({
+                    data: { last_run_at: '2024-01-15T00:00:00.000Z' },
+                    error: null,
+                }),
+            };
+
+            const rowsSelectChain = {
+                select: vi.fn().mockReturnThis(),
+                gte: vi.fn().mockReturnThis(),
+                lt: vi.fn().mockReturnThis(),
+                order: vi.fn().mockResolvedValue({
+                    data: [
+                        {
+                            deployment_id: 'dep-1',
+                            metric_type: 'requests',
+                            metric_value: 100,
+                            recorded_at: '2024-01-15T02:00:00.000Z',
+                        },
+                        {
+                            deployment_id: 'dep-1',
+                            metric_type: 'requests',
+                            metric_value: 200,
+                            recorded_at: '2024-01-15T22:30:00.000Z',
+                        },
+                    ],
+                    error: null,
+                }),
+            };
+
+            const upsertChain = {
+                upsert: vi.fn().mockResolvedValue({ error: null }),
+            };
+
+            const updateCursorChain = {
+                update: vi.fn().mockReturnThis(),
+                eq: vi.fn().mockResolvedValue({ error: null }),
+            };
+
+            mockFrom.mockImplementation((table: string) => {
+                if (table === 'rollup_cursors') {
+                    return { ...cursorSelectChain, ...updateCursorChain };
+                }
+                if (table === 'deployment_analytics') return rowsSelectChain;
+                if (table === 'analytics_rollups') return upsertChain;
+                throw new Error(`Unexpected table: ${table}`);
+            });
+
+            const result = await service.aggregate('24h');
+
+            expect(result).toEqual({ bucketsWritten: 1 });
+            const [upsertRows] = upsertChain.upsert.mock.calls[0];
+            expect(upsertRows[0].granularity).toBe('24h');
+            expect(upsertRows[0].bucket_start).toBe('2024-01-15T00:00:00.000Z');
+            expect(upsertRows[0].total_value).toBe(300);
+            expect(upsertRows[0].record_count).toBe(2);
+        });
+    });
+
+    describe('Bucket Boundary Edge Cases', () => {
+        it('correctly categorizes timestamps exactly on, before, and after bucket boundaries', async () => {
+            const cursorSelectChain = {
+                select: vi.fn().mockReturnThis(),
+                eq: vi.fn().mockReturnThis(),
+                single: vi.fn().mockResolvedValue({
+                    data: { last_run_at: '2024-01-15T00:00:00.000Z' },
+                    error: null,
+                }),
+            };
+
+            const rowsSelectChain = {
+                select: vi.fn().mockReturnThis(),
+                gte: vi.fn().mockReturnThis(),
+                lt: vi.fn().mockReturnThis(),
+                order: vi.fn().mockResolvedValue({
+                    data: [
+                        // 1 millisecond before 01:00 -> belongs to 00:00 bucket
+                        {
+                            deployment_id: 'dep-boundary',
+                            metric_type: 'event',
+                            metric_value: 1,
+                            recorded_at: '2024-01-15T00:59:59.999Z',
+                        },
+                        // Exactly on 01:00:00.000 -> belongs to 01:00 bucket
+                        {
+                            deployment_id: 'dep-boundary',
+                            metric_type: 'event',
+                            metric_value: 2,
+                            recorded_at: '2024-01-15T01:00:00.000Z',
+                        },
+                        // 1 millisecond after 01:00 -> belongs to 01:00 bucket
+                        {
+                            deployment_id: 'dep-boundary',
+                            metric_type: 'event',
+                            metric_value: 4,
+                            recorded_at: '2024-01-15T01:00:00.001Z',
+                        },
+                    ],
+                    error: null,
+                }),
+            };
+
+            const upsertChain = {
+                upsert: vi.fn().mockResolvedValue({ error: null }),
+            };
+
+            const updateCursorChain = {
+                update: vi.fn().mockReturnThis(),
+                eq: vi.fn().mockResolvedValue({ error: null }),
+            };
+
+            mockFrom.mockImplementation((table: string) => {
+                if (table === 'rollup_cursors') {
+                    return { ...cursorSelectChain, ...updateCursorChain };
+                }
+                if (table === 'deployment_analytics') return rowsSelectChain;
+                if (table === 'analytics_rollups') return upsertChain;
+                throw new Error(`Unexpected table: ${table}`);
+            });
+
+            const result = await service.aggregate('1h');
+
+            expect(result).toEqual({ bucketsWritten: 2 });
+            const [upsertRows] = upsertChain.upsert.mock.calls[0];
+
+            const bucket0 = upsertRows.find((r: any) => r.bucket_start === '2024-01-15T00:00:00.000Z');
+            const bucket1 = upsertRows.find((r: any) => r.bucket_start === '2024-01-15T01:00:00.000Z');
+
+            expect(bucket0).toBeDefined();
+            expect(bucket0.total_value).toBe(1);
+            expect(bucket0.record_count).toBe(1);
+
+            expect(bucket1).toBeDefined();
+            expect(bucket1.total_value).toBe(6);
+            expect(bucket1.record_count).toBe(2);
+        });
+    });
+
+    describe('Empty Input Handling', () => {
+        it('returns bucketsWritten: 0 and does not upsert or advance cursor when no rows exist', async () => {
+            const cursorSelectChain = {
+                select: vi.fn().mockReturnThis(),
+                eq: vi.fn().mockReturnThis(),
+                single: vi.fn().mockResolvedValue({
+                    data: { last_run_at: '2024-01-15T00:00:00.000Z' },
+                    error: null,
+                }),
+            };
+
+            const rowsSelectChain = {
+                select: vi.fn().mockReturnThis(),
+                gte: vi.fn().mockReturnThis(),
+                lt: vi.fn().mockReturnThis(),
+                order: vi.fn().mockResolvedValue({
+                    data: [],
+                    error: null,
+                }),
+            };
+
+            const upsertChain = {
+                upsert: vi.fn().mockResolvedValue({ error: null }),
+            };
+
+            const updateCursorChain = {
+                update: vi.fn().mockReturnThis(),
+                eq: vi.fn().mockResolvedValue({ error: null }),
+            };
+
+            mockFrom.mockImplementation((table: string) => {
+                if (table === 'rollup_cursors') {
+                    return { ...cursorSelectChain, ...updateCursorChain };
+                }
+                if (table === 'deployment_analytics') return rowsSelectChain;
+                if (table === 'analytics_rollups') return upsertChain;
+                throw new Error(`Unexpected table: ${table}`);
+            });
+
+            const result = await service.aggregate('1h');
+
+            expect(result).toEqual({ bucketsWritten: 0 });
+            expect(upsertChain.upsert).not.toHaveBeenCalled();
+            expect(updateCursorChain.update).not.toHaveBeenCalled();
+        });
+
+        it('returns bucketsWritten: 0 when rows is null', async () => {
+            const cursorSelectChain = {
+                select: vi.fn().mockReturnThis(),
+                eq: vi.fn().mockReturnThis(),
+                single: vi.fn().mockResolvedValue({
+                    data: { last_run_at: '2024-01-15T00:00:00.000Z' },
+                    error: null,
+                }),
+            };
+
+            const rowsSelectChain = {
+                select: vi.fn().mockReturnThis(),
+                gte: vi.fn().mockReturnThis(),
+                lt: vi.fn().mockReturnThis(),
+                order: vi.fn().mockResolvedValue({
+                    data: null,
+                    error: null,
+                }),
+            };
+
+            const upsertChain = {
+                upsert: vi.fn().mockResolvedValue({ error: null }),
+            };
+
+            mockFrom.mockImplementation((table: string) => {
+                if (table === 'rollup_cursors') return cursorSelectChain;
+                if (table === 'deployment_analytics') return rowsSelectChain;
+                if (table === 'analytics_rollups') return upsertChain;
+                throw new Error(`Unexpected table: ${table}`);
+            });
+
+            const result = await service.aggregate('1h');
+            expect(result).toEqual({ bucketsWritten: 0 });
+            expect(upsertChain.upsert).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('Error Propagation', () => {
+        it('throws error when reading rollup cursor fails', async () => {
+            mockFrom.mockReturnValue({
+                select: vi.fn().mockReturnThis(),
+                eq: vi.fn().mockReturnThis(),
+                single: vi.fn().mockResolvedValue({
+                    data: null,
+                    error: { message: 'relation rollup_cursors does not exist' },
+                }),
+            });
+
+            await expect(service.aggregate('1h')).rejects.toThrow(
+                'Failed to read rollup cursor: relation rollup_cursors does not exist'
+            );
+        });
+
+        it('throws error when fetching deployment analytics rows fails', async () => {
+            const cursorSelectChain = {
+                select: vi.fn().mockReturnThis(),
+                eq: vi.fn().mockReturnThis(),
+                single: vi.fn().mockResolvedValue({
+                    data: { last_run_at: '2024-01-15T00:00:00.000Z' },
+                    error: null,
+                }),
+            };
+
+            const rowsSelectChain = {
+                select: vi.fn().mockReturnThis(),
+                gte: vi.fn().mockReturnThis(),
+                lt: vi.fn().mockReturnThis(),
+                order: vi.fn().mockResolvedValue({
+                    data: null,
+                    error: { message: 'connection timeout' },
+                }),
+            };
+
+            mockFrom.mockImplementation((table: string) => {
+                if (table === 'rollup_cursors') return cursorSelectChain;
+                if (table === 'deployment_analytics') return rowsSelectChain;
+                throw new Error(`Unexpected table: ${table}`);
+            });
+
+            await expect(service.aggregate('1h')).rejects.toThrow(
+                'Failed to fetch analytics rows: connection timeout'
+            );
+        });
+
+        it('throws error when upserting rollups fails', async () => {
+            const cursorSelectChain = {
+                select: vi.fn().mockReturnThis(),
+                eq: vi.fn().mockReturnThis(),
+                single: vi.fn().mockResolvedValue({
+                    data: { last_run_at: '2024-01-15T00:00:00.000Z' },
+                    error: null,
+                }),
+            };
+
+            const rowsSelectChain = {
+                select: vi.fn().mockReturnThis(),
+                gte: vi.fn().mockReturnThis(),
+                lt: vi.fn().mockReturnThis(),
+                order: vi.fn().mockResolvedValue({
+                    data: [
+                        {
+                            deployment_id: 'dep-1',
+                            metric_type: 'p95',
+                            metric_value: 42,
+                            recorded_at: '2024-01-15T00:10:00.000Z',
+                        },
+                    ],
+                    error: null,
+                }),
+            };
+
+            const upsertChain = {
+                upsert: vi.fn().mockResolvedValue({
+                    error: { message: 'unique constraint violation' },
+                }),
+            };
+
+            mockFrom.mockImplementation((table: string) => {
+                if (table === 'rollup_cursors') return cursorSelectChain;
+                if (table === 'deployment_analytics') return rowsSelectChain;
+                if (table === 'analytics_rollups') return upsertChain;
+                throw new Error(`Unexpected table: ${table}`);
+            });
+
+            await expect(service.aggregate('1h')).rejects.toThrow(
+                'Failed to upsert rollups: unique constraint violation'
+            );
+        });
+
+        it('throws error when advancing rollup cursor fails', async () => {
+            const cursorSelectChain = {
+                select: vi.fn().mockReturnThis(),
+                eq: vi.fn().mockReturnThis(),
+                single: vi.fn().mockResolvedValue({
+                    data: { last_run_at: '2024-01-15T00:00:00.000Z' },
+                    error: null,
+                }),
+            };
+
+            const rowsSelectChain = {
+                select: vi.fn().mockReturnThis(),
+                gte: vi.fn().mockReturnThis(),
+                lt: vi.fn().mockReturnThis(),
+                order: vi.fn().mockResolvedValue({
+                    data: [
+                        {
+                            deployment_id: 'dep-1',
+                            metric_type: 'p95',
+                            metric_value: 42,
+                            recorded_at: '2024-01-15T00:10:00.000Z',
+                        },
+                    ],
+                    error: null,
+                }),
+            };
+
+            const upsertChain = {
+                upsert: vi.fn().mockResolvedValue({ error: null }),
+            };
+
+            const updateCursorChain = {
+                update: vi.fn().mockReturnThis(),
+                eq: vi.fn().mockResolvedValue({
+                    error: { message: 'database locked' },
+                }),
+            };
+
+            mockFrom.mockImplementation((table: string) => {
+                if (table === 'rollup_cursors') {
+                    return { ...cursorSelectChain, ...updateCursorChain };
+                }
+                if (table === 'deployment_analytics') return rowsSelectChain;
+                if (table === 'analytics_rollups') return upsertChain;
+                throw new Error(`Unexpected table: ${table}`);
+            });
+
+            await expect(service.aggregate('1h')).rejects.toThrow(
+                'Failed to advance rollup cursor: database locked'
+            );
+        });
+    });
+
+    describe('Singleton export', () => {
+        it('exports a singleton instance of AnalyticsAggregationService', () => {
+            expect(analyticsAggregationService).toBeInstanceOf(AnalyticsAggregationService);
+        });
+    });
+});

--- a/apps/backend/src/services/artifact-signing.service.test.ts
+++ b/apps/backend/src/services/artifact-signing.service.test.ts
@@ -1,0 +1,245 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { ArtifactSigningService, artifactSigningService } from './artifact-signing.service';
+
+describe('ArtifactSigningService', () => {
+    const PRIMARY_SECRET = 'primary-secret-key-1234567890';
+    const OLD_SECRET_1 = 'old-secret-key-alpha-987654321';
+    const OLD_SECRET_2 = 'old-secret-key-beta-1122334455';
+    let service: ArtifactSigningService;
+    const originalEnv = process.env;
+
+    beforeEach(() => {
+        process.env = { ...originalEnv };
+        process.env.ARTIFACT_SIGNING_SECRET = PRIMARY_SECRET;
+        delete process.env.ARTIFACT_SIGNING_SECRET_PREVIOUS;
+        service = new ArtifactSigningService();
+    });
+
+    afterEach(() => {
+        process.env = originalEnv;
+    });
+
+    describe('signArtifact()', () => {
+        it('signs a Buffer payload and returns valid checksum and HMAC signature', () => {
+            const payload = Buffer.from('console.log("hello world");', 'utf8');
+            const result = service.signArtifact(payload);
+
+            expect(result.checksum).toMatch(/^sha256:[a-f0-9]{64}$/);
+            expect(result.signature).toMatch(/^[a-f0-9]{64}$/);
+        });
+
+        it('signs a string payload and returns consistent result with Buffer input', () => {
+            const strPayload = 'export const config = { enabled: true };';
+            const bufPayload = Buffer.from(strPayload, 'utf8');
+
+            const resultFromStr = service.signArtifact(strPayload);
+            const resultFromBuf = service.signArtifact(bufPayload);
+
+            expect(resultFromStr.checksum).toBe(resultFromBuf.checksum);
+            expect(resultFromStr.signature).toBe(resultFromBuf.signature);
+        });
+
+        it('produces deterministic output for identical input', () => {
+            const payload = 'consistent-build-artifact-content';
+            const sign1 = service.signArtifact(payload);
+            const sign2 = service.signArtifact(payload);
+
+            expect(sign1.checksum).toBe(sign2.checksum);
+            expect(sign1.signature).toBe(sign2.signature);
+        });
+
+        it('produces distinct checksums and signatures for different payloads', () => {
+            const sign1 = service.signArtifact('artifact-v1');
+            const sign2 = service.signArtifact('artifact-v2');
+
+            expect(sign1.checksum).not.toBe(sign2.checksum);
+            expect(sign1.signature).not.toBe(sign2.signature);
+        });
+
+        it('throws an error if ARTIFACT_SIGNING_SECRET is not configured', () => {
+            delete process.env.ARTIFACT_SIGNING_SECRET;
+
+            expect(() => service.signArtifact('test-payload')).toThrow(
+                'ARTIFACT_SIGNING_SECRET environment variable is not set'
+            );
+        });
+    });
+
+    describe('verifyArtifact() - Happy Path', () => {
+        it('verifies a valid artifact buffer against its signed checksum and signature', () => {
+            const payload = Buffer.from('valid-production-build-data');
+            const { checksum, signature } = service.signArtifact(payload);
+
+            const isValid = service.verifyArtifact(payload, checksum, signature);
+            expect(isValid).toBe(true);
+        });
+
+        it('verifies a valid artifact string against its signed checksum and signature', () => {
+            const payload = 'valid-production-build-string';
+            const { checksum, signature } = service.signArtifact(payload);
+
+            const isValid = service.verifyArtifact(payload, checksum, signature);
+            expect(isValid).toBe(true);
+        });
+    });
+
+    describe('verifyArtifact() - Tampered and Mismatched Payloads (Fail Closed)', () => {
+        it('fails verification when payload is modified (tampered byte)', () => {
+            const originalPayload = Buffer.from('original-unaltered-code');
+            const { checksum, signature } = service.signArtifact(originalPayload);
+
+            const tamperedPayload = Buffer.from('original-altered--code');
+
+            const isValid = service.verifyArtifact(tamperedPayload, checksum, signature);
+            expect(isValid).toBe(false);
+        });
+
+        it('fails verification when payload has appended content', () => {
+            const originalPayload = 'clean code';
+            const { checksum, signature } = service.signArtifact(originalPayload);
+
+            const tamperedPayload = 'clean code; maliciousCode();';
+
+            const isValid = service.verifyArtifact(tamperedPayload, checksum, signature);
+            expect(isValid).toBe(false);
+        });
+
+        it('fails verification when checksum does not match payload', () => {
+            const payload = 'sample code';
+            const { signature } = service.signArtifact(payload);
+            const incorrectChecksum = 'sha256:' + '0'.repeat(64);
+
+            const isValid = service.verifyArtifact(payload, incorrectChecksum, signature);
+            expect(isValid).toBe(false);
+        });
+
+        it('fails verification when signature does not match checksum', () => {
+            const payload = 'sample code';
+            const { checksum } = service.signArtifact(payload);
+            const incorrectSignature = 'f'.repeat(64);
+
+            const isValid = service.verifyArtifact(payload, checksum, incorrectSignature);
+            expect(isValid).toBe(false);
+        });
+    });
+
+    describe('verifyArtifact() - Malformed Inputs (Fail Closed without crashing)', () => {
+        it('returns false when signature is an empty string or malformed length', () => {
+            const payload = 'sample code';
+            const { checksum } = service.signArtifact(payload);
+
+            expect(service.verifyArtifact(payload, checksum, '')).toBe(false);
+            expect(service.verifyArtifact(payload, checksum, 'short-sig')).toBe(false);
+            expect(service.verifyArtifact(payload, checksum, '12345')).toBe(false);
+        });
+
+        it('returns false when checksum is malformed or invalid format', () => {
+            const payload = 'sample code';
+            const { signature } = service.signArtifact(payload);
+
+            expect(service.verifyArtifact(payload, '', signature)).toBe(false);
+            expect(service.verifyArtifact(payload, 'not-a-valid-checksum', signature)).toBe(false);
+            expect(service.verifyArtifact(payload, 'md5:1234', signature)).toBe(false);
+        });
+
+        it('returns false when ARTIFACT_SIGNING_SECRET is unset during verification', () => {
+            const payload = 'sample code';
+            const { checksum, signature } = service.signArtifact(payload);
+
+            delete process.env.ARTIFACT_SIGNING_SECRET;
+
+            const isValid = service.verifyArtifact(payload, checksum, signature);
+            expect(isValid).toBe(false);
+        });
+    });
+
+    describe('verifyArtifact() - Key Rotation Support', () => {
+        it('verifies signatures generated with previous secrets listed in ARTIFACT_SIGNING_SECRET_PREVIOUS', () => {
+            // Sign with OLD_SECRET_1
+            process.env.ARTIFACT_SIGNING_SECRET = OLD_SECRET_1;
+            const oldService = new ArtifactSigningService();
+            const payload = 'legacy-build-artifact';
+            const { checksum, signature } = oldService.signArtifact(payload);
+
+            // Now rotate to PRIMARY_SECRET, keeping OLD_SECRET_1 in previous secrets
+            process.env.ARTIFACT_SIGNING_SECRET = PRIMARY_SECRET;
+            process.env.ARTIFACT_SIGNING_SECRET_PREVIOUS = `${OLD_SECRET_1}, ${OLD_SECRET_2}`;
+            const rotatedService = new ArtifactSigningService();
+
+            const isValid = rotatedService.verifyArtifact(payload, checksum, signature);
+            expect(isValid).toBe(true);
+        });
+
+        it('verifies signatures generated with second rotated secret in list', () => {
+            // Sign with OLD_SECRET_2
+            process.env.ARTIFACT_SIGNING_SECRET = OLD_SECRET_2;
+            const oldService = new ArtifactSigningService();
+            const payload = 'legacy-build-artifact-2';
+            const { checksum, signature } = oldService.signArtifact(payload);
+
+            // Now verify with rotated primary and multiple previous secrets
+            process.env.ARTIFACT_SIGNING_SECRET = PRIMARY_SECRET;
+            process.env.ARTIFACT_SIGNING_SECRET_PREVIOUS = `${OLD_SECRET_1}, ${OLD_SECRET_2}`;
+            const rotatedService = new ArtifactSigningService();
+
+            const isValid = rotatedService.verifyArtifact(payload, checksum, signature);
+            expect(isValid).toBe(true);
+        });
+
+        it('fails verification if artifact was signed with an old secret not present in ARTIFACT_SIGNING_SECRET_PREVIOUS', () => {
+            // Sign with an unlisted old secret
+            process.env.ARTIFACT_SIGNING_SECRET = 'unlisted-retired-secret';
+            const oldService = new ArtifactSigningService();
+            const payload = 'retired-build-artifact';
+            const { checksum, signature } = oldService.signArtifact(payload);
+
+            // Rotate without adding the unlisted secret
+            process.env.ARTIFACT_SIGNING_SECRET = PRIMARY_SECRET;
+            process.env.ARTIFACT_SIGNING_SECRET_PREVIOUS = `${OLD_SECRET_1}`;
+            const rotatedService = new ArtifactSigningService();
+
+            const isValid = rotatedService.verifyArtifact(payload, checksum, signature);
+            expect(isValid).toBe(false);
+        });
+    });
+
+    describe('validateStoragePath()', () => {
+        it('returns true for valid per-user storage paths', () => {
+            expect(service.validateStoragePath('user_123', 'user_123/deployments/dep_1/bundle.zip')).toBe(true);
+            expect(service.validateStoragePath('org_abc', 'org_abc/artifact.tar.gz')).toBe(true);
+        });
+
+        it('returns false for path traversal attempts escaping user namespace', () => {
+            expect(
+                service.validateStoragePath('user_123', 'user_123/../../other_user/deployments/bundle.zip')
+            ).toBe(false);
+            expect(
+                service.validateStoragePath('user_123', '../user_123/bundle.zip')
+            ).toBe(false);
+            expect(
+                service.validateStoragePath('user_123', 'user_123/sub/../../..')
+            ).toBe(false);
+        });
+
+        it('returns false when storagePath starts with a different user prefix', () => {
+            expect(
+                service.validateStoragePath('user_123', 'user_456/deployments/bundle.zip')
+            ).toBe(false);
+            expect(
+                service.validateStoragePath('user_123', 'user_123_extra/bundle.zip')
+            ).toBe(false);
+        });
+
+        it('returns false when userId or storagePath is empty', () => {
+            expect(service.validateStoragePath('', 'user_123/bundle.zip')).toBe(false);
+            expect(service.validateStoragePath('user_123', '')).toBe(false);
+            expect(service.validateStoragePath('', '')).toBe(false);
+        });
+    });
+
+    describe('Singleton export', () => {
+        it('exports a default singleton instance of ArtifactSigningService', () => {
+            expect(artifactSigningService).toBeInstanceOf(ArtifactSigningService);
+        });
+    });
+});


### PR DESCRIPTION
## Overview
This PR resolves four issues (#1071, #1072, #1073, and #1074) covering webhook Dead Letter Queue (DLQ) improvements and adding unit test coverage for backend services.

---

### #1071 — Strengthen Webhook DLQ Entry ID Generation Beyond Math.random Collision Risk
- **Problem**: `generateId()` in `dead-letter-queue.ts` previously built IDs using `Math.random()`, which was not collision-resistant or cryptographically secure under high failure volume in the same millisecond.
- **Fix**: Replaced the `Math.random()` suffix with `crypto.randomUUID()`, retaining the `dlq_` prefix for backwards compatibility and log grep-ability.
- **Tests**: Added batch collision regression tests in `dead-letter-queue.test.ts` verifying unique UUID format across large rapid generations.

Closes #1071

---

### #1072 — Prune the Webhook DLQ Dedup Index So Resolved Entries Do Not Leak Memory Forever
- **Problem**: `webhookDLQ.capture()` added distinct `(source, eventType, payload)` keys to `dedupIndex` and never removed them, even after an entry reached `reprocessStatus: 'succeeded'`, causing monotonic memory growth.
- **Fix**: Pruned `dedupIndex` upon successful reprocessing in both `reprocess()` and `scheduleRetry()`. Dedup merging for pending/failing entries remains intact.
- **Tests**: Added regression tests in `dead-letter-queue.test.ts` ensuring `dedupIndex` size does not grow unboundedly across capture→succeed cycles and that `_reset()` clears it fully.

Closes #1072

---

### #1073 — Engineer Unit Test Coverage for AnalyticsAggregationService Rollup Logic
- **Problem**: `AnalyticsAggregationService` had no co-located test suite to verify its time-series rollup math, bucket boundaries, or Supabase error propagation.
- **Fix**: Created `analytics-aggregation.service.test.ts` with comprehensive unit tests mocking the Supabase client.
- **Coverage**:
  - `1h` and `24h` rollups, bucket start calculation, aggregation of metric values, and `uptime_check` up-counts.
  - Bucket-boundary edge cases (timestamps exactly on, before, and after bucket boundaries).
  - Empty input handling (`[]` and `null`).
  - Error propagation on cursor read, data select, rollup upsert, and cursor update failures.

Closes #1073

---

### #1074 — Engineer Unit Test Coverage for ArtifactSigningService Signature Verification
- **Problem**: `ArtifactSigningService` lacked isolated unit tests for its signing, HMAC verification, tampered payload defense, and path traversal validation.
- **Fix**: Created `artifact-signing.service.test.ts` with thorough unit tests independent of integration tests.
- **Coverage**:
  - `signArtifact` with Buffer and string inputs, verifying deterministic output and format (`sha256:` prefix and 64-char hex signature).
  - `verifyArtifact` round-trips for valid payloads.
  - Tampered payload, modified checksum, and mismatched signature cases asserting verification fails closed (`false`).
  - Malformed signature and checksum input handling.
  - Key rotation grace period using `ARTIFACT_SIGNING_SECRET_PREVIOUS`.
  - `validateStoragePath` verifying per-user namespace isolation and rejection of path traversal (`../`) attacks.

Closes #1074

---

### Summary of Changes & Commits
- `524b5a1`: `fix(backend): generate webhook DLQ entry IDs with crypto.randomUUID instead of Math.random`
- `180af3e`: `fix(backend): prune webhook DLQ dedup index entries once their underlying entry succeeds`
- `d2fb0cf`: `test(backend): add unit coverage for AnalyticsAggregationService`
- `c82c6e4`: `test(backend): add unit coverage for ArtifactSigningService sign/verify paths`