### PR TITLE
fix(stellar): resolve map-key collapse, breaking-change detection, identifier collisions, and frozen config (#1103 #1104 #1105 #1106)

### DIFF
--- a/packages/stellar/src/abi-binding-generator.test.ts
+++ b/packages/stellar/src/abi-binding-generator.test.ts
@@ -626,3 +626,96 @@ describe('generateBinding', () => {
     expect(source).toContain('Unauthorized = 7');
   });
 });
+
+// ---------------------------------------------------------------------------
+// Regression #1105 – sanitized-identifier collision detection
+// ---------------------------------------------------------------------------
+
+describe('generateBinding – identifier collision detection (regression #1105)', () => {
+  it('throws a descriptive error when two function names sanitize to the same identifier', () => {
+    // "transfer-from" and "transfer_from" both become "transfer_from" after safeIdent
+    const entries = buildSpecEntries({
+      functions: [
+        {
+          name: 'transfer-from',
+          inputs: [{ name: 'amount', type: xdr.ScSpecTypeDef.scSpecTypeU64() }],
+          outputs: [xdr.ScSpecTypeDef.scSpecTypeBool()],
+        },
+        {
+          name: 'transfer_from',
+          inputs: [{ name: 'amount', type: xdr.ScSpecTypeDef.scSpecTypeU64() }],
+          outputs: [xdr.ScSpecTypeDef.scSpecTypeBool()],
+        },
+      ],
+    });
+
+    expect(() => generateBinding(entries)).toThrow(/collision/i);
+    expect(() => generateBinding(entries)).toThrow(/transfer.from/);
+  });
+
+  it('includes both colliding raw names in the error message', () => {
+    const entries = buildSpecEntries({
+      functions: [
+        {
+          name: 'my.method',
+          inputs: [],
+          outputs: [xdr.ScSpecTypeDef.scSpecTypeVoid()],
+        },
+        {
+          name: 'my_method',
+          inputs: [],
+          outputs: [xdr.ScSpecTypeDef.scSpecTypeVoid()],
+        },
+      ],
+    });
+
+    let err: Error | undefined;
+    try {
+      generateBinding(entries);
+    } catch (e) {
+      err = e as Error;
+    }
+    expect(err).toBeDefined();
+    expect(err!.message).toContain('my.method');
+    expect(err!.message).toContain('my_method');
+  });
+
+  it('does NOT throw when all function names produce distinct safe identifiers', () => {
+    const entries = buildSpecEntries({
+      functions: [
+        {
+          name: 'transfer',
+          inputs: [],
+          outputs: [xdr.ScSpecTypeDef.scSpecTypeVoid()],
+        },
+        {
+          name: 'approve',
+          inputs: [],
+          outputs: [xdr.ScSpecTypeDef.scSpecTypeVoid()],
+        },
+      ],
+    });
+
+    expect(() => generateBinding(entries)).not.toThrow();
+  });
+
+  it('throws when two UDT names sanitize to the same identifier', () => {
+    // "My-Type" and "My_Type" both become "My_Type"
+    const myType1 = buildStructUdt('My-Type', [
+      { name: 'value', type: xdr.ScSpecTypeDef.scSpecTypeU32() },
+    ]);
+    const myType2 = buildStructUdt('My_Type', [
+      { name: 'value', type: xdr.ScSpecTypeDef.scSpecTypeU32() },
+    ]);
+    const fnEntries = buildSpecEntries({
+      functions: [
+        { name: 'noop', inputs: [], outputs: [xdr.ScSpecTypeDef.scSpecTypeVoid()] },
+      ],
+    });
+
+    expect(() => generateBinding([myType1, myType2, ...fnEntries])).toThrow(/collision/i);
+  });
+});
+// ---------------------------------------------------------------------------
+// End regression #1105
+// ---------------------------------------------------------------------------

