### PR TITLE
test(backend): unit test coverage for RBAC, usage-tracking, security-headers, and deployment rate-limit middleware

### DIFF
--- a/apps/backend/src/lib/api/deployment-rate-limit.test.ts
+++ b/apps/backend/src/lib/api/deployment-rate-limit.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import {
+    checkDeploymentRateLimit,
+    TIER_HOURLY_LIMITS,
+    WINDOW_MS,
+    ESCALATION_REDUCTION,
+} from './deployment-rate-limit';
+
+const NOW = new Date('2026-01-01T00:00:00.000Z').getTime();
+
+type CountResult = { count: number | null; error: unknown };
+type EscalationRow = { hit_count: number; window_start: string } | null;
+type OldestRow = { created_at: string } | null;
+
+/**
+ * Builds a fake Supabase client covering the two tables the module reads and
+ * writes: `deployment_rate_limit_requests` (count + oldest-in-window + insert)
+ * and `deployment_rate_limit_escalations` (read + upsert/update). The two
+ * query shapes on the requests table are distinguished the same way the real
+ * PostgREST builder is: a `head: true` select is the count query, otherwise
+ * it's the "oldest request" lookup.
+ */
+function createSupabaseMock(opts: {
+    countResult: CountResult;
+    oldestRow?: OldestRow;
+    escalationRow?: EscalationRow;
+}) {
+    const insert = vi.fn().mockResolvedValue({ data: null, error: null });
+    const upsert = vi.fn().mockResolvedValue({ data: null, error: null });
+    const updateEq = vi.fn().mockResolvedValue({ data: null, error: null });
+    const update = vi.fn(() => ({ eq: updateEq }));
+
+    const from = vi.fn((table: string) => {
+        if (table === 'deployment_rate_limit_requests') {
+            return {
+                select: vi.fn((_cols: string, selectOpts?: { head?: boolean }) => {
+                    if (selectOpts?.head) {
+                        return {
+                            eq: vi.fn(() => ({
+                                gte: vi.fn(() => Promise.resolve(opts.countResult)),
+                            })),
+                        };
+                    }
+                    return {
+                        eq: vi.fn(() => ({
+                            gte: vi.fn(() => ({
+                                order: vi.fn(() => ({
+                                    limit: vi.fn(() => ({
+                                        single: vi.fn(() =>
+                                            Promise.resolve({ data: opts.oldestRow ?? null })
+                                        ),
+                                    })),
+                                })),
+                            })),
+                        })),
+                    };
+                }),
+                insert,
+            };
+        }
+
+        if (table === 'deployment_rate_limit_escalations') {
+            return {
+                select: vi.fn(() => ({
+                    eq: vi.fn(() => ({
+                        single: vi.fn(() => Promise.resolve({ data: opts.escalationRow ?? null })),
+                    })),
+                })),
+                upsert,
+                update,
+            };
+        }
+
+        throw new Error(`Unexpected table: ${table}`);
+    });
+
+    return { from, insert, upsert, update, updateEq } as unknown as SupabaseClient & {
+        insert: typeof insert;
+        upsert: typeof upsert;
+        update: typeof update;
+        updateEq: typeof updateEq;
+    };
+}
+
+describe('checkDeploymentRateLimit', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.setSystemTime(NOW);
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('allows a request under the limit and logs it', async () => {
+        const supabase = createSupabaseMock({
+            countResult: { count: 5, error: null },
+            escalationRow: null,
+        });
+
+        const result = await checkDeploymentRateLimit(supabase, 'user-1', 'free');
+
+        expect(result.allowed).toBe(true);
+        expect(result.limit).toBe(TIER_HOURLY_LIMITS.free);
+        expect(result.remaining).toBe(TIER_HOURLY_LIMITS.free - 5 - 1);
+        expect(result.escalated).toBe(false);
+        expect(supabase.insert).toHaveBeenCalledWith(
+            expect.objectContaining({ user_id: 'user-1' })
+        );
+    });
+
+    it('allows the request that reaches exactly one below the limit (boundary)', async () => {
+        const supabase = createSupabaseMock({
+            countResult: { count: TIER_HOURLY_LIMITS.free - 1, error: null },
+            escalationRow: null,
+        });
+
+        const result = await checkDeploymentRateLimit(supabase, 'user-1', 'free');
+
+        expect(result.allowed).toBe(true);
+        expect(result.remaining).toBe(0);
+    });
+
+    it('rejects a request at the limit boundary and returns the fields used for rate-limit headers', async () => {
+        const oldestCreatedAt = new Date(NOW - 30 * 60 * 1_000).toISOString(); // 30 min into the window
+        const supabase = createSupabaseMock({
+            countResult: { count: TIER_HOURLY_LIMITS.free, error: null },
+            oldestRow: { created_at: oldestCreatedAt },
+            escalationRow: null,
+        });
+
+        const result = await checkDeploymentRateLimit(supabase, 'user-1', 'free');
+
+        // These fields map directly onto the response headers the caller sets:
+        // X-RateLimit-Limit <- limit, X-RateLimit-Remaining <- remaining (0),
+        // X-RateLimit-Reset <- resetAt, Retry-After <- retryAfterSeconds.
+        expect(result.allowed).toBe(false);
+        expect(result.limit).toBe(TIER_HOURLY_LIMITS.free);
+        expect(result.remaining).toBe(0);
+        expect(result.resetAt).toBe(new Date(oldestCreatedAt).getTime() + WINDOW_MS);
+        expect(result.retryAfterSeconds).toBe(
+            Math.ceil((result.resetAt - NOW) / 1_000)
+        );
+        expect(result.retryAfterSeconds).toBeGreaterThan(0);
+    });
+
+    it('does not log a request that is rejected', async () => {
+        const supabase = createSupabaseMock({
+            countResult: { count: TIER_HOURLY_LIMITS.free, error: null },
+            oldestRow: { created_at: new Date(NOW).toISOString() },
+            escalationRow: null,
+        });
+
+        await checkDeploymentRateLimit(supabase, 'user-1', 'free');
+
+        expect(supabase.insert).not.toHaveBeenCalled();
+    });
+
+    it('retryAfterSeconds is always at least 1 even when the window resets almost immediately', async () => {
+        const supabase = createSupabaseMock({
+            countResult: { count: TIER_HOURLY_LIMITS.free, error: null },
+            oldestRow: { created_at: new Date(NOW - WINDOW_MS + 100).toISOString() },
+            escalationRow: null,
+        });
+
+        const result = await checkDeploymentRateLimit(supabase, 'user-1', 'free');
+
+        expect(result.retryAfterSeconds).toBeGreaterThanOrEqual(1);
+    });
+
+    it.each([
+        ['free', TIER_HOURLY_LIMITS.free],
+        ['pro', TIER_HOURLY_LIMITS.pro],
+        ['enterprise', TIER_HOURLY_LIMITS.enterprise],
+    ] as const)('uses the %s tier limit of %d requests/hour', async (tier, limit) => {
+        const supabase = createSupabaseMock({
+            countResult: { count: 0, error: null },
+            escalationRow: null,
+        });
+
+        const result = await checkDeploymentRateLimit(supabase, 'user-1', tier);
+
+        expect(result.limit).toBe(limit);
+    });
+
+    it('halves the effective limit once the user has been escalated', async () => {
+        const supabase = createSupabaseMock({
+            countResult: { count: 4, error: null },
+            escalationRow: { hit_count: 3, window_start: new Date(NOW).toISOString() },
+        });
+
+        const result = await checkDeploymentRateLimit(supabase, 'user-1', 'free');
+        const expectedLimit = Math.floor(TIER_HOURLY_LIMITS.free * ESCALATION_REDUCTION);
+
+        expect(result.escalated).toBe(true);
+        expect(result.limit).toBe(expectedLimit);
+        // 4 requests already made against a reduced limit of 5 -> still allowed, 0 remaining after this one.
+        expect(result.allowed).toBe(expectedLimit > 4);
+    });
+
+    it('ignores an escalation row whose window has expired', async () => {
+        const expiredWindowStart = new Date(NOW - WINDOW_MS - 60_000).toISOString();
+        const supabase = createSupabaseMock({
+            countResult: { count: 4, error: null },
+            escalationRow: { hit_count: 5, window_start: expiredWindowStart },
+        });
+
+        const result = await checkDeploymentRateLimit(supabase, 'user-1', 'free');
+
+        expect(result.escalated).toBe(false);
+        expect(result.limit).toBe(TIER_HOURLY_LIMITS.free);
+    });
+
+    it('fails open (allows the request) when the count query errors', async () => {
+        const supabase = createSupabaseMock({
+            countResult: { count: null, error: new Error('db unavailable') },
+            escalationRow: null,
+        });
+
+        const result = await checkDeploymentRateLimit(supabase, 'user-1', 'free');
+
+        expect(result.allowed).toBe(true);
+        expect(result.limit).toBe(TIER_HOURLY_LIMITS.free);
+        expect(supabase.insert).not.toHaveBeenCalled();
+    });
+
+    it('starts a fresh escalation record via upsert on the first rejection', async () => {
+        const supabase = createSupabaseMock({
+            countResult: { count: TIER_HOURLY_LIMITS.free, error: null },
+            oldestRow: { created_at: new Date(NOW).toISOString() },
+            escalationRow: null,
+        });
+
+        await checkDeploymentRateLimit(supabase, 'user-1', 'free');
+
+        expect(supabase.upsert).toHaveBeenCalledWith(
+            expect.objectContaining({ user_id: 'user-1', hit_count: 1 })
+        );
+        expect(supabase.update).not.toHaveBeenCalled();
+    });
+
+    it('increments an existing, still-active escalation record via update', async () => {
+        const supabase = createSupabaseMock({
+            countResult: { count: TIER_HOURLY_LIMITS.free, error: null },
+            oldestRow: { created_at: new Date(NOW).toISOString() },
+            escalationRow: { hit_count: 1, window_start: new Date(NOW).toISOString() },
+        });
+
+        await checkDeploymentRateLimit(supabase, 'user-1', 'free');
+
+        expect(supabase.update).toHaveBeenCalledWith(
+            expect.objectContaining({ hit_count: 2 })
+        );
+        expect(supabase.upsert).not.toHaveBeenCalled();
+    });
+});

