### PR TITLE
test(backend): add unit coverage for rate limiting, error handler, Stripe client, and GitHub webhook auth

### DIFF
--- a/apps/backend/src/lib/api/deployment-rate-limit.test.ts
+++ b/apps/backend/src/lib/api/deployment-rate-limit.test.ts
@@ -1,0 +1,253 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import {
+    checkDeploymentRateLimit,
+    TIER_HOURLY_LIMITS,
+    ESCALATION_THRESHOLD,
+    ESCALATION_REDUCTION,
+    WINDOW_MS,
+} from './deployment-rate-limit';
+
+// ── Supabase mock ─────────────────────────────────────────────────────────────
+
+interface MockOptions {
+    requestRows?: Array<{ user_id: string; created_at: string }>;
+    escalationRow?: { hit_count: number; window_start: string } | null;
+    countError?: { message: string } | null;
+}
+
+function makeSupabaseMock({ requestRows = [], escalationRow = null, countError = null }: MockOptions = {}) {
+    const inserted: Array<Record<string, unknown>> = [];
+    const upserts: Array<Record<string, unknown>> = [];
+    const updates: Array<Record<string, unknown>> = [];
+    let escalation = escalationRow;
+
+    const client = {
+        from(table: string) {
+            if (table === 'deployment_rate_limit_requests') {
+                return {
+                    select(_cols: string, opts?: { count?: string; head?: boolean }) {
+                        if (opts?.count === 'exact' && opts?.head) {
+                            return {
+                                eq(_col: string, userId: string) {
+                                    return {
+                                        gte(_col2: string, sinceIso: string) {
+                                            if (countError) {
+                                                return Promise.resolve({ count: null, error: countError });
+                                            }
+                                            const count = requestRows.filter(
+                                                (r) => r.user_id === userId && r.created_at >= sinceIso,
+                                            ).length;
+                                            return Promise.resolve({ count, error: null });
+                                        },
+                                    };
+                                },
+                            };
+                        }
+                        // oldest-request lookup: select('created_at')
+                        return {
+                            eq(_col: string, userId: string) {
+                                return {
+                                    gte(_col2: string, sinceIso: string) {
+                                        return {
+                                            order() {
+                                                return {
+                                                    limit() {
+                                                        return {
+                                                            single() {
+                                                                const rows = requestRows
+                                                                    .filter(
+                                                                        (r) =>
+                                                                            r.user_id === userId &&
+                                                                            r.created_at >= sinceIso,
+                                                                    )
+                                                                    .sort((a, b) =>
+                                                                        a.created_at.localeCompare(b.created_at),
+                                                                    );
+                                                                const oldest = rows[0] ?? null;
+                                                                return Promise.resolve({
+                                                                    data: oldest,
+                                                                    error: oldest ? null : { message: 'no rows' },
+                                                                });
+                                                            },
+                                                        };
+                                                    },
+                                                };
+                                            },
+                                        };
+                                    },
+                                };
+                            },
+                        };
+                    },
+                    insert(row: Record<string, unknown>) {
+                        inserted.push(row);
+                        return Promise.resolve({ error: null });
+                    },
+                };
+            }
+
+            if (table === 'deployment_rate_limit_escalations') {
+                return {
+                    select() {
+                        return {
+                            eq() {
+                                return {
+                                    single() {
+                                        return Promise.resolve({ data: escalation, error: null });
+                                    },
+                                };
+                            },
+                        };
+                    },
+                    upsert(row: Record<string, unknown>) {
+                        upserts.push(row);
+                        escalation = row as typeof escalation;
+                        return Promise.resolve({ error: null });
+                    },
+                    update(patch: Record<string, unknown>) {
+                        return {
+                            eq() {
+                                updates.push(patch);
+                                escalation = { ...(escalation as any), ...patch };
+                                return Promise.resolve({ error: null });
+                            },
+                        };
+                    },
+                };
+            }
+
+            throw new Error(`Unexpected table: ${table}`);
+        },
+    } as unknown as SupabaseClient;
+
+    return { client, inserted, upserts, updates, getEscalation: () => escalation };
+}
+
+describe('checkDeploymentRateLimit', () => {
+    it('allows a request under the tier limit and logs it', async () => {
+        const mock = makeSupabaseMock({ requestRows: [] });
+
+        const result = await checkDeploymentRateLimit(mock.client, 'user-1', 'free');
+
+        expect(result.allowed).toBe(true);
+        expect(result.limit).toBe(TIER_HOURLY_LIMITS.free);
+        expect(result.remaining).toBe(TIER_HOURLY_LIMITS.free - 1);
+        expect(result.escalated).toBe(false);
+        expect(mock.inserted).toHaveLength(1);
+        expect(mock.inserted[0]).toMatchObject({ user_id: 'user-1' });
+    });
+
+    it('allows the request that reaches exactly one below the limit boundary', async () => {
+        const now = Date.now();
+        const requestRows = Array.from({ length: TIER_HOURLY_LIMITS.free - 1 }, (_, i) => ({
+            user_id: 'user-2',
+            created_at: new Date(now - i * 1000).toISOString(),
+        }));
+        const mock = makeSupabaseMock({ requestRows });
+
+        const result = await checkDeploymentRateLimit(mock.client, 'user-2', 'free');
+
+        expect(result.allowed).toBe(true);
+        expect(result.remaining).toBe(0);
+    });
+
+    it('rejects the request that hits the limit boundary', async () => {
+        const now = Date.now();
+        const requestRows = Array.from({ length: TIER_HOURLY_LIMITS.free }, (_, i) => ({
+            user_id: 'user-3',
+            created_at: new Date(now - i * 1000).toISOString(),
+        }));
+        const mock = makeSupabaseMock({ requestRows });
+
+        const result = await checkDeploymentRateLimit(mock.client, 'user-3', 'free');
+
+        expect(result.allowed).toBe(false);
+        expect(result.remaining).toBe(0);
+        expect(result.limit).toBe(TIER_HOURLY_LIMITS.free);
+        expect(mock.inserted).toHaveLength(0);
+    });
+
+    it('computes retryAfterSeconds and resetAt from the oldest request in the window on rejection', async () => {
+        const now = Date.now();
+        const oldestCreatedAt = new Date(now - 10_000).toISOString();
+        const requestRows = [
+            { user_id: 'user-4', created_at: oldestCreatedAt },
+            ...Array.from({ length: TIER_HOURLY_LIMITS.free - 1 }, (_, i) => ({
+                user_id: 'user-4',
+                created_at: new Date(now - i * 100).toISOString(),
+            })),
+        ];
+        const mock = makeSupabaseMock({ requestRows });
+
+        const result = await checkDeploymentRateLimit(mock.client, 'user-4', 'free');
+
+        expect(result.allowed).toBe(false);
+        const expectedResetAt = new Date(oldestCreatedAt).getTime() + WINDOW_MS;
+        expect(result.resetAt).toBe(expectedResetAt);
+        expect(result.retryAfterSeconds).toBe(Math.max(1, Math.ceil((expectedResetAt - now) / 1000)));
+    });
+
+    it('records an escalation hit on rejection', async () => {
+        const now = Date.now();
+        const requestRows = Array.from({ length: TIER_HOURLY_LIMITS.free }, (_, i) => ({
+            user_id: 'user-5',
+            created_at: new Date(now - i * 1000).toISOString(),
+        }));
+        const mock = makeSupabaseMock({ requestRows, escalationRow: null });
+
+        await checkDeploymentRateLimit(mock.client, 'user-5', 'free');
+
+        expect(mock.getEscalation()).toMatchObject({ user_id: 'user-5', hit_count: 1 });
+    });
+
+    it('halves the effective limit once escalation threshold is reached', async () => {
+        const now = Date.now();
+        const mock = makeSupabaseMock({
+            requestRows: [],
+            escalationRow: {
+                hit_count: ESCALATION_THRESHOLD,
+                window_start: new Date(now - 1000).toISOString(),
+            },
+        });
+
+        const result = await checkDeploymentRateLimit(mock.client, 'user-6', 'free');
+
+        expect(result.escalated).toBe(true);
+        expect(result.limit).toBe(Math.floor(TIER_HOURLY_LIMITS.free * ESCALATION_REDUCTION));
+    });
+
+    it('does not escalate when the escalation window has expired', async () => {
+        const now = Date.now();
+        const mock = makeSupabaseMock({
+            requestRows: [],
+            escalationRow: {
+                hit_count: ESCALATION_THRESHOLD + 5,
+                window_start: new Date(now - WINDOW_MS - 1000).toISOString(),
+            },
+        });
+
+        const result = await checkDeploymentRateLimit(mock.client, 'user-7', 'free');
+
+        expect(result.escalated).toBe(false);
+        expect(result.limit).toBe(TIER_HOURLY_LIMITS.free);
+    });
+
+    it('fails open (allows the request) when the count query errors', async () => {
+        const mock = makeSupabaseMock({ countError: { message: 'db unavailable' } });
+
+        const result = await checkDeploymentRateLimit(mock.client, 'user-8', 'pro');
+
+        expect(result.allowed).toBe(true);
+        expect(result.limit).toBe(TIER_HOURLY_LIMITS.pro);
+        expect(result.retryAfterSeconds).toBe(0);
+    });
+
+    it('applies the correct per-tier limits', async () => {
+        for (const tier of ['free', 'pro', 'enterprise'] as const) {
+            const mock = makeSupabaseMock();
+            const result = await checkDeploymentRateLimit(mock.client, `user-tier-${tier}`, tier);
+            expect(result.limit).toBe(TIER_HOURLY_LIMITS[tier]);
+        }
+    });
+});