--- a/packages/stellar/src/abi-binding-generator.ts
+++ b/packages/stellar/src/abi-binding-generator.ts
@@ -453,6 +453,29 @@ function specEntriesToBase64(entries: xdr.ScSpecEntry[]): string[] {
 // ---------------------------------------------------------------------------
 
 /**
+ * Detect whether any two distinct raw names in `names` sanitize to the same
+ * `safeIdent` output.  Throws a descriptive error if a collision is found.
+ *
+ * @param names - Array of raw names to check (e.g. function names or UDT names)
+ * @param context - A human-readable label used in the error message (e.g. 'function', 'UDT')
+ */
+function assertNoIdentifierCollisions(names: string[], context: string): void {
+  const seen = new Map<string, string>(); // safeIdent → first raw name
+  for (const raw of names) {
+    const safe = safeIdent(raw);
+    const existing = seen.get(safe);
+    if (existing !== undefined && existing !== raw) {
+      throw new Error(
+        `Identifier collision detected in ${context} names: ` +
+        `"${existing}" and "${raw}" both sanitize to "${safe}". ` +
+        `Rename one of these in the contract before generating bindings.`,
+      );
+    }
+    seen.set(safe, raw);
+  }
+}
+
+/**
  * Generate a complete TypeScript source file that provides type-safe
  * bindings for a Soroban contract from its XDR spec entries.
  *
@@ -483,6 +506,19 @@ export function generateBinding(
   contractName?: string,
 ): string {
   const parsed = parseAbi(specEntries, contractName);
+
+  // ── Collision detection ───────────────────────────────────────────────────
+  // Detect any two distinct function names that map to the same safe identifier.
+  assertNoIdentifierCollisions(
+    parsed.functions.map((f) => f.name),
+    'function',
+  );
+  // Detect any two distinct UDT names that map to the same safe identifier.
+  assertNoIdentifierCollisions(
+    parsed.udts.map((u) => u.name),
+    'UDT',
+  );
+  // ─────────────────────────────────────────────────────────────────────────
 
   let base64: string[];
   if (typeof specEntries[0] === 'string') {

--- a/packages/stellar/src/config.test.ts
+++ b/packages/stellar/src/config.test.ts
@@ -258,3 +258,65 @@ describe('Stellar Config — Snapshot Regression Tests (#540)', () => {
         });
     });
 });
+
+// ---------------------------------------------------------------------------
+// Regression #1106 – config.stellar must re-resolve on env change
+// ---------------------------------------------------------------------------
+
+describe('config.stellar live getter (regression #1106)', () => {
+    let originalNetwork: string | undefined;
+
+    beforeEach(() => {
+        originalNetwork = process.env.STELLAR_NETWORK;
+    });
+
+    afterEach(() => {
+        if (originalNetwork === undefined) {
+            delete process.env.STELLAR_NETWORK;
+        } else {
+            process.env.STELLAR_NETWORK = originalNetwork;
+        }
+    });
+
+    it('reflects a change to STELLAR_NETWORK made after module load', async () => {
+        // Dynamically import so the getter is exercised at call-time, not frozen
+        const { config } = await import('./config');
+
+        process.env.STELLAR_NETWORK = 'testnet';
+        const first = config.stellar.network;
+
+        process.env.STELLAR_NETWORK = 'mainnet';
+        const second = config.stellar.network;
+
+        expect(first).toBe('testnet');
+        expect(second).toBe('mainnet');
+        // The critical assertion: the two reads must differ
+        expect(first).not.toBe(second);
+    });
+
+    it('returns testnet after switching back from mainnet', async () => {
+        const { config } = await import('./config');
+
+        process.env.STELLAR_NETWORK = 'mainnet';
+        expect(config.stellar.network).toBe('mainnet');
+
+        process.env.STELLAR_NETWORK = 'testnet';
+        expect(config.stellar.network).toBe('testnet');
+    });
+
+    it('config.stellar always returns the same shape as getNetworkConfig()', async () => {
+        const { config, getNetworkConfig: getConfig } = await import('./config');
+
+        process.env.STELLAR_NETWORK = 'mainnet';
+        const live = config.stellar;
+        const snapshot = getConfig();
+
+        expect(live.network).toBe(snapshot.network);
+        expect(live.horizonUrl).toBe(snapshot.horizonUrl);
+        expect(live.networkPassphrase).toBe(snapshot.networkPassphrase);
+        expect(live.sorobanRpcUrl).toBe(snapshot.sorobanRpcUrl);
+    });
+});
+// ---------------------------------------------------------------------------
+// End regression #1106
+// ---------------------------------------------------------------------------

--- a/packages/stellar/src/config.ts
+++ b/packages/stellar/src/config.ts
@@ -124,10 +124,35 @@ export function getNetworkPassphrase(network?: Network): string {
   return NETWORK_PASSPHRASES[net];
 }
 
-/** Default config resolved from environment variables. */
-export const config = {
-  stellar: getNetworkConfig(),
-} as const;
+/**
+ * Default config object whose `stellar` property is resolved fresh on every
+ * access via a getter, so that changes to `STELLAR_NETWORK` /
+ * `NEXT_PUBLIC_STELLAR_NETWORK` after module load are always reflected.
+ *
+ * Callers that need a one-time snapshot can still call `getNetworkConfig()`
+ * directly; that remains the recommended approach for most use-cases.
+ *
+ * @example
+ * ```ts
+ * // Live read — always picks up the current env var:
+ * const { network } = config.stellar;
+ *
+ * // Snapshot — freeze the value at call-time:
+ * const snapshot = getNetworkConfig();
+ * ```
+ */
+export const config: { readonly stellar: ReturnType<typeof getNetworkConfig> } = Object.defineProperties(
+  {} as { readonly stellar: ReturnType<typeof getNetworkConfig> },
+  {
+    stellar: {
+      get(): ReturnType<typeof getNetworkConfig> {
+        return getNetworkConfig();
+      },
+      enumerable: true,
+      configurable: false,
+    },
+  },
+);
 
 export default config;
 

--- a/packages/stellar/src/soroban-xdr-deserializer.test.ts
+++ b/packages/stellar/src/soroban-xdr-deserializer.test.ts
@@ -398,6 +398,109 @@ describe('serializeScVal – round-trip tests', () => {
     });
 });
 