--- a/apps/backend/src/lib/api/security-headers.test.ts
+++ b/apps/backend/src/lib/api/security-headers.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import type { SecurityHeader } from './security-headers';
+
+// isDev/cspValue are computed once at module load time from NODE_ENV, so each
+// test that needs a specific environment resets the module registry and
+// re-imports it under that environment.
+async function loadHeaders(nodeEnv: string): Promise<SecurityHeader[]> {
+    vi.resetModules();
+    process.env.NODE_ENV = nodeEnv;
+    const mod = await import('./security-headers');
+    return mod.getSecurityHeaders();
+}
+
+describe('getSecurityHeaders', () => {
+    const originalNodeEnv = process.env.NODE_ENV;
+
+    afterEach(() => {
+        process.env.NODE_ENV = originalNodeEnv;
+        vi.resetModules();
+    });
+
+    it('uses Content-Security-Policy-Report-Only in development', async () => {
+        const headers = await loadHeaders('development');
+        const csp = headers.find((h) => h.key.startsWith('Content-Security-Policy'));
+
+        expect(csp?.key).toBe('Content-Security-Policy-Report-Only');
+    });
+
+    it('uses an enforced Content-Security-Policy in production', async () => {
+        const headers = await loadHeaders('production');
+        const csp = headers.find((h) => h.key.startsWith('Content-Security-Policy'));
+
+        expect(csp?.key).toBe('Content-Security-Policy');
+    });
+
+    it('treats any non-production NODE_ENV as development for CSP purposes', async () => {
+        const headers = await loadHeaders('test');
+        const csp = headers.find((h) => h.key.startsWith('Content-Security-Policy'));
+
+        expect(csp?.key).toBe('Content-Security-Policy-Report-Only');
+    });
+
+    it('returns exactly the documented set of headers, in order', async () => {
+        const headers = await loadHeaders('production');
+        const keys = headers.map((h) => h.key);
+
+        expect(keys).toEqual([
+            'Content-Security-Policy',
+            'Strict-Transport-Security',
+            'X-Content-Type-Options',
+            'X-Frame-Options',
+            'Referrer-Policy',
+            'Permissions-Policy',
+        ]);
+    });
+
+    it('sets the exact values for the static (non-CSP) headers', async () => {
+        const headers = await loadHeaders('production');
+        const byKey = Object.fromEntries(headers.map((h) => [h.key, h.value]));
+
+        expect(byKey['Strict-Transport-Security']).toBe(
+            'max-age=63072000; includeSubDomains; preload'
+        );
+        expect(byKey['X-Content-Type-Options']).toBe('nosniff');
+        expect(byKey['X-Frame-Options']).toBe('DENY');
+        expect(byKey['Referrer-Policy']).toBe('strict-origin-when-cross-origin');
+        expect(byKey['Permissions-Policy']).toBe('camera=(), microphone=(), geolocation=()');
+    });
+
+    it('builds a CSP value containing every configured directive', async () => {
+        const headers = await loadHeaders('production');
+        const csp = headers.find((h) => h.key === 'Content-Security-Policy')!.value;
+
+        expect(csp).toContain("default-src 'self'");
+        expect(csp).toContain("script-src 'self'");
+        expect(csp).toContain("style-src 'self' 'unsafe-inline'");
+        expect(csp).toContain("img-src 'self' data: https:");
+        expect(csp).toContain("font-src 'self'");
+        expect(csp).toContain(
+            "connect-src 'self' https://*.supabase.co https://api.stripe.com https://api.vercel.com https://horizon-testnet.stellar.org https://horizon.stellar.org"
+        );
+        expect(csp).toContain("frame-src 'none'");
+        expect(csp).toContain("object-src 'none'");
+        expect(csp).toContain("base-uri 'self'");
+        expect(csp).toContain("form-action 'self'");
+        expect(csp).toContain('upgrade-insecure-requests');
+    });
+
+    it('produces the same CSP value regardless of dev/prod mode', async () => {
+        const devCsp = (await loadHeaders('development')).find((h) =>
+            h.key.startsWith('Content-Security-Policy')
+        )!.value;
+        const prodCsp = (await loadHeaders('production')).find((h) => h.key === 'Content-Security-Policy')!
+            .value;
+
+        expect(devCsp).toBe(prodCsp);
+    });
+});