--- a/apps/backend/src/lib/api/error-handler.test.ts
+++ b/apps/backend/src/lib/api/error-handler.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect } from 'vitest';
+import { handleApiError, validationError, unauthorizedError, AppError } from './error-handler';
+
+class GitHubCredentialError extends Error {
+    constructor(
+        public readonly code: string,
+        message: string,
+    ) {
+        super(message);
+        this.name = 'GitHubCredentialError';
+    }
+}
+
+async function bodyOf(res: Response) {
+    return res.json();
+}
+
+describe('handleApiError', () => {
+    it('formats a known AppError using its own code, and includes details', async () => {
+        const err = new AppError('AUTH_FORBIDDEN', 'You cannot do that.', { reason: 'not-owner' });
+
+        const res = handleApiError(err);
+        const body = await bodyOf(res);
+
+        expect(res.status).toBe(403);
+        expect(body).toMatchObject({
+            code: 'AUTH_FORBIDDEN',
+            category: 'auth',
+            message: 'You cannot do that.',
+            details: { reason: 'not-owner' },
+        });
+    });
+
+    it('omits details for a plain Error', async () => {
+        const res = handleApiError(new Error('boom'));
+        const body = await bodyOf(res);
+
+        expect(body.details).toBeUndefined();
+    });
+
+    it('includes the correlationId when provided', async () => {
+        const res = handleApiError(new Error('boom'), 'corr-123');
+        const body = await bodyOf(res);
+
+        expect(body.correlationId).toBe('corr-123');
+    });
+
+    it('omits the correlationId when not provided', async () => {
+        const res = handleApiError(new Error('boom'));
+        const body = await bodyOf(res);
+
+        expect(body.correlationId).toBeUndefined();
+    });
+
+    it('classifies an unauthorized message', async () => {
+        const res = handleApiError(new Error('Unauthorized access'));
+        const body = await bodyOf(res);
+
+        expect(res.status).toBe(401);
+        expect(body.code).toBe('AUTH_UNAUTHENTICATED');
+    });
+
+    it('classifies an unauthenticated message', async () => {
+        const res = handleApiError(new Error('user is unauthenticated'));
+        const body = await bodyOf(res);
+
+        expect(body.code).toBe('AUTH_UNAUTHENTICATED');
+    });
+
+    it('classifies a forbidden message', async () => {
+        const res = handleApiError(new Error('Forbidden: no access'));
+        const body = await bodyOf(res);
+
+        expect(res.status).toBe(403);
+        expect(body.code).toBe('AUTH_FORBIDDEN');
+    });
+
+    it.each([
+        ['NOT_CONNECTED', 'AUTH_TOKEN_NOT_CONNECTED'],
+        ['TOKEN_EXPIRED', 'AUTH_TOKEN_EXPIRED'],
+        ['TOKEN_INVALID', 'AUTH_TOKEN_INVALID'],
+        ['SOMETHING_ELSE', 'GITHUB_AUTH_FAILED'],
+    ])('maps GitHubCredentialError code %s to %s', async (credCode, expectedCode) => {
+        const err = new GitHubCredentialError(credCode, 'credential problem');
+        const res = handleApiError(err);
+        const body = await bodyOf(res);
+
+        expect(body.code).toBe(expectedCode);
+        expect(body.message).toBe('credential problem');
+    });
+
+    it('classifies a GitHub rate-limit message', async () => {
+        const res = handleApiError(new Error('GitHub API rate limit exceeded'));
+        const body = await bodyOf(res);
+
+        expect(res.status).toBe(429);
+        expect(body.code).toBe('GITHUB_RATE_LIMITED');
+    });
+
+    it('classifies a Vercel rate-limit message', async () => {
+        const res = handleApiError(new Error('vercel returned 429'));
+        const body = await bodyOf(res);
+
+        expect(body.code).toBe('VERCEL_RATE_LIMITED');
+    });
+
+    it('defaults an unattributed rate-limit message to GitHub', async () => {
+        const res = handleApiError(new Error('rate limit hit'));
+        const body = await bodyOf(res);
+
+        expect(body.code).toBe('GITHUB_RATE_LIMITED');
+    });
+
+    it('classifies a GitHub network error', async () => {
+        const res = handleApiError(new Error('github fetch failed: ECONNREFUSED'));
+        const body = await bodyOf(res);
+
+        expect(body.code).toBe('GITHUB_NETWORK_ERROR');
+        expect(body.message).toBe('Could not reach GitHub.');
+    });
+
+    it('classifies a Vercel network error', async () => {
+        const res = handleApiError(new Error('vercel network unreachable'));
+        const body = await bodyOf(res);
+
+        expect(body.code).toBe('VERCEL_NETWORK_ERROR');
+    });
+
+    it('classifies a Stellar network error', async () => {
+        const res = handleApiError(new Error('stellar network timeout'));
+        const body = await bodyOf(res);
+
+        expect(body.code).toBe('STELLAR_ENDPOINT_UNREACHABLE');
+    });
+
+    it('classifies an unattributed network error as internal', async () => {
+        const res = handleApiError(new Error('network unreachable'));
+        const body = await bodyOf(res);
+
+        expect(body.code).toBe('INTERNAL_SERVER_ERROR');
+        expect(body.message).toBe('A network error occurred.');
+    });
+
+    it('classifies a database error without leaking the raw driver message', async () => {
+        const rawMessage = 'supabase: relation "users" violates unique constraint at /internal/db.ts:42';
+        const res = handleApiError(new Error(rawMessage));
+        const body = await bodyOf(res);
+
+        expect(res.status).toBe(500);
+        expect(body.code).toBe('INTERNAL_DATABASE_ERROR');
+        expect(body.message).toBe('A database error occurred.');
+        expect(body.message).not.toContain(rawMessage);
+        expect(JSON.stringify(body)).not.toContain('/internal/db.ts');
+    });
+
+    it('classifies an unknown generic error without leaking its message or a stack trace', async () => {
+        const err = new Error('SELECT * FROM secrets WHERE token = "abc123"');
+        const res = handleApiError(err);
+        const body = await bodyOf(res);
+
+        expect(res.status).toBe(500);
+        expect(body.code).toBe('INTERNAL_SERVER_ERROR');
+        expect(body.category).toBe('internal');
+        expect(body.message).toBe('An unexpected error occurred.');
+        expect(JSON.stringify(body)).not.toContain('secrets');
+        expect(JSON.stringify(body)).not.toContain('abc123');
+        expect(body).not.toHaveProperty('stack');
+    });
+
+    it('classifies a non-Error thrown value as an unexpected internal error', async () => {
+        const res = handleApiError('just a string');
+        const body = await bodyOf(res);
+
+        expect(body.code).toBe('INTERNAL_SERVER_ERROR');
+        expect(body.message).toBe('An unexpected error occurred.');
+    });
+});
+
+describe('validationError', () => {
+    it('returns a 400 with the validation code and provided details', async () => {
+        const res = validationError({ field: 'email', issue: 'required' });
+        const body = await bodyOf(res);
+
+        expect(res.status).toBe(400);
+        expect(body).toMatchObject({
+            code: 'VALIDATION_SCHEMA_ERROR',
+            category: 'validation',
+            message: 'Validation failed.',
+            details: { field: 'email', issue: 'required' },
+        });
+    });
+
+    it('includes the correlationId when provided', async () => {
+        const res = validationError({ field: 'email' }, 'corr-456');
+        const body = await bodyOf(res);
+
+        expect(body.correlationId).toBe('corr-456');
+    });
+});
+
+describe('unauthorizedError', () => {
+    it('returns a 401 with the auth code', async () => {
+        const res = unauthorizedError();
+        const body = await bodyOf(res);
+
+        expect(res.status).toBe(401);
+        expect(body).toMatchObject({
+            code: 'AUTH_UNAUTHENTICATED',
+            category: 'auth',
+            message: 'Authentication required.',
+        });
+        expect(body.correlationId).toBeUndefined();
+    });
+
+    it('includes the correlationId when provided', async () => {
+        const res = unauthorizedError('corr-789');
+        const body = await bodyOf(res);
+
+        expect(body.correlationId).toBe('corr-789');
+    });
+});

