### PR TITLE
fix(backend): prevent duplicate Slack alert, bound rate-limit & idempotency cache growth

### DIFF
--- a/apps/backend/src/lib/api/idempotency.test.ts
+++ b/apps/backend/src/lib/api/idempotency.test.ts
@@ -16,6 +16,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import {
     withIdempotency,
     clearIdempotencyCache,
+    evictExpired,
     IDEMPOTENCY_KEY_HEADER,
 } from './idempotency';
 
@@ -265,5 +266,50 @@ describe('withIdempotency — non-JSON response bodies', () => {
 
         const body2 = await r2.json();
         expect(body2).toBeNull();
+    });
+});
+
+// ── Bounded / scheduled eviction (#1048) ──────────────────────────────────────
+
+describe('withIdempotency — bounded cache growth (#1048)', () => {
+    it('evicts expired entries even when no further keyed request arrives', async () => {
+        // Very short TTL so all entries expire quickly.
+        vi.stubEnv('IDEMPOTENCY_TTL_MS', '50');
+
+        const handler = makeHandler(201, { id: 'dep_1' });
+        const wrapped = withIdempotency('user_a', handler);
+
+        // One-shot keys: each used exactly once, then never re-requested.
+        for (let i = 0; i < 200; i++) {
+            await wrapped(makeRequest(`one-shot-${i}`));
+        }
+
+        // No further keyed traffic — but the entries must still expire.
+        await new Promise((r) => setTimeout(r, 80));
+        evictExpired();
+
+        await vi.waitFor(() => {
+            const replay = makeHandler(201, { id: 'dep_1' });
+            const replayedWrapped = withIdempotency('user_a', replay);
+            return replayedWrapped(makeRequest('one-shot-0')).then(() => {
+                expect(replay).toHaveBeenCalledTimes(1);
+            });
+        });
+    });
+
+    it('keeps the cache size bounded under many one-off keys', async () => {
+        // Cap the cache so growth can be asserted deterministically.
+        vi.stubEnv('IDEMPOTENCY_MAX_ENTRIES', '10');
+
+        const handler = makeHandler(201, { id: 'dep_1' });
+        const wrapped = withIdempotency('user_a', handler);
+
+        for (let i = 0; i < 500; i++) {
+            await wrapped(makeRequest(`cap-${i}`));
+        }
+
+        // Cache must never exceed the configured cap (oldest evicted on write).
+        const { _cacheSize } = await import('./idempotency');
+        expect(_cacheSize()).toBeLessThanOrEqual(10);
     });
 });

--- a/apps/backend/src/lib/api/idempotency.ts
+++ b/apps/backend/src/lib/api/idempotency.ts
@@ -10,7 +10,22 @@
  * never collide even if the raw key string is identical.
  *
  * Configuration:
- *   IDEMPOTENCY_TTL_MS — Cache TTL in milliseconds. Default: 86_400_000 (24 h)
+ *   IDEMPOTENCY_TTL_MS      — Cache TTL in milliseconds. Default: 86_400_000 (24 h)
+ *   IDEMPOTENCY_MAX_ENTRIES — Hard cap on cached entries; when exceeded the
+ *                             oldest entry (by storedAt) is evicted. Default: 10_000
+ *   IDEMPOTENCY_SWEEP_MS    — Interval at which a background sweep evicts
+ *                             expired entries independently of new keyed
+ *                             requests, bounding memory even for one-shot keys.
+ *                             Default: 60_000 (60 s). Disabled under NODE_ENV=test.
+ *
+ * Eviction strategy:
+ *   - Every keyed request that misses the cache prunes expired entries first
+ *     (lazy sweep), so a hot key never accumulates stale data.
+ *   - A periodic background sweep runs on an interval to evict entries that
+ *     have fully expired even when no further request arrives on that key
+ *     (the common one-shot checkout case), preventing unbounded growth.
+ *   - A max-size cap provides a hard backstop: if the sweep lags, the oldest
+ *     stored entry is evicted on write.
  *
  * Usage:
  *   const handler = withIdempotency(userId, async (req) => { ... });
@@ -36,16 +51,61 @@ function ttlMs(): number {
     return Number.isFinite(val) && val > 0 ? val : 86_400_000;
 }
 
