### PR TITLE
fix: resolve documentation and consistency issues #1095 #1096 #1097 #1098

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,43 @@ npm run build
 
 5. Link the PR to the relevant issue.
 
+## Rate Limiting, Idempotency, and Tier Enforcement
+
+Several backend middleware modules read tunable behavior from environment
+variables or module-level constants. This section is the single reference
+for all of them; each source file below points back here.
+
+### `RATE_LIMIT_DISABLED`
+
+- **Read by:** `apps/backend/src/lib/api/with-rate-limit.ts`, `apps/backend/src/lib/api/tier-rate-limit.ts`
+- **Default:** unset (rate limiting enforced)
+- **Effect:** when set to the string `"true"`, bypasses sliding-window and tier-based rate limiting entirely. Intended for local development and CI, where generous production limits would otherwise add friction.
+
+### `IDEMPOTENCY_TTL_MS`
+
+- **Read by:** `apps/backend/src/lib/api/idempotency.ts`
+- **Default:** `86400000` (24 hours)
+- **Effect:** how long a cached response for a given `(userId, Idempotency-Key)` pair is replayed instead of re-executing the handler. Falls back to the default when unset, non-numeric, or `<= 0`.
+
+### `SCOPE_VALIDATION_CACHE_TTL_MS`
+
+- **Read by:** `apps/backend/src/lib/github/scope-validator.ts`
+- **Default:** `300000` (5 minutes)
+- **Effect:** how long a validated GitHub token-scope result is cached (keyed by a SHA-256 hash of the token) before being re-checked against the GitHub API.
+
+### Tier-limit constants
+
+These are not environment variables — they are constants defined directly in
+source, listed here so all tunable rate-limiting/tier behavior has one
+reference page.
+
+- `apps/backend/src/lib/api/tier-rate-limit.ts`:
+  - `GENERAL_TIER_LIMITS` — per-tier request budget for regular endpoints: free 100/min, pro 1000/min, enterprise 10000/min.
+  - `SENSITIVE_TIER_LIMITS` — stricter per-tier budget applied to endpoints matched by `isSensitiveEndpoint()` (auth, payments, checkout, subscription, deployment creation): free 10/min, pro 100/min, enterprise 1000/min.
+- `apps/backend/src/lib/tier-enforcement.middleware.ts`:
+  - `TIER_ORDER` — numeric ordering used to compare a user's tier against a route's required tier (`free: 0`, `pro: 1`, `enterprise: 2`).
+  - `FEATURE_GATES` — declarative map from route-pattern substrings to the minimum subscription tier required to access them.
+
 ## Snapshot Testing (Stellar Configuration)
 
 Snapshot tests capture and diff configuration outputs to catch unintended changes in network settings, RPC endpoints, and serialization.

--- a/apps/backend/src/lib/api/idempotency.ts
+++ b/apps/backend/src/lib/api/idempotency.ts
@@ -15,6 +15,9 @@
  * Usage:
  *   const handler = withIdempotency(userId, async (req) => { ... });
  *   return handler(req);
+ *
+ * See "Rate Limiting, Idempotency, and Tier Enforcement" in CONTRIBUTING.md
+ * for the full env-var reference.
  */
 
 import { NextResponse } from 'next/server';

--- a/apps/backend/src/lib/api/rate-limit.ts
+++ b/apps/backend/src/lib/api/rate-limit.ts
@@ -21,6 +21,9 @@
  * ─────────────────
  * Set RATE_LIMIT_DISABLED=true in .env.local to bypass all checks.
  * Thresholds are intentionally generous in dev to avoid friction.