--- a/apps/backend/src/lib/github/github-webhook.test.ts
+++ b/apps/backend/src/lib/github/github-webhook.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { NextRequest, NextResponse } from 'next/server';
+
+const { mockVerify, mockWarn } = vi.hoisted(() => ({
+    mockVerify: vi.fn(),
+    mockWarn: vi.fn(),
+}));
+
+vi.mock('./webhook-verification', () => ({
+    verifyGitHubWebhookSignature: mockVerify,
+}));
+
+vi.mock('@/lib/api/logger', () => ({
+    createLogger: () => ({ warn: mockWarn, info: vi.fn(), error: vi.fn() }),
+}));
+
+import { verifyGitHubSignature, withGitHubWebhookAuth } from './github-webhook';
+
+function makeRequest(body: string, headers: Record<string, string> = {}) {
+    return new NextRequest('http://localhost/api/admin/webhooks/github', {
+        method: 'POST',
+        headers,
+        body,
+    });
+}
+
+describe('verifyGitHubSignature', () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    it('delegates to verifyGitHubWebhookSignature with the same arguments', () => {
+        mockVerify.mockReturnValue(true);
+
+        const result = verifyGitHubSignature('payload', 'sha256=abc', 'secret');
+
+        expect(result).toBe(true);
+        expect(mockVerify).toHaveBeenCalledWith('payload', 'sha256=abc', 'secret');
+    });
+
+    it('returns false when the underlying verifier rejects the signature', () => {
+        mockVerify.mockReturnValue(false);
+
+        expect(verifyGitHubSignature('payload', 'sha256=bad', 'secret')).toBe(false);
+    });
+});
+
+describe('withGitHubWebhookAuth', () => {
+    const ORIGINAL_ENV = process.env;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        process.env = { ...ORIGINAL_ENV, GITHUB_WEBHOOK_SECRET: 'test-secret' };
+    });
+
+    afterEach(() => {
+        process.env = ORIGINAL_ENV;
+    });
+
+    it('returns 401 with WWW-Authenticate: HMAC and skips verification when the secret is not configured', async () => {
+        delete process.env.GITHUB_WEBHOOK_SECRET;
+        const handler = vi.fn();
+        const wrapped = withGitHubWebhookAuth(handler);
+
+        const res = await wrapped(makeRequest('{}'));
+
+        expect(res.status).toBe(401);
+        expect(res.headers.get('WWW-Authenticate')).toBe('HMAC');
+        expect(handler).not.toHaveBeenCalled();
+        expect(mockVerify).not.toHaveBeenCalled();
+    });
+
+    it('returns 401 with WWW-Authenticate: HMAC when the signature is invalid', async () => {
+        mockVerify.mockReturnValue(false);
+        const handler = vi.fn();
+        const wrapped = withGitHubWebhookAuth(handler);
+
+        const res = await wrapped(makeRequest('{}', { 'x-hub-signature-256': 'sha256=bad' }));
+
+        expect(res.status).toBe(401);
+        expect(res.headers.get('WWW-Authenticate')).toBe('HMAC');
+        expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('logs the source IP (from x-forwarded-for) on signature failure', async () => {
+        mockVerify.mockReturnValue(false);
+        const wrapped = withGitHubWebhookAuth(vi.fn());
+
+        await wrapped(makeRequest('{}', { 'x-forwarded-for': '1.2.3.4, 5.6.7.8' }));
+
+        expect(mockWarn).toHaveBeenCalledWith('GitHub webhook signature verification failed', {
+            sourceIp: '1.2.3.4',
+        });
+    });
+
+    it('logs sourceIp as "unknown" when x-forwarded-for is absent', async () => {
+        mockVerify.mockReturnValue(false);
+        const wrapped = withGitHubWebhookAuth(vi.fn());
+
+        await wrapped(makeRequest('{}'));
+
+        expect(mockWarn).toHaveBeenCalledWith('GitHub webhook signature verification failed', {
+            sourceIp: 'unknown',
+        });
+    });
+
+    it('verifies using the raw body, x-hub-signature-256 header, and configured secret', async () => {
+        mockVerify.mockReturnValue(true);
+        const wrapped = withGitHubWebhookAuth(vi.fn().mockResolvedValue(NextResponse.json({ ok: true })));
+
+        await wrapped(makeRequest('{"action":"opened"}', { 'x-hub-signature-256': 'sha256=xyz' }));
+
+        expect(mockVerify).toHaveBeenCalledWith('{"action":"opened"}', 'sha256=xyz', 'test-secret');
+    });
+
+    it('calls the wrapped handler with a request whose body is still readable when the signature is valid', async () => {
+        mockVerify.mockReturnValue(true);
+        const handler = vi.fn().mockResolvedValue(NextResponse.json({ ok: true }));
+        const wrapped = withGitHubWebhookAuth(handler);
+
+        const res = await wrapped(makeRequest('{"action":"opened"}', { 'x-hub-signature-256': 'sha256=xyz' }));
+
+        expect(res.status).toBe(200);
+        expect(handler).toHaveBeenCalledOnce();
+        const forwardedReq = handler.mock.calls[0][0] as NextRequest;
+        await expect(forwardedReq.json()).resolves.toEqual({ action: 'opened' });
+    });
+
+    it('forwards the ctx argument to the wrapped handler unchanged', async () => {
+        mockVerify.mockReturnValue(true);
+        const handler = vi.fn().mockResolvedValue(NextResponse.json({ ok: true }));
+        const wrapped = withGitHubWebhookAuth(handler);
+        const ctx = { params: { id: '1' } };
+
+        await wrapped(makeRequest('{}', { 'x-hub-signature-256': 'sha256=xyz' }), ctx);
+
+        expect(handler.mock.calls[0][1]).toBe(ctx);
+    });
+});

