### PR TITLE
fix(backend): address issues #1067, #1069, #1070, and #1068

### DIFF
--- a/apps/backend/src/app/api/webhooks/github/route.ts
+++ b/apps/backend/src/app/api/webhooks/github/route.ts
@@ -13,13 +13,36 @@ const SUPPORTED_EVENTS = new Set([
 
 const MAX_ATTEMPTS = 3;
 
+/**
+ * Processes a GitHub webhook event payload according to its eventType.
+ */
+export async function processGitHubWebhookEvent(
+    eventType: string,
+    payload: unknown,
+    log: ReturnType<typeof createLogger>
+): Promise<void> {
+    if (eventType === 'push') {
+        await handlePushEvent(payload, log);
+    } else if (eventType === 'ping') {
+        log.info('Ping event received');
+    } else if (eventType === 'installation') {
+        await handleInstallationEvent(payload, log);
+    } else if (eventType === 'installation_repositories') {
+        await handleInstallationRepositoriesEvent(payload, log);
+    }
+}
+
 // Register a reprocessing handler so DLQ entries can be retried via the admin endpoint.
 webhookDLQ.registerProcessor('github', async (entry) => {
     const payload = JSON.parse(entry.payload);
-    if (entry.eventType === 'push') {
-        const log = createLogger({ correlationId: 'dlq-reprocess', service: 'github-webhook' });
-        await handlePushEvent(payload, log);
-    }
+    const log = createLogger({ correlationId: 'dlq-reprocess', service: 'github-webhook' });
+    await processGitHubWebhookEvent(entry.eventType, payload, log);
+});
+
+// Register a processor so replayed deliveries in WebhookDeliveryService re-trigger downstream processing.
+webhookDeliveryService.registerProcessor(async (delivery) => {
+    const log = createLogger({ correlationId: `replay-${delivery.deliveryId}`, service: 'github-webhook' });
+    await processGitHubWebhookEvent(delivery.eventType, delivery.payload, log);
 });
 
 /**
@@ -127,15 +150,7 @@ export async function POST(req: NextRequest) {
     // 9. Process the webhook event
     let lastError: Error | undefined;
     try {
-        if (eventType === 'push') {
-            await handlePushEvent(payload, log);
-        } else if (eventType === 'ping') {
-            log.info('Ping event received');
-        } else if (eventType === 'installation') {
-            await handleInstallationEvent(payload, log);
-        } else if (eventType === 'installation_repositories') {
-            await handleInstallationRepositoriesEvent(payload, log);
-        }
+        await processGitHubWebhookEvent(eventType, payload, log);
 
         // Mark delivery as processed
         if (deliveryId) {

--- a/apps/backend/src/lib/tier-enforcement.middleware.ts
+++ b/apps/backend/src/lib/tier-enforcement.middleware.ts
@@ -14,6 +14,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
+import { createLogger, resolveCorrelationId } from '@/lib/api/logger';
 import type { SubscriptionTier } from '@craft/types';
 
 // ── Tier ordering ─────────────────────────────────────────────────────────────
@@ -71,11 +72,22 @@ export function withTierEnforcement<TParams = {}>(
         }
 
         // Re-read tier from DB — intentionally not trusting the JWT claim.
-        const { data: profile } = await supabase
+        const { data: profile, error: profileError } = await supabase
             .from('profiles')
             .select('subscription_tier')
             .eq('id', user.id)
             .single();
+
+        if (profileError) {
+            const correlationId = resolveCorrelationId(req);
+            const log = createLogger({ correlationId, userId: user.id });
+            log.error('Database error during subscription tier lookup; failing closed to free tier', profileError, {
+                path: req.nextUrl?.pathname || req.url,
+                method: req.method,
+                requiredTier,
+                errorMessage: profileError.message,
+            });
+        }
 
         const userTier = (profile?.subscription_tier ?? 'free') as SubscriptionTier;
 

--- a/apps/backend/src/services/cron-failure-tracker.service.ts
+++ b/apps/backend/src/services/cron-failure-tracker.service.ts
@@ -56,28 +56,89 @@ export class CronFailureTrackerService {
         );
 
         if (rpcError) {
-            console.error('[cron-failure-tracker] RPC call failed, falling back to upsert', rpcError);
-            // Fallback: read-then-upsert (not atomic, but better than failing)
-            const { data: existing } = await supabase
-                .from('cron_job_failures')
-                .select('consecutive_failures')
-                .eq('job_name', jobName)
-                .single();
+            console.error('[cron-failure-tracker] RPC call failed, falling back to optimistic concurrency update', rpcError);
+            /**
+             * Fallback path when `increment_cron_failure` RPC is unavailable.
+             *
+             * Note on non-atomicity: A naive read-then-upsert is subject to race conditions
+             * if two workers fail concurrently for the same jobName (both read same count and write count + 1,
+             * losing an increment). To mitigate lost updates, we use an optimistic-concurrency guard:
+             * conditional update on the expected consecutive_failures value with a retry loop.
+             */
+            const MAX_RETRIES = 3;
+            let persistedCount: number | null = null;
 
-            const newCount = (existing?.consecutive_failures ?? 0) + 1;
+            for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+                const { data: existing } = await supabase
+                    .from('cron_job_failures')
+                    .select('consecutive_failures')
+                    .eq('job_name', jobName)
+                    .maybeSingle();
 
-            await supabase.from('cron_job_failures').upsert(
-                {
-                    job_name: jobName,
-                    consecutive_failures: newCount,
-                    last_failure_at: new Date().toISOString(),
-                    last_error: error,
-                    updated_at: new Date().toISOString(),
-                },
-                { onConflict: 'job_name' }
-            );
+                if (existing) {
+                    const currentFailures = existing.consecutive_failures ?? 0;
+                    const nextCount = currentFailures + 1;
+                    const { data: updated, error: updateErr } = await supabase
+                        .from('cron_job_failures')
+                        .update({
+                            consecutive_failures: nextCount,
+                            last_failure_at: new Date().toISOString(),
+                            last_error: error,
+                            updated_at: new Date().toISOString(),
+                        })
+                        .eq('job_name', jobName)
+                        .eq('consecutive_failures', currentFailures)
+                        .select('consecutive_failures')
+                        .maybeSingle();
 
-            await this._escalate(jobName, newCount, error);
+                    if (!updateErr && updated) {
+                        persistedCount = updated.consecutive_failures;
+                        break;
+                    }
+                } else {
+                    const { data: inserted, error: insertErr } = await supabase
+                        .from('cron_job_failures')
+                        .insert({
+                            job_name: jobName,
+                            consecutive_failures: 1,
+                            last_failure_at: new Date().toISOString(),
+                            last_error: error,
+                            updated_at: new Date().toISOString(),
+                        })
+                        .select('consecutive_failures')
+                        .maybeSingle();
+
+                    if (!insertErr && inserted) {
+                        persistedCount = inserted.consecutive_failures;
+                        break;
+                    }
+                }
+            }
+
+            // If optimistic-concurrency retries were exhausted due to high contention,
+            // fall back to a direct upsert so the failure is recorded.
+            if (persistedCount === null) {
+                const { data: existing } = await supabase
+                    .from('cron_job_failures')
+                    .select('consecutive_failures')
+                    .eq('job_name', jobName)
+                    .maybeSingle();
+
+                const fallbackCount = (existing?.consecutive_failures ?? 0) + 1;
+                await supabase.from('cron_job_failures').upsert(
+                    {
+                        job_name: jobName,
+                        consecutive_failures: fallbackCount,
+                        last_failure_at: new Date().toISOString(),
+                        last_error: error,
+                        updated_at: new Date().toISOString(),
+                    },
+                    { onConflict: 'job_name' }
+                );
+                persistedCount = fallbackCount;
+            }
+
+            await this._escalate(jobName, persistedCount, error);
             return;
         }
 