+// ── Regression: #1103 – scvBytes / scvAddress as distinct map keys ────────────
+
+describe('scvMap with scvBytes keys (regression #1103)', () => {
+    it('deserializes multiple distinct scvBytes keys as separate entries', () => {
+        const key1 = Buffer.from([0x01, 0x02, 0x03]);
+        const key2 = Buffer.from([0xaa, 0xbb, 0xcc]);
+        const key3 = Buffer.from([0x00]);
+
+        const mapVal = xdr.ScVal.scvMap([
+            new xdr.ScMapEntry({ key: xdr.ScVal.scvBytes(key1), val: xdr.ScVal.scvU32(1) }),
+            new xdr.ScMapEntry({ key: xdr.ScVal.scvBytes(key2), val: xdr.ScVal.scvU32(2) }),
+            new xdr.ScMapEntry({ key: xdr.ScVal.scvBytes(key3), val: xdr.ScVal.scvU32(3) }),
+        ]);
+
+        const result = deserializeScVal(mapVal) as Record<string, unknown>;
+
+        // All three entries must survive — none should collapse to the same key
+        expect(Object.keys(result)).toHaveLength(3);
+        expect(result['0x010203']).toBe(1);
+        expect(result['0xaabbcc']).toBe(2);
+        expect(result['0x00']).toBe(3);
+    });
+
+    it('encodes scvBytes keys as hex with 0x prefix', () => {
+        const mapVal = xdr.ScVal.scvMap([
+            new xdr.ScMapEntry({
+                key: xdr.ScVal.scvBytes(Buffer.from([0xde, 0xad, 0xbe, 0xef])),
+                val: xdr.ScVal.scvBool(true),
+            }),
+        ]);
+
+        const result = deserializeScVal(mapVal) as Record<string, unknown>;
+        expect(result['0xdeadbeef']).toBe(true);
+    });
+
+    it('treats empty bytes as a valid distinct key', () => {
+        const mapVal = xdr.ScVal.scvMap([
+            new xdr.ScMapEntry({ key: xdr.ScVal.scvBytes(Buffer.alloc(0)), val: xdr.ScVal.scvU32(99) }),
+        ]);
+
+        const result = deserializeScVal(mapVal) as Record<string, unknown>;
+        expect(result['0x']).toBe(99);
+    });
+});
+
+describe('scvMap with scvAddress keys (regression #1103)', () => {
+    it('deserializes multiple distinct scvAddress keys as separate entries', () => {
+        const addr1 = xdr.ScAddress.scAddressTypeAccount(
+            xdr.AccountId.publicKeyTypeEd25519(Buffer.alloc(32, 0x01)),
+        );
+        const addr2 = xdr.ScAddress.scAddressTypeAccount(
+            xdr.AccountId.publicKeyTypeEd25519(Buffer.alloc(32, 0x02)),
+        );
+
+        const mapVal = xdr.ScVal.scvMap([
+            new xdr.ScMapEntry({ key: xdr.ScVal.scvAddress(addr1), val: xdr.ScVal.scvU32(10) }),
+            new xdr.ScMapEntry({ key: xdr.ScVal.scvAddress(addr2), val: xdr.ScVal.scvU32(20) }),
+        ]);
+
+        const result = deserializeScVal(mapVal) as Record<string, unknown>;
+
+        // Both entries must survive — distinct addresses must not collapse
+        expect(Object.keys(result)).toHaveLength(2);
+        const keys = Object.keys(result);
+        // Keys must be StrKey-encoded G... addresses
+        expect(keys[0]).toMatch(/^G/);
+        expect(keys[1]).toMatch(/^G/);
+        expect(keys[0]).not.toBe(keys[1]);
+        expect(result[keys[0]]).toBe(10);
+        expect(result[keys[1]]).toBe(20);
+    });
+
+    it('renders contract address keys as C... StrKey strings', () => {
+        const contractAddr = xdr.ScAddress.scAddressTypeContract(Buffer.alloc(32, 0xab));
+
+        const mapVal = xdr.ScVal.scvMap([
+            new xdr.ScMapEntry({ key: xdr.ScVal.scvAddress(contractAddr), val: xdr.ScVal.scvBool(false) }),
+        ]);
+
+        const result = deserializeScVal(mapVal) as Record<string, unknown>;
+        const keys = Object.keys(result);
+        expect(keys).toHaveLength(1);
+        expect(keys[0]).toMatch(/^C/);
+        expect(result[keys[0]]).toBe(false);
+    });
+});
+
+describe('scvMap key – unsupported type throws (regression #1103)', () => {
+    it('throws SorobanDeserializationError for unrecognized key types', () => {
+        // scvVec is not a valid map key type
+        const mapVal = xdr.ScVal.scvMap([
+            new xdr.ScMapEntry({
+                key: xdr.ScVal.scvVec([xdr.ScVal.scvU32(1)]),
+                val: xdr.ScVal.scvBool(true),
+            }),
+        ]);
+
+        expect(() => deserializeScVal(mapVal)).toThrow(SorobanDeserializationError);
+    });
+});
+
+// ── End regression #1103 ─────────────────────────────────────────────────────
+
 describe('serializeScVal – error handling', () => {
     it('throws for unsupported type', () => {
         const obj = new Date();

--- a/packages/stellar/src/soroban-xdr-deserializer.ts
+++ b/packages/stellar/src/soroban-xdr-deserializer.ts
@@ -423,6 +423,16 @@ function decodeAddress(addr: xdr.ScAddress): string {
  * Convert a ScVal map key to a string for use as an object property name.
  * Symbols and strings are used verbatim; numeric and other types are
  * rendered as their string representation.
+ *
+ * scvBytes keys are hex-encoded (prefixed with "0x") to guarantee distinct
+ * strings for distinct byte sequences.
+ *
+ * scvAddress keys are decoded via `decodeAddress` to their canonical StrKey
+ * representation (G..., C..., M..., etc.) so that each distinct address
+ * maps to a unique string.
+ *
+ * For genuinely unrecognised key types a `SorobanDeserializationError` is
+ * thrown rather than silently collapsing all such keys to the same placeholder.
  */
 function mapKeyToString(key: xdr.ScVal): string {
     const typeName = key.switch().name as string;
@@ -434,9 +444,13 @@ function mapKeyToString(key: xdr.ScVal): string {
         case 'scvU64':    return uint64ToBigInt(key.u64()).toString();
         case 'scvI64':    return int64ToBigInt(key.i64()).toString();
         case 'scvBool':   return String(key.b());
+        case 'scvBytes':  return '0x' + (key.bytes() as Buffer).toString('hex');
+        case 'scvAddress': return decodeAddress(key.address());
         default:
-            // Fall back to a recognisable placeholder rather than silently losing data.
-            return `[${typeName}]`;
+            throw new SorobanDeserializationError(
+                `Unsupported ScVal map key type: ${typeName}`,
+                typeName,
+            );
     }
 }
 

--- a/packages/stellar/src/upgrade-orchestrator.test.ts
+++ b/packages/stellar/src/upgrade-orchestrator.test.ts
@@ -198,7 +198,8 @@ describe('diffAbiSchemas', () => {
     expect(report.changes.find((c) => c.type === 'added')?.key).toBe('new_flag');
     expect(report.changes.find((c) => c.type === 'removed')?.key).toBe('admin');
     expect(report.changes.find((c) => c.type === 'type_changed')?.key).toBe('balance');
-    expect(report.breakingChanges).toHaveLength(2);
+    // admin removed (required) + balance type changed + new_flag added (required) = 3 breaking
+    expect(report.breakingChanges).toHaveLength(3);
   });
 
   // ── Function signature diffing (Issue #969) ────────────────────────────────

--- a/packages/stellar/src/upgrade-orchestrator.ts
+++ b/packages/stellar/src/upgrade-orchestrator.ts
@@ -181,6 +181,10 @@ export function diffAbiSchemas(
 
   const breakingChanges = changes.filter((c) => {
     if (c.type === 'removed' && c.oldEntry?.required) return true;
+    // A newly-added key that is required is a breaking change: existing on-chain
+    // contract instances will not have this key populated, so code that relies on
+    // its presence (per required: true) can fail post-upgrade.
+    if (c.type === 'added' && c.newEntry?.required) return true;
     if (c.type === 'type_changed') return true;
     if (c.type === 'function_removed') return true;
     if (c.type === 'function_signature_changed') return true;
@@ -216,6 +220,10 @@ export function diffAbiSchemas(
     for (const bc of breakingChanges) {
       if (bc.type === 'removed') {
         summaryLines.push(`    - Key "${bc.key}" (${bc.oldEntry?.type}) was REMOVED`);
+      } else if (bc.type === 'added') {
+        summaryLines.push(
+          `    - Key "${bc.key}" (${bc.newEntry?.type}) added as REQUIRED — existing on-chain instances lack this key`,
+        );
       } else if (bc.type === 'type_changed') {
         summaryLines.push(
           `    - Key "${bc.key}" storage type changed: ${bc.oldEntry?.type} → ${bc.newEntry?.type}`,


### PR DESCRIPTION
## Summary

Fixes four bugs in `packages/stellar` discovered and filed as separate issues. All fixes are in source files only (no dependency changes) and come with regression tests.

---

## Closes

- Closes #1103
- Closes #1104
- Closes #1105
- Closes #1106

---

## Fix #1103 — Preserve Bytes and Address Map Keys Instead of Losing Them to an Opaque Placeholder

**File:** `packages/stellar/src/soroban-xdr-deserializer.ts`

**Problem:** `mapKeyToString` fell back to `[typeName]` for any unhandled key type, causing every `scvBytes` key to collapse to `"[scvBytes]"` and every `scvAddress` key to collapse to `"[scvAddress]"`. A contract map with multiple bytes- or address-keyed entries would silently lose all but the last entry on deserialization.

**Fix:**
- `scvBytes` keys are now hex-encoded with a `0x` prefix (e.g. `0xdeadbeef`), guaranteeing distinct strings for distinct byte sequences.
- `scvAddress` keys are decoded via the existing `decodeAddress` helper to their canonical StrKey representation (`G...`, `C...`, `M...`).
- The silent `[typeName]` fallback is replaced with a `SorobanDeserializationError` throw, so genuinely unsupported key types surface as an error rather than masking a gap.

**Tests added** (`soroban-xdr-deserializer.test.ts`):
- scvMap with 3 distinct scvBytes keys → all 3 entries survive with hex-encoded keys
- scvMap with 2 distinct scvAddress (account) keys → both survive with G... strings
- scvMap with a contract address key → C... string
- scvMap with scvVec (invalid) key type → throws `SorobanDeserializationError`

---

## Fix #1104 — Classify a Newly-Required Storage Key as a Breaking Change

**File:** `packages/stellar/src/upgrade-orchestrator.ts`

**Problem:** `diffAbiSchemas` only classified *removed* required keys and *type-changed* keys as breaking. Adding a new storage key with `required: true` was reported as safe, even though existing on-chain contract instances have no such key and code that assumes its presence will fail post-upgrade.

**Fix:**
- Added `c.type === 'added' && c.newEntry?.required` to the `breakingChanges` filter.
- Extended the human-readable summary block with a distinct message for newly-required added keys: *"Key \"X\" (persistent) added as REQUIRED — existing on-chain instances lack this key"*.
- Updated the existing `'detects all additions, removals, and changes in one diff'` test whose expected `breakingChanges` count was based on the pre-fix behaviour (2 → 3, now that the added required key is correctly classified).

**Tests added/updated** (`upgrade-orchestrator.test.ts`):
- Pre-existing test `'flags added required keys as breaking'` now exercises the corrected code path.
- Pre-existing test `'includes newly-required keys in breaking change summary'` asserts the new summary text.

---

## Fix #1105 — Detect Sanitized-Identifier Collisions Before They Silently Overwrite Generated Bindings

**File:** `packages/stellar/src/abi-binding-generator.ts`

**Problem:** `safeIdent` replaces characters outside `[a-zA-Z0-9_$]` with `_`. Nothing checked whether two distinct contract names sanitized to the same identifier (e.g. `transfer-from` and `transfer_from` both become `transfer_from`). `generateBinding` would silently emit duplicate TypeScript declarations, producing code that either fails to compile or silently shadows one binding.

**Fix:**
- Added `assertNoIdentifierCollisions(names, context)` helper that groups raw names by their `safeIdent` output and throws a descriptive `Error` when any two distinct names collide.
- Called for `parsed.functions.map(f => f.name)` and `parsed.udts.map(u => u.name)` at the top of `generateBinding`, before any code is emitted.
- Error message includes both colliding raw names to make the fix actionable.

**Tests added** (`abi-binding-generator.test.ts`):
- `transfer-from` + `transfer_from` → throws with message matching `/collision/i` and containing both names
- `my.method` + `my_method` → error message contains both raw names
- Non-colliding names → does not throw
- Two UDTs `My-Type` + `My_Type` → throws collision error

---

## Fix #1106 — Re-Resolve the Stellar Network Config Singleton Instead of Freezing It at Module Import Time

**File:** `packages/stellar/src/config.ts`

**Problem:** `export const config = { stellar: getNetworkConfig() } as const` computed `stellar` once at first import. Any change to `STELLAR_NETWORK` / `NEXT_PUBLIC_STELLAR_NETWORK` after module load was silently ignored by callers of `config.stellar`, while the sibling `getNetworkConfig()` / `getSorobanRpcUrl()` functions correctly re-read the environment on every call.

**Fix:**
- Replaced the frozen singleton with an `Object.defineProperties` getter so `config.stellar` re-invokes `getNetworkConfig()` on every access.
- Type is preserved as `{ readonly stellar: ReturnType<typeof getNetworkConfig> }`.
- Existing consumers (`soroban.ts`, `soroban-ttl-manager.ts`) use `config.stellar.network` which now correctly reflects the live environment with no call-site changes needed.
- `getNetworkConfig()` remains the recommended pattern for callers that need a one-time snapshot.

**Tests added** (`config.test.ts`):
- Changing `STELLAR_NETWORK` between two reads of `config.stellar.network` returns different values.
- Switching back from `mainnet` to `testnet` is reflected immediately.
- `config.stellar` and `getNetworkConfig()` return identical values at the same env state.

---

## Testing

All new regression tests pass. The 6 failures in the test run are **pre-existing on `main`** (3 in `soroban-xdr-deserializer.test.ts` for round-trip u128/i256 and a Date serialization edge case; 3 in `abi-binding-generator.test.ts` for union/enum UDT helpers) and are not introduced or worsened by this PR.

```
npm run lint --workspace=packages/stellar   # ✅ 0 errors
vitest run [4 affected test files]          # ✅ 165 passed, 6 pre-existing failures unchanged
```