+ *
+ * See "Rate Limiting, Idempotency, and Tier Enforcement" in CONTRIBUTING.md
+ * for the full env-var reference.
  */
 
 export interface RateLimitConfig {

--- a/apps/backend/src/lib/api/tier-rate-limit.ts
+++ b/apps/backend/src/lib/api/tier-rate-limit.ts
@@ -14,6 +14,9 @@ import { createClient } from '@/lib/supabase/server';
  *   - enterprise: 10000 req/min general, 1000 req/min sensitive
  *
  * Sensitive endpoints: auth, payments, deployments
+ *
+ * See "Rate Limiting, Idempotency, and Tier Enforcement" in CONTRIBUTING.md
+ * for the full reference of tier limits and the RATE_LIMIT_DISABLED env var.
  */
 
 export interface TierRateLimitConfig {

--- a/apps/backend/src/lib/api/with-validation.ts
+++ b/apps/backend/src/lib/api/with-validation.ts
@@ -41,6 +41,20 @@ function formatErrors(err: ZodError): Record<string, string[]> {
  * Validates the JSON request body against the given Zod schema.
  * Returns 400 with field-level errors if validation fails.
  * Attaches `req.validatedBody` for the inner handler.
+ *
+ * @example
+ * ```typescript
+ * const createDeploymentSchema = z.object({
+ *   projectId: z.string().uuid(),
+ *   branch: z.string().min(1),
+ * });
+ *
+ * export const POST = withValidation(createDeploymentSchema)(async (req) => {
+ *   const { projectId, branch } = req.validatedBody; // typed, already valid
+ *   const deployment = await createDeployment(projectId, branch);
+ *   return NextResponse.json(deployment, { status: 201 });
+ * });
+ * ```
  */
 export function withValidation<TBody, TParams = {}>(schema: ZodSchema<TBody>) {
     return (handler: RouteHandler<TBody, TParams>) =>
@@ -69,6 +83,20 @@ export function withValidation<TBody, TParams = {}>(schema: ZodSchema<TBody>) {
  * Validates URL search params against the given Zod schema.
  * Returns 400 with field-level errors if validation fails.
  * Attaches `req.validatedQuery` for the inner handler.
+ *
+ * @example
+ * ```typescript
+ * const listDeploymentsQuerySchema = z.object({
+ *   status: z.enum(['pending', 'live', 'failed']).optional(),
+ *   limit: z.coerce.number().int().positive().max(100).default(20),
+ * });
+ *
+ * export const GET = withQueryValidation(listDeploymentsQuerySchema)(async (req) => {
+ *   const { status, limit } = req.validatedQuery; // typed, already valid
+ *   const deployments = await listDeployments({ status, limit });
+ *   return NextResponse.json(deployments);
+ * });
+ * ```
  */
 export function withQueryValidation<TQuery, TParams = {}>(schema: ZodSchema<TQuery>) {
     return (handler: QueryHandler<TQuery, TParams>) =>
@@ -90,6 +118,17 @@ export function withQueryValidation<TQuery, TParams = {}>(schema: ZodSchema<TQue
 /**
  * Validates route params against the given Zod schema.
  * Returns 400 with field-level errors if validation fails.
+ *
+ * @example
+ * ```typescript
+ * const paramsSchema = z.object({ deploymentId: z.string().uuid() });
+ *
+ * export const DELETE = withParamsValidation(paramsSchema)(async (req, ctx) => {
+ *   const { deploymentId } = ctx.params; // typed, already valid
+ *   await deleteDeployment(deploymentId);
+ *   return NextResponse.json({ deleted: true });
+ * });
+ * ```
  */
 export function withParamsValidation<TParams extends Record<string, unknown>>(
     schema: ZodSchema<TParams>,

--- a/apps/backend/src/lib/github/scope-validator.ts
+++ b/apps/backend/src/lib/github/scope-validator.ts
@@ -30,6 +30,9 @@
  *
  * Feature: github-oauth-scope-validation
  * Issue: #658, #938
+ *
+ * See "Rate Limiting, Idempotency, and Tier Enforcement" in CONTRIBUTING.md
+ * for the full env-var reference.
  */
 
 import { createHash } from 'node:crypto';

--- a/apps/backend/src/lib/tier-enforcement.middleware.ts
+++ b/apps/backend/src/lib/tier-enforcement.middleware.ts
@@ -10,6 +10,9 @@
  *
  * Returns 402 Payment Required with an upgrade URL when the user's tier
  * is below the required minimum.
+ *
+ * See "Rate Limiting, Idempotency, and Tier Enforcement" in CONTRIBUTING.md
+ * for the full reference of FEATURE_GATES and TIER_ORDER.
  */
 
 import { NextRequest, NextResponse } from 'next/server';

--- a/apps/backend/src/services/feature-flag-engine.test.ts
+++ b/apps/backend/src/services/feature-flag-engine.test.ts
@@ -18,7 +18,7 @@ import {
     type FlagDefinition,
     type UserContext,
     type TargetingRule,
-} from './rollout-strategy';
+} from './feature-flag-engine';
 
 // ── Fixtures ──────────────────────────────────────────────────────────────────
 

--- a/apps/backend/src/services/feature-flag-engine.ts
+++ b/apps/backend/src/services/feature-flag-engine.ts
@@ -1,9 +1,12 @@
 /**
- * Deployment Rollout Strategy & Feature Flag Targeting Rules Engine
+ * Feature Flag Targeting Rules Engine
  *
- * Implements canary, blue-green, and percentage-based rollout strategies,
- * plus a feature flag evaluation engine with user-segment targeting
- * and deterministic percentage-based rollouts.
+ * Feature flag evaluation engine with user-segment targeting and
+ * deterministic percentage-based rollouts.
+ *
+ * Not to be confused with `./rollout-strategy.service.ts`, which implements
+ * the canary/blue-green deployment rollout classes (`RolloutEngine`,
+ * `BlueGreenSwitcher`).
  */
 
 import { createHmac } from 'crypto';

--- a/apps/backend/src/services/rollout-strategy.service.ts
+++ b/apps/backend/src/services/rollout-strategy.service.ts
@@ -1,3 +1,13 @@
+/**
+ * Canary & Blue-Green Deployment Rollout Strategies
+ *
+ * Implements `RolloutEngine` (percentage-based canary rollout with
+ * auto-rollback) and `BlueGreenSwitcher` (blue/green traffic switching).
+ *
+ * Not to be confused with `./feature-flag-engine.ts`, which implements the
+ * standalone feature-flag targeting/evaluation engine (`FlagEngine`).
+ */
+
 export type DeploymentColor = 'blue' | 'green';
 export type RolloutStatus = 'pending' | 'in_progress' | 'promoted' | 'rolled_back';
 

--- a/packages/stellar/src/soroban-address-derivation.fuzz.test.ts
+++ b/packages/stellar/src/soroban-address-derivation.fuzz.test.ts
@@ -18,6 +18,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
+import { Networks } from 'stellar-sdk';
 import { deriveContractAddress } from './soroban';
 
 // ── Deterministic test fixtures ───────────────────────────────────────────────
@@ -74,7 +75,7 @@ describe('F1 — invalid WASM hash lengths always throw', () => {
         for (let byteLen = 0; byteLen < 32; byteLen++) {
             const shortHash = '00'.repeat(byteLen);
             expect(
-                () => deriveContractAddress(DEPLOYER_A, SALT_32, shortHash),
+                () => deriveContractAddress(DEPLOYER_A, SALT_32, shortHash, Networks.TESTNET),
                 `expected throw for wasmHash length ${byteLen}`,
             ).toThrow('wasmHash must be 32 bytes');
         }
@@ -84,7 +85,7 @@ describe('F1 — invalid WASM hash lengths always throw', () => {
         for (let byteLen = 33; byteLen <= 64; byteLen++) {
             const longHash = '00'.repeat(byteLen);
             expect(
-                () => deriveContractAddress(DEPLOYER_A, SALT_32, longHash),
+                () => deriveContractAddress(DEPLOYER_A, SALT_32, longHash, Networks.TESTNET),
                 `expected throw for wasmHash length ${byteLen}`,
             ).toThrow('wasmHash must be 32 bytes');
         }
@@ -96,7 +97,7 @@ describe('F1 — invalid WASM hash lengths always throw', () => {
             if (byteLen === 32) continue; // skip valid lengths
             const hash = '00'.repeat(byteLen);
             expect(
-                () => deriveContractAddress(DEPLOYER_A, SALT_32, hash),
+                () => deriveContractAddress(DEPLOYER_A, SALT_32, hash, Networks.TESTNET),
             ).toThrow('wasmHash must be 32 bytes');
         }
     });
@@ -106,26 +107,26 @@ describe('F1 — invalid WASM hash lengths always throw', () => {
 
 describe('F2 — salt boundary values', () => {
     it('empty salt (0 bytes) throws', () => {
-        expect(() => deriveContractAddress(DEPLOYER_A, '', WASM_32)).toThrow(
+        expect(() => deriveContractAddress(DEPLOYER_A, '', WASM_32, Networks.TESTNET)).toThrow(
             'salt must be 32 bytes',
         );
     });
 
     it('salt exactly 32 bytes succeeds and returns a C… StrKey', () => {
-        const addr = deriveContractAddress(DEPLOYER_A, SALT_32, WASM_32);
+        const addr = deriveContractAddress(DEPLOYER_A, SALT_32, WASM_32, Networks.TESTNET);
         expect(addr).toMatch(/^C[A-Z2-7]{55}$/);
     });
 
     it('salt of 31 bytes throws', () => {
         const short = '00'.repeat(31);
-        expect(() => deriveContractAddress(DEPLOYER_A, short, WASM_32)).toThrow(
+        expect(() => deriveContractAddress(DEPLOYER_A, short, WASM_32, Networks.TESTNET)).toThrow(
             'salt must be 32 bytes',
         );
     });
 
     it('salt of 33 bytes throws', () => {
         const long = '00'.repeat(33);
-        expect(() => deriveContractAddress(DEPLOYER_A, long, WASM_32)).toThrow(
+        expect(() => deriveContractAddress(DEPLOYER_A, long, WASM_32, Networks.TESTNET)).toThrow(
             'salt must be 32 bytes',
         );
     });
@@ -133,7 +134,7 @@ describe('F2 — salt boundary values', () => {
     it('salt over 32 bytes always throws', () => {
         for (let byteLen = 33; byteLen <= 64; byteLen++) {
             expect(
-                () => deriveContractAddress(DEPLOYER_A, '00'.repeat(byteLen), WASM_32),
+                () => deriveContractAddress(DEPLOYER_A, '00'.repeat(byteLen), WASM_32, Networks.TESTNET),
                 `expected throw for salt length ${byteLen}`,
             ).toThrow('salt must be 32 bytes');
         }
@@ -141,13 +142,13 @@ describe('F2 — salt boundary values', () => {
 
     it('Buffer salt of exactly 32 bytes succeeds', () => {
         const saltBuf = Buffer.alloc(32, 0x01);
-        const addr = deriveContractAddress(DEPLOYER_A, saltBuf, WASM_32);
+        const addr = deriveContractAddress(DEPLOYER_A, saltBuf, WASM_32, Networks.TESTNET);
         expect(addr).toMatch(/^C[A-Z2-7]{55}$/);
     });
 
     it('Buffer salt of 31 bytes throws', () => {
         expect(
-            () => deriveContractAddress(DEPLOYER_A, Buffer.alloc(31), WASM_32),
+            () => deriveContractAddress(DEPLOYER_A, Buffer.alloc(31), WASM_32, Networks.TESTNET),
         ).toThrow('salt must be 32 bytes');
     });
 });
@@ -164,7 +165,7 @@ describe('F3 — collision resistance across 200 distinct inputs', () => {
             const salt = gen32ByteHex(rand);
             const wasm = gen32ByteHex(rand);
 
-            const addr = deriveContractAddress(deployer, salt, wasm);
+            const addr = deriveContractAddress(deployer, salt, wasm, Networks.TESTNET);
 
             // Invariant: this address must not have appeared before
             expect(seen.has(addr)).toBe(false);
@@ -179,8 +180,8 @@ describe('F3 — collision resistance across 200 distinct inputs', () => {
             const salt2 = gen32ByteHex(rand);
             if (salt1 === salt2) continue;
 
-            const a1 = deriveContractAddress(DEPLOYER_A, salt1, WASM_32);
-            const a2 = deriveContractAddress(DEPLOYER_A, salt2, WASM_32);
+            const a1 = deriveContractAddress(DEPLOYER_A, salt1, WASM_32, Networks.TESTNET);
+            const a2 = deriveContractAddress(DEPLOYER_A, salt2, WASM_32, Networks.TESTNET);
             expect(a1).not.toBe(a2);
         }
     });
@@ -192,15 +193,15 @@ describe('F3 — collision resistance across 200 distinct inputs', () => {
             const w2 = gen32ByteHex(rand);
             if (w1 === w2) continue;
 
-            const a1 = deriveContractAddress(DEPLOYER_A, SALT_32, w1);
-            const a2 = deriveContractAddress(DEPLOYER_A, SALT_32, w2);
+            const a1 = deriveContractAddress(DEPLOYER_A, SALT_32, w1, Networks.TESTNET);
+            const a2 = deriveContractAddress(DEPLOYER_A, SALT_32, w2, Networks.TESTNET);
             expect(a1).not.toBe(a2);
         }
     });
 
     it('changing only the deployer produces a different address', () => {
-        const a1 = deriveContractAddress(DEPLOYER_A, SALT_32, WASM_32);
-        const a2 = deriveContractAddress(DEPLOYER_B, SALT_32, WASM_32);
+        const a1 = deriveContractAddress(DEPLOYER_A, SALT_32, WASM_32, Networks.TESTNET);
+        const a2 = deriveContractAddress(DEPLOYER_B, SALT_32, WASM_32, Networks.TESTNET);
         expect(a1).not.toBe(a2);
     });
 });
@@ -216,7 +217,7 @@ describe('F4 — output is always a valid C… StrKey', () => {
             const deployer = pickDeployer(i);
             const salt = gen32ByteHex(rand);
             const wasm = gen32ByteHex(rand);
-            const addr = deriveContractAddress(deployer, salt, wasm);
+            const addr = deriveContractAddress(deployer, salt, wasm, Networks.TESTNET);
             expect(addr).toMatch(C_STRKEY_RE);
         }
     });
@@ -233,7 +234,7 @@ describe('F5 — no collision with well-known contract IDs', () => {
             const deployer = pickDeployer(i);
             const salt = gen32ByteHex(rand);
             const wasm = gen32ByteHex(rand);
-            const addr = deriveContractAddress(deployer, salt, wasm);
+            const addr = deriveContractAddress(deployer, salt, wasm, Networks.TESTNET);
             expect(wellKnownSet.has(addr)).toBe(false);
         }
     });

--- a/packages/stellar/src/soroban-address-derivation.test.ts
+++ b/packages/stellar/src/soroban-address-derivation.test.ts
@@ -2,6 +2,7 @@
  * Tests for deterministic contract address derivation (#613)
  */
 import { describe, it, expect } from 'vitest';
+import { Networks } from 'stellar-sdk';
 import { deriveContractAddress, verifyContractAddress } from './soroban';
 
 // Known-good fixture: deployer, salt, wasmHash → expected contract address.
@@ -13,55 +14,66 @@ const WASM_HASH_HEX = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 
 describe('deriveContractAddress (#613)', () => {
     it('returns a C… strkey', () => {
-        const addr = deriveContractAddress(DEPLOYER, SALT_HEX, WASM_HASH_HEX);
+        const addr = deriveContractAddress(DEPLOYER, SALT_HEX, WASM_HASH_HEX, Networks.TESTNET);
         expect(addr).toMatch(/^C[A-Z2-7]{55}$/);
     });
 
     it('is deterministic — same inputs produce same address', () => {
-        const a = deriveContractAddress(DEPLOYER, SALT_HEX, WASM_HASH_HEX);
-        const b = deriveContractAddress(DEPLOYER, SALT_HEX, WASM_HASH_HEX);
+        const a = deriveContractAddress(DEPLOYER, SALT_HEX, WASM_HASH_HEX, Networks.TESTNET);
+        const b = deriveContractAddress(DEPLOYER, SALT_HEX, WASM_HASH_HEX, Networks.TESTNET);
         expect(a).toBe(b);
     });
 
     it('differs when salt changes', () => {
         const salt2 = '0000000000000000000000000000000000000000000000000000000000000002';
-        const a = deriveContractAddress(DEPLOYER, SALT_HEX, WASM_HASH_HEX);
-        const b = deriveContractAddress(DEPLOYER, salt2, WASM_HASH_HEX);
+        const a = deriveContractAddress(DEPLOYER, SALT_HEX, WASM_HASH_HEX, Networks.TESTNET);
+        const b = deriveContractAddress(DEPLOYER, salt2, WASM_HASH_HEX, Networks.TESTNET);
         expect(a).not.toBe(b);
     });
 
     it('differs when wasmHash changes', () => {
         const wasm2 = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
-        const a = deriveContractAddress(DEPLOYER, SALT_HEX, WASM_HASH_HEX);
-        const b = deriveContractAddress(DEPLOYER, SALT_HEX, wasm2);
+        const a = deriveContractAddress(DEPLOYER, SALT_HEX, WASM_HASH_HEX, Networks.TESTNET);
+        const b = deriveContractAddress(DEPLOYER, SALT_HEX, wasm2, Networks.TESTNET);
+        expect(a).not.toBe(b);
+    });
+
+    it('differs when networkPassphrase changes', () => {
+        const a = deriveContractAddress(DEPLOYER, SALT_HEX, WASM_HASH_HEX, Networks.TESTNET);
+        const b = deriveContractAddress(DEPLOYER, SALT_HEX, WASM_HASH_HEX, Networks.PUBLIC);
         expect(a).not.toBe(b);
     });
 
     it('accepts Buffer inputs', () => {
         const saltBuf = Buffer.from(SALT_HEX, 'hex');
         const wasmBuf = Buffer.from(WASM_HASH_HEX, 'hex');
-        const fromHex = deriveContractAddress(DEPLOYER, SALT_HEX, WASM_HASH_HEX);
-        const fromBuf = deriveContractAddress(DEPLOYER, saltBuf, wasmBuf);
+        const fromHex = deriveContractAddress(DEPLOYER, SALT_HEX, WASM_HASH_HEX, Networks.TESTNET);
+        const fromBuf = deriveContractAddress(DEPLOYER, saltBuf, wasmBuf, Networks.TESTNET);
         expect(fromHex).toBe(fromBuf);
     });
 
     it('throws when salt is not 32 bytes', () => {
-        expect(() => deriveContractAddress(DEPLOYER, 'deadbeef', WASM_HASH_HEX)).toThrow('salt must be 32 bytes');
+        expect(() => deriveContractAddress(DEPLOYER, 'deadbeef', WASM_HASH_HEX, Networks.TESTNET)).toThrow('salt must be 32 bytes');
     });
 
     it('throws when wasmHash is not 32 bytes', () => {
-        expect(() => deriveContractAddress(DEPLOYER, SALT_HEX, 'deadbeef')).toThrow('wasmHash must be 32 bytes');
+        expect(() => deriveContractAddress(DEPLOYER, SALT_HEX, 'deadbeef', Networks.TESTNET)).toThrow('wasmHash must be 32 bytes');
     });
 });
 
 describe('verifyContractAddress (#613)', () => {
     it('returns true when derived address matches deployed address', () => {
-        const deployed = deriveContractAddress(DEPLOYER, SALT_HEX, WASM_HASH_HEX);
-        expect(verifyContractAddress(DEPLOYER, SALT_HEX, WASM_HASH_HEX, deployed)).toBe(true);
+        const deployed = deriveContractAddress(DEPLOYER, SALT_HEX, WASM_HASH_HEX, Networks.TESTNET);
+        expect(verifyContractAddress(DEPLOYER, SALT_HEX, WASM_HASH_HEX, deployed, Networks.TESTNET)).toBe(true);
     });
 
     it('returns false when deployed address does not match', () => {
         const wrong = 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM';
-        expect(verifyContractAddress(DEPLOYER, SALT_HEX, WASM_HASH_HEX, wrong)).toBe(false);
+        expect(verifyContractAddress(DEPLOYER, SALT_HEX, WASM_HASH_HEX, wrong, Networks.TESTNET)).toBe(false);
+    });
+
+    it('returns false when the address was derived under a different network passphrase', () => {
+        const deployedOnTestnet = deriveContractAddress(DEPLOYER, SALT_HEX, WASM_HASH_HEX, Networks.TESTNET);
+        expect(verifyContractAddress(DEPLOYER, SALT_HEX, WASM_HASH_HEX, deployedOnTestnet, Networks.PUBLIC)).toBe(false);
     });
 });


### PR DESCRIPTION
## Summary

## #1095 — Document Rate-Limiting, Idempotency, and Tier-Enforcement Environment Configuration

**Problem:** `RATE_LIMIT_DISABLED`, `IDEMPOTENCY_TTL_MS`, `SCOPE_VALIDATION_CACHE_TTL_MS`, and the tier-rate-limit/feature-gate constants were documented only inline in scattered source comments, with no single reference page.

**Fix:**
- Added a new `## Rate Limiting, Idempotency, and Tier Enforcement` section to `CONTRIBUTING.md` enumerating each env var (default + effect) and the tier-limit constants.
- Added a top-of-file comment pointer back to that section in `rate-limit.ts`, `idempotency.ts`, `tier-rate-limit.ts`, `tier-enforcement.middleware.ts`, and `scope-validator.ts` (for `SCOPE_VALIDATION_CACHE_TTL_MS`).

Documentation-only, no behavior change.

---

## #1096 — Disambiguate the Two Similarly-Named Rollout-Strategy Modules

**Problem:** `apps/backend/src/services/rollout-strategy.service.ts` (canary/blue-green `RolloutEngine`/`BlueGreenSwitcher`) and `apps/backend/src/services/rollout-strategy.ts` (standalone feature-flag targeting engine `FlagEngine`) had nearly identical names for unrelated responsibilities.

**Fix:**
- Renamed `rollout-strategy.ts` → `feature-flag-engine.ts` (its sole active responsibility is the feature-flag targeting engine).
- Renamed its test file `rollout-strategy.targeting.test.ts` → `feature-flag-engine.test.ts` and updated its import.
- Added cross-referencing header comments to both files so their responsibilities — and the distinction between them — are unambiguous from the file itself.
- Repo-wide grep confirms no stray references to the old filename remain.

Rename/refactor-only, no behavior change. `npm run build --workspace=@craft/backend` currently fails in this environment on `main` as well (pre-existing missing-module webpack errors unrelated to this change); verified instead via `npm run test --workspace=@craft/backend` — all rollout-strategy/feature-flag-engine tests pass (91/91).

---

## #1097 — Add JSDoc Usage Examples to the Request-Validation Middleware

**Problem:** `apps/backend/src/lib/api/with-validation.ts` had no `@example` JSDoc blocks, unlike sibling modules such as `packages/stellar/src/soroban.ts`.

**Fix:**
- Added an `@example` block to each exported function — `withValidation`, `withQueryValidation`, `withParamsValidation` — modeled on the existing example style in `soroban.ts` and cross-checked against `with-validation.test.ts`'s usage patterns.

Documentation-only, no behavior change.

---

## #1098 — Repair the Broken Contract-Address Derivation Test Suite

**Problem:** `deriveContractAddress`/`verifyContractAddress` require a `networkPassphrase` parameter, but `soroban-address-derivation.test.ts` (and `soroban-address-derivation.fuzz.test.ts`) called both with only 3 args, breaking type-checking and the `#613` regression suite.

**Fix:**
- Updated every call site in `soroban-address-derivation.test.ts` and `soroban-address-derivation.fuzz.test.ts` to pass `networkPassphrase` (`Networks.TESTNET`).
- Added the new regression test asserting the same deployer/salt/wasmHash produces different addresses under `Networks.TESTNET` vs. `Networks.PUBLIC`, for both `deriveContractAddress` and `verifyContractAddress`.
- `npm run test --workspace=@craft/stellar -- soroban-address-derivation` passes (27/27).
- Confirmed via repo-wide grep that no other call sites of either function were missed. `npx tsc --noEmit` in `packages/stellar` shows only pre-existing, unrelated `rootDir` project-reference errors (present identically on `main`, verified via `git stash`).

---

Closes #1095
Closes #1096
Closes #1097
Closes #1098

## Files Changed

| File | Change |
|------|--------|
| `CONTRIBUTING.md` | New env-var/tier-constant reference section |
| `apps/backend/src/lib/api/rate-limit.ts` | Doc pointer to CONTRIBUTING.md |
| `apps/backend/src/lib/api/idempotency.ts` | Doc pointer to CONTRIBUTING.md |
| `apps/backend/src/lib/api/tier-rate-limit.ts` | Doc pointer to CONTRIBUTING.md |
| `apps/backend/src/lib/tier-enforcement.middleware.ts` | Doc pointer to CONTRIBUTING.md |
| `apps/backend/src/lib/github/scope-validator.ts` | Doc pointer to CONTRIBUTING.md |
| `apps/backend/src/services/rollout-strategy.ts` → `feature-flag-engine.ts` | Renamed for disambiguation |
| `apps/backend/src/services/rollout-strategy.targeting.test.ts` → `feature-flag-engine.test.ts` | Renamed, import updated |
| `apps/backend/src/services/rollout-strategy.service.ts` | Cross-reference header comment |
| `apps/backend/src/lib/api/with-validation.ts` | Added `@example` JSDoc blocks |
| `packages/stellar/src/soroban-address-derivation.test.ts` | Fixed missing `networkPassphrase` arg + new cross-network regression tests |
| `packages/stellar/src/soroban-address-derivation.fuzz.test.ts` | Fixed missing `networkPassphrase` arg |

## Checklist

- [x] Branched off `main`
- [x] Each issue linked via `Closes #`
- [x] `npm run test --workspace=@craft/stellar` passes
- [x] `npm run test --workspace=@craft/backend` passes for all touched modules
- [x] `npm run lint --workspace=@craft/stellar` passes clean