--- a/apps/backend/src/lib/stripe/client.test.ts
+++ b/apps/backend/src/lib/stripe/client.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const StripeConstructorMock = vi.fn();
+
+vi.mock('stripe', () => {
+    return {
+        default: class MockStripe {
+            constructor(secretKey: string, options: Record<string, unknown>) {
+                StripeConstructorMock(secretKey, options);
+                return { __mockStripeInstance: true, secretKey, options } as unknown as MockStripe;
+            }
+        },
+    };
+});
+
+describe('stripe client', () => {
+    const ORIGINAL_ENV = process.env;
+
+    beforeEach(() => {
+        vi.resetModules();
+        StripeConstructorMock.mockClear();
+        process.env = { ...ORIGINAL_ENV };
+    });
+
+    afterEach(() => {
+        process.env = ORIGINAL_ENV;
+    });
+
+    it('throws when STRIPE_SECRET_KEY is not set', async () => {
+        delete process.env.STRIPE_SECRET_KEY;
+        const { stripe } = await import('./client');
+
+        expect(() => stripe.customers).toThrow('STRIPE_SECRET_KEY is not set');
+        expect(StripeConstructorMock).not.toHaveBeenCalled();
+    });
+
+    it('initializes the SDK with the pinned API version and typescript mode once a key is present', async () => {
+        process.env.STRIPE_SECRET_KEY = 'sk_test_123';
+        const { stripe } = await import('./client');
+
+        void stripe.customers;
+
+        expect(StripeConstructorMock).toHaveBeenCalledTimes(1);
+        expect(StripeConstructorMock).toHaveBeenCalledWith('sk_test_123', {
+            apiVersion: '2026-02-25.clover',
+            typescript: true,
+        });
+    });
+
+    it('reuses the same underlying Stripe instance across multiple property accesses', async () => {
+        process.env.STRIPE_SECRET_KEY = 'sk_test_456';
+        const { stripe } = await import('./client');
+
+        void stripe.customers;
+        void stripe.subscriptions;
+        void stripe.invoices;
+
+        expect(StripeConstructorMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not construct the client eagerly at module load time', async () => {
+        process.env.STRIPE_SECRET_KEY = 'sk_test_789';
+        await import('./client');
+
+        expect(StripeConstructorMock).not.toHaveBeenCalled();
+    });
+});

--- a/apps/backend/vitest.config.ts
+++ b/apps/backend/vitest.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),
+      '@craft/types': path.resolve(__dirname, '../../packages/types/src'),
     },
   },
 });