--- a/apps/backend/src/services/rollout-strategy.service.ts
+++ b/apps/backend/src/services/rollout-strategy.service.ts
@@ -36,6 +36,15 @@ function invalidateFlagCache(flagKey?: string): void {
     }
 }
 
+function hashIdentityToBucket(identity: string): number {
+    let hash = 2166136261;
+    for (let i = 0; i < identity.length; i++) {
+        hash ^= identity.charCodeAt(i);
+        hash = Math.imul(hash, 16777619);
+    }
+    return Math.abs(hash >>> 0) % 100;
+}
+
 export class RolloutEngine {
     private _canaryPercent = 0;
     private _status: RolloutStatus = 'pending';
@@ -87,20 +96,38 @@ export class RolloutEngine {
         this._status = percent === 0 ? 'pending' : percent === 100 ? 'promoted' : 'in_progress';
     }
 
-    routeRequest(): DeploymentVersion {
+    /**
+     * Routes a request to either candidate (canary) or stable deployment.
+     * When an identity is provided (e.g. userId, sessionId), routing is deterministic
+     * and sticky across requests for the same rollout configuration.
+     * If no identity is provided, falls back to a shared request counter.
+     */
+    routeRequest(identity?: string): DeploymentVersion {
+        if (identity !== undefined && identity !== '') {
+            const bucket = hashIdentityToBucket(identity);
+            const useCanary = bucket < this._canaryPercent;
+            return useCanary ? this.candidate : this.stable;
+        }
+
         this._requestCounter += 1;
         const useCanary = (this._requestCounter % 100) < this._canaryPercent;
         return useCanary ? this.candidate : this.stable;
     }
 
-    simulateTraffic(requestCount: number): Record<string, number> {
+    simulateTraffic(
+        requestCount: number,
+        identityGenerator?: (index: number) => string
+    ): Record<string, number> {
         const counts: Record<string, number> = {
             [this.stable.id]: 0,
             [this.candidate.id]: 0,
         };
 
         for (let i = 0; i < requestCount; i += 1) {
-            const servedBy = this.routeRequest();
+            const identity = identityGenerator
+                ? identityGenerator(i)
+                : `user-sim-${i}`;
+            const servedBy = this.routeRequest(identity);
             counts[servedBy.id] = (counts[servedBy.id] ?? 0) + 1;
         }
 

--- a/apps/backend/src/services/webhook-delivery.service.ts
+++ b/apps/backend/src/services/webhook-delivery.service.ts
@@ -81,6 +81,8 @@ export interface ReplayDeliveryResult {
     error?: string;
 }
 
+export type WebhookDeliveryProcessor = (delivery: WebhookDelivery) => Promise<void>;
+
 // ── Service ───────────────────────────────────────────────────────────────────
 
 export class WebhookDeliveryService {
@@ -88,6 +90,21 @@ export class WebhookDeliveryService {
         correlationId: 'webhook-delivery-service',
         service: 'webhook-delivery',
     });
+    private processor: WebhookDeliveryProcessor | null = null;
+
+    /**
+     * Registers a processor function to handle downstream processing of replayed webhook deliveries.
+     */
+    registerProcessor(processor: WebhookDeliveryProcessor): void {
+        this.processor = processor;
+    }
+
+    /**
+     * Returns the registered processor, if any.
+     */
+    getProcessor(): WebhookDeliveryProcessor | null {
+        return this.processor;
+    }
 
     /**
      * Records a new webhook delivery in the database.
@@ -321,6 +338,24 @@ export class WebhookDeliveryService {
                 newDeliveryId,
                 eventType: original.event_type,
             });
+
+            // Re-trigger downstream processing if a processor is registered
+            if (this.processor) {
+                const replayedDelivery = this.mapToWebhookDelivery(replayed);
+                try {
+                    await this.processor(replayedDelivery);
+                    await this.markProcessed(newDeliveryId);
+                } catch (procErr: any) {
+                    this.log.error('Failed to process replayed webhook delivery', procErr, {
+                        newDeliveryId,
+                        originalDeliveryId,
+                    });
+                    await this.markFailed(
+                        newDeliveryId,
+                        procErr?.message || 'Replay processing failed'
+                    );
+                }
+            }
 
             return { success: true, newDeliveryId };
         } catch (error: any) {

--- a/apps/backend/tests/deployment/rollout-strategy.test.ts
+++ b/apps/backend/tests/deployment/rollout-strategy.test.ts
@@ -61,6 +61,33 @@ describe('Canary rollout - traffic percentage controls', () => {
         expect(() => engine.setTrafficPercent(-1)).toThrow(RangeError);
         expect(() => engine.setTrafficPercent(101)).toThrow(RangeError);
     });
+
+    it('routes deterministically and stickily for the same identity across repeated calls', () => {
+        engine.setTrafficPercent(30);
+
+        const userA = 'user-123-abc';
+        const userB = 'user-456-def';
+
+        const resultA1 = engine.routeRequest(userA);
+        const resultA2 = engine.routeRequest(userA);
+        const resultA3 = engine.routeRequest(userA);
+
+        const resultB1 = engine.routeRequest(userB);
+        const resultB2 = engine.routeRequest(userB);
+
+        // Same user always gets same assignment at a fixed percentage
+        expect(resultA1.id).toBe(resultA2.id);
+        expect(resultA2.id).toBe(resultA3.id);
+        expect(resultB1.id).toBe(resultB2.id);
+    });
+
+    it('falls back to request counter when identity is not provided', () => {
+        engine.setTrafficPercent(50);
+        const r1 = engine.routeRequest();
+        const r2 = engine.routeRequest();
+        expect(r1).toBeDefined();
+        expect(r2).toBeDefined();
+    });
 });
 
 describe('Canary rollout - automatic rollback', () => {

--- a/apps/backend/tests/monitoring/cron-failure-tracker.test.ts
+++ b/apps/backend/tests/monitoring/cron-failure-tracker.test.ts
@@ -273,4 +273,60 @@ describe('CronFailureTrackerService', () => {
         // Should not call fetch again (alert already sent)
         expect(fetchSpy).not.toHaveBeenCalled();
     });
+
+    it('falls back to optimistic-concurrency update when RPC is unavailable and retries on conflict', async () => {
+        const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+        const svc = await load();
+
+        let attempt = 0;
+        const mock = {
+            rpc: vi.fn().mockImplementation((fn: string) => {
+                if (fn === 'increment_cron_failure') {
+                    return Promise.resolve({ data: null, error: { message: 'RPC not available' } });
+                }
+                if (fn === 'mark_cron_alert_sent') {
+                    return Promise.resolve({ data: null, error: null });
+                }
+                return Promise.resolve({ data: null, error: null });
+            }),
+            from: vi.fn().mockReturnValue({
+                select: vi.fn().mockReturnThis(),
+                update: vi.fn().mockReturnThis(),
+                insert: vi.fn().mockReturnThis(),
+                eq: vi.fn().mockReturnThis(),
+                maybeSingle: vi.fn().mockImplementation(() => {
+                    attempt++;
+                    if (attempt === 1) {
+                        // First read: existing row has consecutive_failures = 1
+                        return Promise.resolve({ data: { consecutive_failures: 1 }, error: null });
+                    } else if (attempt === 2) {
+                        // First update attempt fails (simulating concurrent write that bumped count to 2)
+                        return Promise.resolve({ data: null, error: null });
+                    } else if (attempt === 3) {
+                        // Second read: existing row now has consecutive_failures = 2
+                        return Promise.resolve({ data: { consecutive_failures: 2 }, error: null });
+                    } else {
+                        // Second update succeeds and returns updated row with consecutive_failures = 3
+                        return Promise.resolve({ data: { consecutive_failures: 3 }, error: null });
+                    }
+                }),
+                single: vi.fn().mockResolvedValue({
+                    data: { slack_alert_sent: false, email_alert_sent: false },
+                    error: null,
+                }),
+                upsert: vi.fn().mockResolvedValue({ error: null }),
+            }),
+        };
+
+        mockCreateClient.mockReturnValue(mock as any);
+
+        await svc.recordFailure('fallback-job', 'simulated failure');
+
+        expect(mock.rpc).toHaveBeenCalledWith('increment_cron_failure', {
+            p_job_name: 'fallback-job',
+            p_error: 'simulated failure',
+        });
+        expect(consoleErrorSpy).toHaveBeenCalled();
+    });
 });
+

--- a/apps/backend/tests/subscription/tier-enforcement.test.ts
+++ b/apps/backend/tests/subscription/tier-enforcement.test.ts
@@ -150,4 +150,49 @@ describe('withTierEnforcement', () => {
         const res = await freeHandler(makeRequest(), { params: {} });
         expect(res.status).toBe(200);
     });
+
+    it('logs database query errors and fails closed to free tier (returning 402 for pro)', async () => {
+        const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+        const mock = {
+            auth: {
+                getUser: vi.fn().mockResolvedValue({
+                    data: { user: { id: 'user-1' } },
+                    error: null,
+                }),
+            },
+            from: vi.fn().mockReturnValue({
+                select: vi.fn().mockReturnThis(),
+                eq: vi.fn().mockReturnThis(),
+                single: vi.fn().mockResolvedValue({
+                    data: null,
+                    error: { message: 'connection timeout to Supabase', code: 'PGRST504' },
+                }),
+            }),
+        };
+        mockCreateClient.mockReturnValue(mock as any);
+        const withTierEnforcement = await load();
+
+        const handler = withTierEnforcement('pro', okHandler);
+        const res = await handler(makeRequest('/api/deployments/analytics'), { params: {} });
+
+        expect(res.status).toBe(402);
+        expect(okHandler).not.toHaveBeenCalled();
+        expect(consoleErrorSpy).toHaveBeenCalled();
+        const logged = consoleErrorSpy.mock.calls[0]?.[0];
+        expect(logged).toContain('Database error during subscription tier lookup');
+        consoleErrorSpy.mockRestore();
+    });
+
+    it('does not log error for legitimate free-tier user with no database error', async () => {
+        const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+        mockCreateClient.mockReturnValue(makeSupabaseMock('free') as any);
+        const withTierEnforcement = await load();
+
+        const handler = withTierEnforcement('pro', okHandler);
+        const res = await handler(makeRequest('/api/deployments/analytics'), { params: {} });
+
+        expect(res.status).toBe(402);
+        expect(consoleErrorSpy).not.toHaveBeenCalled();
+        consoleErrorSpy.mockRestore();
+    });
 });

--- a/apps/backend/tests/webhooks/webhook-replay.integration.test.ts
+++ b/apps/backend/tests/webhooks/webhook-replay.integration.test.ts
@@ -1,0 +1,191 @@
+// @vitest-environment node
+/**
+ * Webhook Delivery Replay Integration Tests (#1069)
+ *
+ * Verifies that replaying a delivery actually re-triggers downstream
+ * event processing and transitions status to processed/failed rather
+ * than leaving the delivery stuck at 'received'.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { WebhookDeliveryService } from '@/services/webhook-delivery.service';
+
+const mockRpc = vi.fn();
+const mockFrom = vi.fn();
+const mockSelect = vi.fn();
+const mockInsert = vi.fn();
+const mockUpdate = vi.fn();
+const mockEq = vi.fn();
+const mockSingle = vi.fn();
+
+vi.mock('@/lib/supabase/server', () => ({
+    createClient: vi.fn(() => ({
+        rpc: mockRpc,
+        from: mockFrom,
+    })),
+}));
+
+describe('Webhook Delivery Replay Integration', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+
+        mockFrom.mockReturnValue({
+            select: mockSelect,
+            insert: mockInsert,
+            update: mockUpdate,
+        });
+
+        mockSelect.mockReturnValue({
+            eq: mockEq,
+        });
+
+        mockInsert.mockReturnValue({
+            select: mockSelect,
+        });
+
+        mockUpdate.mockReturnValue({
+            eq: mockEq,
+        });
+
+        mockEq.mockReturnValue({
+            single: mockSingle,
+            select: mockSelect,
+        });
+
+        mockSingle.mockResolvedValue({
+            data: null,
+            error: null,
+        });
+
+        mockRpc.mockResolvedValue({ data: null, error: null });
+    });
+
+    it('replays delivery and invokes registered processor, transitioning status to processed', async () => {
+        const service = new WebhookDeliveryService();
+
+        const originalDelivery = {
+            id: 'uuid-1',
+            delivery_id: 'del-orig-1',
+            event_type: 'push',
+            payload: { ref: 'refs/heads/main' },
+            headers: { 'x-github-event': 'push' },
+            status: 'failed',
+            created_at: new Date().toISOString(),
+            updated_at: new Date().toISOString(),
+        };
+
+        const replayedDeliveryRow = {
+            id: 'uuid-2',
+            delivery_id: 'replay-12345-abc',
+            event_type: 'push',
+            payload: { ref: 'refs/heads/main' },
+            headers: { 'x-github-event': 'push' },
+            status: 'received',
+            replayed_from_delivery_id: 'del-orig-1',
+            created_at: new Date().toISOString(),
+            updated_at: new Date().toISOString(),
+        };
+
+        mockFrom.mockReturnValueOnce({
+            select: vi.fn().mockReturnValue({
+                eq: vi.fn().mockReturnValue({
+                    single: vi.fn().mockResolvedValue({
+                        data: originalDelivery,
+                        error: null,
+                    }),
+                }),
+            }),
+        });
+
+        mockFrom.mockReturnValueOnce({
+            insert: vi.fn().mockReturnValue({
+                select: vi.fn().mockReturnValue({
+                    single: vi.fn().mockResolvedValue({
+                        data: replayedDeliveryRow,
+                        error: null,
+                    }),
+                }),
+            }),
+        });
+
+        const processorMock = vi.fn().mockResolvedValue(undefined);
+        service.registerProcessor(processorMock);
+
+        const result = await service.replayDelivery('del-orig-1');
+
+        expect(result.success).toBe(true);
+        expect(result.newDeliveryId).toBe('replay-12345-abc');
+        expect(processorMock).toHaveBeenCalledOnce();
+        expect(processorMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                deliveryId: 'replay-12345-abc',
+                eventType: 'push',
+                payload: { ref: 'refs/heads/main' },
+            })
+        );
+        expect(mockRpc).toHaveBeenCalledWith('mark_delivery_processed', {
+            p_delivery_id: 'replay-12345-abc',
+        });
+    });
+
+    it('marks delivery as failed when registered processor throws an error', async () => {
+        const service = new WebhookDeliveryService();
+
+        const originalDelivery = {
+            id: 'uuid-1',
+            delivery_id: 'del-orig-2',
+            event_type: 'push',
+            payload: { ref: 'refs/heads/main' },
+            headers: { 'x-github-event': 'push' },
+            status: 'failed',
+            created_at: new Date().toISOString(),
+            updated_at: new Date().toISOString(),
+        };
+
+        const replayedDeliveryRow = {
+            id: 'uuid-3',
+            delivery_id: 'replay-67890-xyz',
+            event_type: 'push',
+            payload: { ref: 'refs/heads/main' },
+            headers: { 'x-github-event': 'push' },
+            status: 'received',
+            replayed_from_delivery_id: 'del-orig-2',
+            created_at: new Date().toISOString(),
+            updated_at: new Date().toISOString(),
+        };
+
+        mockFrom.mockReturnValueOnce({
+            select: vi.fn().mockReturnValue({
+                eq: vi.fn().mockReturnValue({
+                    single: vi.fn().mockResolvedValue({
+                        data: originalDelivery,
+                        error: null,
+                    }),
+                }),
+            }),
+        });
+
+        mockFrom.mockReturnValueOnce({
+            insert: vi.fn().mockReturnValue({
+                select: vi.fn().mockReturnValue({
+                    single: vi.fn().mockResolvedValue({
+                        data: replayedDeliveryRow,
+                        error: null,
+                    }),
+                }),
+            }),
+        });
+
+        const processorMock = vi.fn().mockRejectedValue(new Error('Downstream processing failed'));
+        service.registerProcessor(processorMock);
+
+        const result = await service.replayDelivery('del-orig-2');
+
+        expect(result.success).toBe(true);
+        expect(processorMock).toHaveBeenCalledOnce();
+        expect(mockRpc).toHaveBeenCalledWith('mark_delivery_failed', {
+            p_delivery_id: 'replay-67890-xyz',
+            p_error_message: 'Downstream processing failed',
+        });
+    });
+});


### PR DESCRIPTION
## Description

This PR resolves four backend issues across cron failure tracking, webhook replay, canary rollout routing, and subscription tier enforcement:

### 1. #1067: Prevent Concurrent recordFailure Fallback Writes From Losing Cron Failure Increments
- **Problem**: When `increment_cron_failure` RPC fails, `CronFailureTrackerService.recordFailure` fell back to a non-atomic read-then-upsert which could lose increments under concurrent failure calls.
- **Solution**: Documented the non-atomicity in the fallback branch and added an optimistic-concurrency guard with retry loop checking `.eq('consecutive_failures', currentFailures)` so detected races retry and the escalation alert is driven by the persisted failure count.
- **Closes #1067**

---

### 2. #1069: Verify GitHub Webhook Replay Actually Re-Triggers Downstream Processing End-to-End
- **Problem**: `WebhookDeliveryService.replayDelivery` recorded a new row with status `'received'`, but did not invoke downstream event processing, leaving replayed deliveries stuck at `'received'`.
- **Solution**: Added processor registration support (`registerProcessor`) to `WebhookDeliveryService`, wired it to `processGitHubWebhookEvent` in the GitHub webhook route handler, and ensured `replayDelivery` executes the processor and transitions delivery status to `processed` (or `failed`). Added integration test coverage.
- **Closes #1069**

---

### 3. #1070: Make Canary Traffic Bucketing Sticky Per User Instead of Per Request Counter
- **Problem**: `RolloutEngine.routeRequest` used a shared request counter (`this._requestCounter % 100 < this._canaryPercent`), causing a user's requests to flip between canary and stable on every invocation.
- **Solution**: Updated `routeRequest` to derive bucket assignments deterministically using an FNV-1a string hash when an `identity` (e.g. userId or sessionId) is provided, while maintaining a counter fallback for callers without an identity. Updated `simulateTraffic` and added unit test coverage for per-identity stickiness.
- **Closes #1070**

---

### 4. #1068: Log Tier-Enforcement Database Errors Instead of Silently Fail-Closing to Free Tier
- **Problem**: `withTierEnforcement` queried `profiles.subscription_tier` and fell back to `'free'` without checking whether the query itself failed due to a database outage, leaving no diagnostic log distinguishing a real free-tier user from a Supabase error.
- **Solution**: Inspected `profileError` from the profile query and logged it via the structured logger (`createLogger`) including route path, method, user ID, required tier, and error message, while preserving the fail-closed 402 behavior. Added test coverage.
- **Closes #1068**