+function maxEntries(): number {
+    const val = parseInt(process.env.IDEMPOTENCY_MAX_ENTRIES ?? '10000', 10);
+    return Number.isFinite(val) && val > 0 ? val : 10_000;
+}
+
+function sweepIntervalMs(): number {
+    const val = parseInt(process.env.IDEMPOTENCY_SWEEP_MS ?? '60000', 10);
+    return Number.isFinite(val) && val > 0 ? val : 60_000;
+}
+
 function cacheKey(userId: string, idempotencyKey: string): string {
     return `${userId}:${idempotencyKey}`;
 }
 
-function evictExpired(): void {
+/** Remove every cache entry whose TTL has elapsed. */
+export function evictExpired(): void {
     const now = Date.now();
     const ttl = ttlMs();
     for (const [key, entry] of cache) {
         if (now - entry.storedAt > ttl) cache.delete(key);
     }
+}
+
+/**
+ * Bound the cache size by evicting the oldest entry when over the cap. Used as
+ * a backstop so memory stays bounded even if the periodic sweep has not yet
+ * reclaimed entries.
+ */
+function enforceMaxSize(): void {
+    const cap = maxEntries();
+    if (cache.size <= cap) return;
+    let oldestKey: string | null = null;
+    let oldestTime = Infinity;
+    for (const [key, entry] of cache) {
+        if (entry.storedAt < oldestTime) {
+            oldestTime = entry.storedAt;
+            oldestKey = key;
+        }
+    }
+    if (oldestKey) cache.delete(oldestKey);
+}
+
+// ── Periodic sweep ────────────────────────────────────────────────────────────
+// Evicts expired entries on a timer so the cache cannot grow without bound for
+// one-shot keys that are never re-requested. Disabled under test environments
+// to avoid open-handle leaks in the test runner.
+
+let sweepHandle: ReturnType<typeof setInterval> | null = null;
+
+function startSweep(): void {
+    if (sweepHandle) return;
+    if (process.env.NODE_ENV === 'test' || process.env.VITEST) return;
+    sweepHandle = setInterval(() => {
+        evictExpired();
+    }, sweepIntervalMs());
 }
 
 export type IdempotentHandler = (req: NextRequest) => Promise<NextResponse>;
@@ -61,6 +121,7 @@ export function withIdempotency(
     handler: IdempotentHandler,
 ): IdempotentHandler {
     return async (req: NextRequest): Promise<NextResponse> => {
+        startSweep();
         const rawKey = req.headers.get(IDEMPOTENCY_KEY_HEADER);
         if (!rawKey) return handler(req);
 
@@ -80,7 +141,9 @@ export function withIdempotency(
 
         if (response.status >= 200 && response.status < 300) {
             const body = await response.clone().json().catch(() => null);
+            if (cache.size >= maxEntries()) evictExpired();
             cache.set(key, { status: response.status, body, storedAt: Date.now() });
+            enforceMaxSize();
         }
 
         return response;
@@ -90,4 +153,9 @@ export function withIdempotency(
 /** Exposed for testing — clears all cached entries. */
 export function clearIdempotencyCache(): void {
     cache.clear();
+}
+
+/** Exposed for testing — returns the current number of cached entries. */
+export function _cacheSize(): number {
+    return cache.size;
 }

--- a/apps/backend/src/lib/api/rate-limit.test.ts
+++ b/apps/backend/src/lib/api/rate-limit.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
-import { checkRateLimit, getRateLimitKey, _resetStore, type RateLimitConfig } from './rate-limit';
+import { checkRateLimit, getRateLimitKey, _resetStore, _sweepStore, _storeSize, type RateLimitConfig } from './rate-limit';
 
 const config: RateLimitConfig = { limit: 3, windowMs: 60_000 };
 
@@ -66,6 +66,66 @@ describe('checkRateLimit', () => {
         for (let i = 0; i < 5; i++) checkRateLimit('key5', config);
         const r = checkRateLimit('key5', config);
         expect(r.remaining).toBe(0);
+    });
+});
+
+describe('checkRateLimit — bounded store growth (#1047)', () => {
+    beforeEach(() => _resetStore());
+    afterEach(() => vi.useRealTimers());
+
+    it('drops an entry whose timestamps are fully expired and never re-queried', () => {
+        vi.useFakeTimers();
+
+        // One-off key: a single allowed request. The entry must not linger.
+        const oneOff: RateLimitConfig = { limit: 5, windowMs: 50 };
+        checkRateLimit('one-off', oneOff);
+        expect(_storeSize()).toBe(1);
+
+        // Age past the window with no further requests on that key.
+        vi.advanceTimersByTime(oneOff.windowMs + 1);
+        _sweepStore();
+
+        expect(_storeSize()).toBe(0);
+    });
+
+    it('returns the store to a bounded size after a burst of one-off keys ages out', () => {
+        vi.useFakeTimers();
+
+        const burst: RateLimitConfig = { limit: 5, windowMs: 100 };
+        const N = 5000;
+        for (let i = 0; i < N; i++) checkRateLimit(`client-${i}`, burst);
+
+        expect(_storeSize()).toBe(N);
+
+        // All windows expire; a single sweep must reclaim every empty entry.
+        vi.advanceTimersByTime(burst.windowMs + 1);
+        _sweepStore();
+
+        expect(_storeSize()).toBe(0);
+    });
+
+    it('keeps active keys while sweeping away expired ones', () => {
+        vi.useFakeTimers();
+
+        const cfg: RateLimitConfig = { limit: 5, windowMs: 100 };
+        checkRateLimit('active', cfg); // will be refreshed below
+        checkRateLimit('stale', cfg);
+
+        vi.advanceTimersByTime(cfg.windowMs + 1);
+        // Refresh 'active' within the new window before the sweep runs.
+        checkRateLimit('active', cfg);
+        _sweepStore();
+
+        expect(_storeSize()).toBe(1);
+        expect(checkRateLimit('active', cfg).allowed).toBe(true);
+    });
+
+    it('does not shrink below the in-progress active entries on a sweep', () => {
+        const cfg: RateLimitConfig = { limit: 5, windowMs: 60_000 };
+        for (let i = 0; i < 10; i++) checkRateLimit(`keep-${i}`, cfg);
+        expect(_storeSize()).toBe(10);
+        _sweepStore();
+        expect(_storeSize()).toBe(10);
     });
 });
 

--- a/apps/backend/src/lib/api/rate-limit.ts
+++ b/apps/backend/src/lib/api/rate-limit.ts
@@ -81,8 +81,47 @@ export const CRON_RATE_LIMIT: RateLimitConfig = {
 
 // ── Store ────────────────────────────────────────────────────────────────────
 
-// Map<key, timestamps[]> — each entry is a sorted list of request timestamps.
-const store = new Map<string, number[]>();
+interface RateLimitEntry {
+  /** Sorted list of request timestamps (ms) within the window. */
+  timestamps: number[];
+  /** Rolling window length (ms) — retained so expired entries can be swept. */
+  windowMs: number;
+}
+
+// Map<key, entry> — each entry tracks its own window so a low-frequency sweep
+// can evict fully-expired entries independent of fresh traffic on that key.
+const store = new Map<string, RateLimitEntry>();
+
+// ── Bounded growth ───────────────────────────────────────────────────────────
+
+// Lazily-triggered sweep that evicts fully-expired entries. This bounds memory
+// growth from one-off clients (scanners, bots, rotating CDN/proxy IPs) that make
+// a single request and never return — their entry would otherwise linger until
+// the next request on that key, which may never come.
+const SWEEP_INTERVAL_CALLS = parseInt(
+  process.env.RATE_LIMIT_SWEEP_INTERVAL ?? '1000',
+  10,
+);
+const SWEEP_EVERY =
+  Number.isFinite(SWEEP_INTERVAL_CALLS) && SWEEP_INTERVAL_CALLS > 0
+    ? SWEEP_INTERVAL_CALLS
+    : 1000;
+
+let callCount = 0;
+
+function sweepStore(): void {
+  const now = Date.now();
+  for (const [key, entry] of store) {
+    const windowStart = now - entry.windowMs;
+    entry.timestamps = entry.timestamps.filter((t) => t > windowStart);
+    if (entry.timestamps.length === 0) store.delete(key);
+  }
+}
+
+function maybeSweep(): void {
+  callCount += 1;
+  if (callCount % SWEEP_EVERY === 0) sweepStore();
+}
 
 // ── Core logic ───────────────────────────────────────────────────────────────
 
@@ -95,17 +134,24 @@ export function checkRateLimit(key: string, config: RateLimitConfig): RateLimitR
   const windowStart = now - config.windowMs;
 
   // Retrieve and prune timestamps outside the current window.
-  const timestamps = (store.get(key) ?? []).filter((t) => t > windowStart);
+  const existing = store.get(key);
+  const timestamps = (existing?.timestamps ?? []).filter((t) => t > windowStart);
 
   const allowed = timestamps.length < config.limit;
 
   if (allowed) {
     timestamps.push(now);
-    store.set(key, timestamps);
+    store.set(key, { timestamps, windowMs: config.windowMs });
+  } else if (timestamps.length === 0) {
+    // Pruning left nothing and the request was not allowed to extend the
+    // window — drop the stale empty entry rather than leaving it behind.
+    store.delete(key);
   }
 
   const oldest = timestamps[0] ?? now;
   const resetAt = oldest + config.windowMs;
+
+  maybeSweep();
 
   return {
     allowed,
@@ -129,4 +175,14 @@ export function getRateLimitKey(req: { headers: { get(name: string): string | nu
 /** Clears the in-memory store — intended for use in tests only. */
 export function _resetStore(): void {
   store.clear();
+}
+
+/** Returns the number of keys currently held in the store — for tests/observability. */
+export function _storeSize(): number {
+  return store.size;
+}
+
+/** Force an immediate sweep of fully-expired entries — exposed for tests. */
+export function _sweepStore(): void {
+  sweepStore();
 }

--- a/apps/backend/src/services/cron-failure-tracker.service.test.ts
+++ b/apps/backend/src/services/cron-failure-tracker.service.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Unit tests for CronFailureTrackerService — Issue #1046
+ *
+ * Regression coverage for the full escalation sequence (3 → 6 failures):
+ *   - Slack alert fires exactly once at the Slack threshold (count >= 3)
+ *   - Email alert fires exactly once at the email threshold (count >= 6)
+ *   - Crossing the email threshold does NOT fire a second Slack alert
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { CronFailureTrackerService } from './cron-failure-tracker.service';
+
+// ── Supabase mock ─────────────────────────────────────────────────────────────
+
+let currentCount = 0;
+const alertState = { slack_alert_sent: false, email_alert_sent: false };
+
+const mockRpc = vi.fn(async (name: string, params: Record<string, unknown>) => {
+    if (name === 'increment_cron_failure') {
+        return { data: currentCount, error: null };
+    }
+    if (name === 'mark_cron_alert_sent') {
+        if (params.p_alert_type === 'slack') alertState.slack_alert_sent = true;
+        if (params.p_alert_type === 'email') alertState.email_alert_sent = true;
+        return { data: null, error: null };
+    }
+    return { data: null, error: null };
+});
+
+const mockSingle = vi.fn(() => ({ data: { ...alertState }, error: null }));
+const mockEq = vi.fn(() => ({ single: mockSingle }));
+const mockSelect = vi.fn(() => ({ eq: mockEq }));
+const mockFrom = vi.fn(() => ({
+    upsert: vi.fn().mockResolvedValue({ error: null }),
+    select: mockSelect,
+}));
+
+vi.mock('@/lib/supabase/server', () => ({
+    createClient: () => ({ from: mockFrom, rpc: mockRpc }),
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeService() {
+    const service = new CronFailureTrackerService();
+    const slackSpy = vi
+        .spyOn(service as unknown as { _sendSlackAlert: (...a: unknown[]) => Promise<void> }, '_sendSlackAlert')
+        .mockResolvedValue(undefined);
+    const emailSpy = vi
+        .spyOn(service as unknown as { _sendEmailAlert: (...a: unknown[]) => void }, '_sendEmailAlert')
+        .mockImplementation(() => undefined);
+    return { service, slackSpy, emailSpy };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('CronFailureTrackerService — escalation (#1046)', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        currentCount = 0;
+        alertState.slack_alert_sent = false;
+        alertState.email_alert_sent = false;
+    });
+
+    it('fires the Slack alert once when reaching the Slack threshold', async () => {
+        const { service, slackSpy, emailSpy } = makeService();
+        currentCount = 3;
+
+        await service.recordFailure('job-a', 'boom');
+
+        expect(slackSpy).toHaveBeenCalledTimes(1);
+        expect(emailSpy).not.toHaveBeenCalled();
+    });
+
+    it('does NOT double-fire the Slack alert when crossing the email threshold', async () => {
+        const { service, slackSpy, emailSpy } = makeService();
+        currentCount = 6;
+
+        await service.recordFailure('job-b', 'boom');
+
+        expect(slackSpy).toHaveBeenCalledTimes(1);
+        expect(emailSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('fires Slack once and Email once across the full 3→6 escalation sequence', async () => {
+        const { service, slackSpy, emailSpy } = makeService();
+
+        currentCount = 3;
+        await service.recordFailure('job-c', 'boom');
+        expect(slackSpy).toHaveBeenCalledTimes(1);
+        expect(emailSpy).not.toHaveBeenCalled();
+
+        currentCount = 6;
+        await service.recordFailure('job-c', 'boom');
+
+        // Slack only ever fired once (at the Slack threshold), not a second
+        // time at the email threshold.
+        expect(slackSpy).toHaveBeenCalledTimes(1);
+        expect(emailSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('fires mark_cron_alert_sent for email exactly once at the email threshold', async () => {
+        const { service } = makeService();
+        currentCount = 6;
+
+        await service.recordFailure('job-d', 'boom');
+
+        const emailMarks = mockRpc.mock.calls.filter(
+            (c) => c[0] === 'mark_cron_alert_sent' && (c[1] as Record<string, unknown>).p_alert_type === 'email',
+        );
+        expect(emailMarks).toHaveLength(1);
+    });
+});

--- a/apps/backend/src/services/cron-failure-tracker.service.ts
+++ b/apps/backend/src/services/cron-failure-tracker.service.ts
@@ -134,7 +134,6 @@ export class CronFailureTrackerService {
 
         // Email alert at threshold 6 or above (if not already sent)
         if (count >= EMAIL_ALERT_THRESHOLD && !row?.email_alert_sent) {
-            await this._sendSlackAlert(jobName, count, error);
             this._sendEmailAlert(jobName, count, error);
             await supabase.rpc('mark_cron_alert_sent', {
                 p_job_name: jobName,


### PR DESCRIPTION
## Summary

Resolves three backend memory/alerting bugs reported against the `StellerCraft/craft`` backend:

- **#1046** — `CronFailureTrackerService._escalate` fired `_sendSlackAlert` a second time inside the `EMAIL_ALERT_THRESHOLD` branch, so a cron job crossing the email threshold paged on-call twice. Removed the stray call; the Slack threshold branch is unchanged. Added `cron-failure-tracker.service.test.ts` asserting exactly one Slack call and one email alert across the 3→6 escalation sequence.
- **#1047** — `checkRateLimit` pruned stale timestamps but never removed the entry from the module-level `store`, causing unbounded growth from distinct one-off clients. Entries whose timestamp array becomes empty are now deleted, a low-frequency sweep (`RATE_LIMIT_SWEEP_INTERVAL`) reclaims fully-expired keys, and `_storeSize`/`_sweepStore` are exposed for tests.
- **#1048** — `withIdempotency` only evicted expired entries when a new keyed request arrived, so one-shot keys accumulated forever. Added a periodic background sweep (`IDEMPOTENCY_SWEEP_MS`) guarded for test environments, plus a hard `IDEMPOTENCY_MAX_ENTRIES` cap with oldest-first eviction.

## Test plan

- `npm run test --workspace=@craft/backend -- cron-failure-tracker` — Slack call count stays at 1 across a run reaching 6 consecutive failures.
- `npm run test --workspace=@craft/backend -- rate-limit` — store returns to a bounded size after a burst of one-off keys ages out.
- `npm run test --workspace=@craft/backend -- idempotency` — cache stays bounded and does not retain entries past their TTL without further keyed traffic.

All three test files pass and `eslint` is clean on changed sources.

Closes #1046
Closes #1047
Closes #1048

Co-authored-by: temma02