### PR DESCRIPTION
## Summary

Adds co-located unit test coverage for four previously-untested backend modules, as requested by four separate issues:

- `apps/backend/src/lib/api/deployment-rate-limit.ts` — covers the allow/reject paths at the per-tier limit boundary, escalation (3+ rejections halving the effective limit, and its expiry), and the fail-open behavior on a DB error. Also asserts the `limit`/`resetAt`/`retryAfterSeconds` fields returned on rejection (the values callers use to build `X-RateLimit-*`/`Retry-After` headers) are computed correctly.
- `apps/backend/src/lib/api/error-handler.ts` — covers `handleApiError`'s classification of `AppError`, `GitHubCredentialError`, auth/rate-limit/network/database message heuristics, and unknown errors, explicitly asserting no stack trace or raw internal error message ever leaks into the response body. Also covers `validationError` and `unauthorizedError`.
- `apps/backend/src/lib/stripe/client.ts` — covers the lazy Proxy-based initialization: the missing-`STRIPE_SECRET_KEY` error path, the configured API version/options passed to the SDK, that construction is deferred until first property access, and that the instance is a singleton across property accesses.
- `apps/backend/src/lib/github/github-webhook.ts` — covers the `withGitHubWebhookAuth` middleware: rejecting with `401` + `WWW-Authenticate: HMAC` when the secret is unconfigured or the signature is invalid (with source-IP logging), and forwarding a still-readable request/ctx to the wrapped handler on success. (Note: this module implements HMAC signature-verification auth, not event-type/action dispatch — there is no such dispatch logic in this file to cover; the tests target the actual routing/gating behavior this module owns.)

Also fixes a pre-existing Vitest issue uncovered while adding the error-handler tests: `@craft/types`'s `tsc` build silently emits nothing (it inherits `noEmit: true` from the shared `tsconfig`), so any runtime (non-type-only) import of `@craft/types` fails to resolve under Vitest. Added an alias in `apps/backend/vitest.config.ts` mapping `@craft/types` to its source, mirroring the path mapping already declared in the shared tsconfig.

## Test plan

- [x] `npm run test --workspace=@craft/backend -- deployment-rate-limit` passes
- [x] `npm run test --workspace=@craft/backend -- error-handler` passes
- [x] `npm run test --workspace=@craft/backend -- lib/stripe/client` passes
- [x] `npm run test --workspace=@craft/backend -- github/github-webhook` passes

Closes #1091
Closes #1092
Closes #1093
Closes #1094