--- a/apps/backend/src/lib/api/with-role.test.ts
+++ b/apps/backend/src/lib/api/with-role.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { NextRequest, NextResponse } from 'next/server';
+import { withRole } from './with-role';
+
+// --- Supabase server mock ---
+const mockGetUser = vi.fn();
+
+vi.mock('@/lib/supabase/server', () => ({
+    createClient: () => ({
+        auth: { getUser: mockGetUser },
+    }),
+}));
+
+const makeRequest = () => new NextRequest('http://localhost/api/admin/stats');
+
+describe('withRole', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        delete process.env.ADMIN_USER_IDS;
+    });
+
+    afterEach(() => {
+        delete process.env.ADMIN_USER_IDS;
+    });
+
+    it('returns 401 when unauthenticated', async () => {
+        mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+
+        const handler = vi.fn();
+        const wrapped = withRole('admin', handler);
+        const res = await wrapped(makeRequest(), { params: {} });
+
+        expect(res.status).toBe(401);
+        expect(await res.json()).toEqual({ error: 'Unauthorized' });
+        expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('returns 401 when getUser returns an error', async () => {
+        mockGetUser.mockResolvedValue({ data: { user: null }, error: new Error('jwt expired') });
+
+        const handler = vi.fn();
+        const wrapped = withRole('admin', handler);
+        const res = await wrapped(makeRequest(), { params: {} });
+
+        expect(res.status).toBe(401);
+        expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('returns 403 when the authenticated user has a different role', async () => {
+        mockGetUser.mockResolvedValue({
+            data: { user: { id: 'user-1', user_metadata: { role: 'member' } } },
+            error: null,
+        });
+
+        const handler = vi.fn();
+        const wrapped = withRole('admin', handler);
+        const res = await wrapped(makeRequest(), { params: {} });
+
+        expect(res.status).toBe(403);
+        expect(await res.json()).toEqual({ error: 'Forbidden: insufficient role' });
+        expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('returns 403 when the user has no role metadata and is not in the ADMIN_USER_IDS fallback', async () => {
+        mockGetUser.mockResolvedValue({
+            data: { user: { id: 'user-1', user_metadata: {} } },
+            error: null,
+        });
+
+        const handler = vi.fn();
+        const wrapped = withRole('admin', handler);
+        const res = await wrapped(makeRequest(), { params: {} });
+
+        expect(res.status).toBe(403);
+        expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('calls the handler when user_metadata.role matches the required role', async () => {
+        mockGetUser.mockResolvedValue({
+            data: { user: { id: 'user-1', user_metadata: { role: 'admin' } } },
+            error: null,
+        });
+
+        const handler = vi.fn().mockResolvedValue(NextResponse.json({ ok: true }));
+        const wrapped = withRole('admin', handler);
+        const res = await wrapped(makeRequest(), { params: {} });
+
+        expect(res.status).toBe(200);
+        expect(handler).toHaveBeenCalledOnce();
+        expect(handler.mock.calls[0][1]).toMatchObject({ userId: 'user-1' });
+    });
+
+    it('calls the handler when the user id is in the ADMIN_USER_IDS fallback allowlist', async () => {
+        process.env.ADMIN_USER_IDS = 'user-2, user-3';
+        mockGetUser.mockResolvedValue({
+            data: { user: { id: 'user-3', user_metadata: {} } },
+            error: null,
+        });
+
+        const handler = vi.fn().mockResolvedValue(NextResponse.json({ ok: true }));
+        const wrapped = withRole('admin', handler);
+        const res = await wrapped(makeRequest(), { params: {} });
+
+        expect(res.status).toBe(200);
+        expect(handler).toHaveBeenCalledOnce();
+    });
+
+    it('does not grant access via ADMIN_USER_IDS when the user id is not listed', async () => {
+        process.env.ADMIN_USER_IDS = 'user-2, user-3';
+        mockGetUser.mockResolvedValue({
+            data: { user: { id: 'user-99', user_metadata: {} } },
+            error: null,
+        });
+
+        const handler = vi.fn();
+        const wrapped = withRole('admin', handler);
+        const res = await wrapped(makeRequest(), { params: {} });
+
+        expect(res.status).toBe(403);
+        expect(handler).not.toHaveBeenCalled();
+    });
+});

--- a/apps/backend/src/lib/api/with-usage-tracking.test.ts
+++ b/apps/backend/src/lib/api/with-usage-tracking.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi } from 'vitest';
+import { NextRequest, NextResponse } from 'next/server';
+import { withUsageTracking, detectOperationType } from './with-usage-tracking';
+
+const makeRequest = (pathname = '/api/deployments', method = 'GET') =>
+    new NextRequest(`http://localhost${pathname}`, { method });
+
+describe('withUsageTracking', () => {
+    it('returns the handler response unchanged on success (pass-through)', async () => {
+        const handler = vi.fn().mockResolvedValue(NextResponse.json({ id: 'dep_1' }, { status: 201 }));
+        const wrapped = await withUsageTracking(handler);
+
+        const res = await wrapped(makeRequest(), { params: {} });
+
+        expect(res.status).toBe(201);
+        expect(await res.json()).toEqual({ id: 'dep_1' });
+        expect(handler).toHaveBeenCalledOnce();
+    });
+
+    it('passes params and the resolved operationType through to the handler', async () => {
+        const handler = vi.fn().mockResolvedValue(NextResponse.json({ ok: true }));
+        const wrapped = await withUsageTracking(handler, 'custom_op');
+
+        await wrapped(makeRequest('/api/deployments'), { params: { id: 'dep_1' } });
+
+        expect(handler).toHaveBeenCalledWith(
+            expect.anything(),
+            expect.objectContaining({ params: { id: 'dep_1' }, operationType: 'custom_op' })
+        );
+    });
+
+    it('detects the operation type from the request path when none is supplied', async () => {
+        const handler = vi.fn().mockResolvedValue(NextResponse.json({ ok: true }));
+        const wrapped = await withUsageTracking(handler);
+
+        await wrapped(makeRequest('/api/deployments/abc/preview'), { params: {} });
+
+        expect(handler).toHaveBeenCalledWith(
+            expect.anything(),
+            expect.objectContaining({ operationType: 'deployment_preview' })
+        );
+    });
+
+    it('propagates errors thrown by the wrapped handler', async () => {
+        const handler = vi.fn().mockRejectedValue(new Error('handler failed'));
+        const wrapped = await withUsageTracking(handler);
+
+        await expect(wrapped(makeRequest(), { params: {} })).rejects.toThrow('handler failed');
+        expect(handler).toHaveBeenCalledOnce();
+    });
+
+    // withUsageTracking has a TODO (see with-usage-tracking.ts) to extract the
+    // authenticated user from the session/JWT and record real usage. Until that
+    // lands there is nothing to assert here — these are marked todo rather than
+    // silently omitted so the gap stays visible in `vitest run`.
+    it.todo('records usage for the authenticated user after a successful response');
+    it.todo('does not record usage when the wrapped handler throws');
+});
+
+describe('detectOperationType', () => {
+    it('detects deployment_preview', () => {
+        expect(detectOperationType('/api/deployments/abc/preview')).toBe('deployment_preview');
+    });
+
+    it('detects domain_config for https and dns paths', () => {
+        expect(detectOperationType('/api/domains/https')).toBe('domain_config');
+        expect(detectOperationType('/api/domains/dns')).toBe('domain_config');
+    });
+
+    it('detects template_clone', () => {
+        expect(detectOperationType('/api/templates/tpl_1/clone')).toBe('template_clone');
+    });
+
+    it('detects custom_domain', () => {
+        expect(detectOperationType('/api/deployments/abc/custom-domain')).toBe('custom_domain');
+    });
+
+    it('detects github_sync', () => {
+        expect(detectOperationType('/api/github/webhook')).toBe('github_sync');
+    });
+
+    it('falls back to api_call for unrecognized paths', () => {
+        expect(detectOperationType('/api/whatever')).toBe('api_call');
+    });
+});


### PR DESCRIPTION
Adds co-located unit test coverage for four backend API middleware modules that previously had none.

## What's covered

- **`with-role.test.ts`** (#1088) — allowed-role success for the `admin` role (including the `ADMIN_USER_IDS` env fallback), denied-role rejection with 403, and 401 for unauthenticated requests.
- **`with-usage-tracking.test.ts`** (#1089) — pass-through of successful handler responses, error propagation when the wrapped handler throws, and `detectOperationType` path-detection coverage. The still-unimplemented usage-recording path (blocked on the existing TODO to extract the user from the session/JWT) is marked with `test.todo` rather than silently omitted.
- **`security-headers.test.ts`** (#1090) — asserts the exact set and values of every documented security header, and both the development (`Content-Security-Policy-Report-Only`) and production (`Content-Security-Policy`) branches.
- **`deployment-rate-limit.test.ts`** (#1091) — sliding-window accept/reject behavior at the tier boundary, the escalation-triggered limit reduction, fail-open behavior on a DB error, and the `limit`/`remaining`/`resetAt`/`retryAfterSeconds` fields the caller (`apps/backend/src/app/api/deployments/route.ts`) uses to build the `X-RateLimit-*` and `Retry-After` response headers.

## Test plan

- [x] `npm run --workspace @craft/backend test -- with-role security-headers deployment-rate-limit with-usage-tracking` — 37 passed, 2 todo, 0 failed
- [x] `npx eslint` on all four new files — clean

Closes #1088
closes #1089 
closes #1090 
closes #1091
