### PR TITLE
fix(stellar): harden TTL renewal batching, Soroban error routing, fee…

### DIFF
--- a/apps/backend/src/services/fee-bump-usage.service.test.ts
+++ b/apps/backend/src/services/fee-bump-usage.service.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Tests for SupabaseFeeBumpUsageStore — durable fee-bump usage (Issue #1111)
+ *
+ * The Supabase client is mocked with a module-level in-memory table that
+ * persists independently of any SupabaseFeeBumpUsageStore instance. Discarding
+ * the store object and creating a new one simulates a server restart: the
+ * process-local service is gone, but the backing database rows remain.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// ── Stateful Supabase mock ────────────────────────────────────────────────────
+
+interface Row {
+  user_id: string;
+  count: number;
+  total_fees_paid: number;
+  last_used_at: string;
+}
+
+/** Stands in for the durable `fee_bump_usage_records` table. */
+const backingTable = new Map<string, Row>();
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: () => ({
+    from: (_table: string) => ({
+      select: (_columns: string) => ({
+        eq: (_column: string, userId: string) => ({
+          maybeSingle: async () => ({
+            data: backingTable.get(userId) ?? null,
+            error: null,
+          }),
+        }),
+      }),
+      upsert: async (row: Row, _options: { onConflict: string }) => {
+        backingTable.set(row.user_id, { ...backingTable.get(row.user_id), ...row });
+        return { error: null };
+      },
+    }),
+  }),
+}));
+
+// Imported after the mock is registered.
+import { SupabaseFeeBumpUsageStore } from './fee-bump-usage.service';
+import type { FeeBumpUsageStore } from '@craft/stellar';
+
+const USER = 'a3f1c2d4-0000-4000-8000-000000000001';
+
+beforeEach(() => {
+  backingTable.clear();
+});
+
+describe('SupabaseFeeBumpUsageStore', () => {
+  it('satisfies the FeeBumpUsageStore interface', () => {
+    const store: FeeBumpUsageStore = new SupabaseFeeBumpUsageStore();
+    expect(typeof store.record).toBe('function');
+  });
+
+  it('creates a usage record on the first fee-bump', async () => {
+    const store = new SupabaseFeeBumpUsageStore();
+    await store.record(USER, 300);
+
+    const usage = await store.get(USER);
+    expect(usage).toBeDefined();
+    expect(usage!.count).toBe(1);
+    expect(usage!.totalFeesPaid).toBe(300);
+  });
+
+  it('accumulates count and totalFeesPaid across fee-bumps', async () => {
+    const store = new SupabaseFeeBumpUsageStore();
+    await store.record(USER, 200);
+    await store.record(USER, 150);
+    await store.record(USER, 50);
+
+    const usage = await store.get(USER);
+    expect(usage!.count).toBe(3);
+    expect(usage!.totalFeesPaid).toBe(400);
+  });
+
+  it('tracks users independently', async () => {
+    const store = new SupabaseFeeBumpUsageStore();
+    await store.record('user-1', 100);
+    await store.record('user-2', 900);
+
+    expect((await store.get('user-1'))!.totalFeesPaid).toBe(100);
+    expect((await store.get('user-2'))!.totalFeesPaid).toBe(900);
+  });
+
+  it('persists usage across a simulated service re-instantiation (restart)', async () => {
+    const storeBeforeRestart = new SupabaseFeeBumpUsageStore();
+    await storeBeforeRestart.record(USER, 250);
+    await storeBeforeRestart.record(USER, 250);
+
+    // Simulate a restart: the service instance is gone; only the durable
+    // Supabase table survives.
+    const storeAfterRestart = new SupabaseFeeBumpUsageStore();
+    const usage = await storeAfterRestart.get(USER);
+
+    expect(usage).toBeDefined();
+    expect(usage!.count).toBe(2);
+    expect(usage!.totalFeesPaid).toBe(500);
+
+    // Continuing to record after the restart builds on the persisted counters
+    // rather than resetting them to zero.
+    await storeAfterRestart.record(USER, 100);
+    const continued = await storeAfterRestart.get(USER);
+    expect(continued!.count).toBe(3);
+    expect(continued!.totalFeesPaid).toBe(600);
+  });
+});

--- a/apps/backend/src/services/fee-bump-usage.service.ts
+++ b/apps/backend/src/services/fee-bump-usage.service.ts
@@ -1,0 +1,100 @@
+/**
+ * Durable Fee-Bump Usage Store (Issue #1111)
+ *
+ * `orchestrateFeeBump` in `@craft/stellar` defaults to an in-memory
+ * `FeeBumpUsageStore` whose own doc comment flags it as a placeholder. A
+ * server restart mid-billing-period wipes every user's `count` /
+ * `totalFeesPaid` back to zero with no reconciliation against what was
+ * actually charged — unacceptable for a usage-based billing signal.
+ *
+ * This Supabase-backed implementation persists each fee-bump so usage survives
+ * restarts. It mirrors the persistence pattern used by
+ * `PaymentIdempotencyService` and `MeteringService`: a read of the current
+ * row followed by an upsert keyed on `user_id`.
+ *
+ * Production call paths that wrap user transactions in a platform-sponsored
+ * fee-bump must inject `supabaseFeeBumpUsageStore` (or another durable
+ * `FeeBumpUsageStore`) rather than relying on the in-memory default.
+ */
+
+import { createClient } from '@/lib/supabase/server';
+import type { FeeBumpUsageRecord, FeeBumpUsageStore } from '@craft/stellar';
+
+const TABLE = 'fee_bump_usage_records';
+
+export class SupabaseFeeBumpUsageStore implements FeeBumpUsageStore {
+  /**
+   * Record a single fee-bump transaction for a user, incrementing the running
+   * count and cumulative fee total. Creates the row on first use.
+   */
+  async record(userId: string, feeCharged: number): Promise<void> {
+    const supabase = createClient();
+
+    const { data: existing, error: readError } = await supabase
+      .from(TABLE)
+      .select('count, total_fees_paid')
+      .eq('user_id', userId)
+      .maybeSingle();
+
+    if (readError) {
+      throw new Error(
+        `Failed to read fee-bump usage for ${userId}: ${readError.message}`,
+      );
+    }
+
+    const nextCount = ((existing?.count as number | undefined) ?? 0) + 1;
+    const nextTotal =
+      ((existing?.total_fees_paid as number | undefined) ?? 0) + feeCharged;
+
+    const { error: writeError } = await supabase.from(TABLE).upsert(
+      {
+        user_id: userId,
+        count: nextCount,
+        total_fees_paid: nextTotal,
+        last_used_at: new Date().toISOString(),
+      },
+      { onConflict: 'user_id' },
+    );
+
+    if (writeError) {
+      throw new Error(
+        `Failed to persist fee-bump usage for ${userId}: ${writeError.message}`,
+      );
+    }
+  }
+
+  /**
+   * Return the persisted usage record for a user, or `undefined` when the user
+   * has no recorded fee-bump activity.
+   */
+  async get(userId: string): Promise<FeeBumpUsageRecord | undefined> {
+    const supabase = createClient();
+
+    const { data, error } = await supabase
+      .from(TABLE)
+      .select('user_id, count, total_fees_paid, last_used_at')
+      .eq('user_id', userId)
+      .maybeSingle();
+
+    if (error) {
+      throw new Error(
+        `Failed to read fee-bump usage for ${userId}: ${error.message}`,
+      );
+    }
+
+    if (!data) return undefined;
+
+    const lastUsedAt = data.last_used_at as string | number | null;
+
+    return {
+      userId: data.user_id as string,
+      count: data.count as number,
+      totalFeesPaid: data.total_fees_paid as number,
+      lastUsedAt:
+        typeof lastUsedAt === 'string' ? Date.parse(lastUsedAt) : lastUsedAt ?? 0,
+    };
+  }
+}
+
+/** Shared durable store instance for production fee-bump orchestration. */
+export const supabaseFeeBumpUsageStore = new SupabaseFeeBumpUsageStore();

--- a/packages/stellar/src/asset-compliance.test.ts
+++ b/packages/stellar/src/asset-compliance.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { checkAssetCompliance, loadComplianceConfig } from './asset-compliance';
 import type { ComplianceConfig } from './asset-compliance';
 
@@ -98,6 +98,52 @@ describe('loadComplianceConfig', () => {
   it('uses provided override directly', () => {
     const config = loadComplianceConfig(baseConfig);
     expect(config.blocklist).toHaveLength(1);
+    expect(config.jurisdictionRules).toHaveLength(1);
+  });
+});
+
+describe('loadComplianceConfig — malformed env var diagnostics', () => {
+  const originalBlocklist = process.env.COMPLIANCE_BLOCKLIST_JSON;
+  const originalJurisdiction = process.env.COMPLIANCE_JURISDICTION_JSON;
+
+  afterEach(() => {
+    if (originalBlocklist === undefined) delete process.env.COMPLIANCE_BLOCKLIST_JSON;
+    else process.env.COMPLIANCE_BLOCKLIST_JSON = originalBlocklist;
+    if (originalJurisdiction === undefined) delete process.env.COMPLIANCE_JURISDICTION_JSON;
+    else process.env.COMPLIANCE_JURISDICTION_JSON = originalJurisdiction;
+    vi.restoreAllMocks();
+  });
+
+  it('logs a warning naming the offending variable while still returning an empty blocklist', () => {
+    process.env.COMPLIANCE_BLOCKLIST_JSON = '[{ "issuer": "GABC", }]'; // trailing comma → invalid JSON
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const config = loadComplianceConfig();
+
+    expect(config.blocklist).toEqual([]);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain('COMPLIANCE_BLOCKLIST_JSON');
+  });
+
+  it('logs a warning for a malformed COMPLIANCE_JURISDICTION_JSON and falls back to empty rules', () => {
+    process.env.COMPLIANCE_JURISDICTION_JSON = '{ not valid json';
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const config = loadComplianceConfig();
+
+    expect(config.jurisdictionRules).toEqual([]);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain('COMPLIANCE_JURISDICTION_JSON');
+  });
+
+  it('does not log when the env vars are absent or valid', () => {
+    delete process.env.COMPLIANCE_BLOCKLIST_JSON;
+    process.env.COMPLIANCE_JURISDICTION_JSON = '[{"jurisdiction":"US","blockedAssets":["TOKEN"]}]';
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const config = loadComplianceConfig();
+
+    expect(warnSpy).not.toHaveBeenCalled();
     expect(config.jurisdictionRules).toHaveLength(1);
   });
 });

--- a/packages/stellar/src/asset-compliance.ts
+++ b/packages/stellar/src/asset-compliance.ts
@@ -64,6 +64,20 @@ export interface ComplianceCheckResult {
  * are injected via `COMPLIANCE_BLOCKLIST_JSON` / `COMPLIANCE_JURISDICTION_JSON`
  * environment variables (serialised JSON arrays).
  */
+/**
+ * Emit a warning-level log identifying a compliance env var that failed to
+ * parse. The caller still falls back to an empty list, so this is the only
+ * signal that compliance checks have been silently degraded by a bad config.
+ */
+function warnMalformedConfig(envVar: string, error: unknown): void {
+  const reason = error instanceof Error ? error.message : String(error);
+  console.warn(
+    `[asset-compliance] Failed to parse ${envVar}: ${reason}. ` +
+      `Falling back to an empty list — compliance checks relying on this ` +
+      `variable are now disabled until the configuration is fixed.`,
+  );
+}
+
 export function loadComplianceConfig(override?: Partial<ComplianceConfig>): ComplianceConfig {
   let blocklist: BlocklistEntry[] = override?.blocklist ?? [];
   let jurisdictionRules: JurisdictionRule[] = override?.jurisdictionRules ?? [];
@@ -72,8 +86,12 @@ export function loadComplianceConfig(override?: Partial<ComplianceConfig>): Comp
     try {
       const raw = process.env.COMPLIANCE_BLOCKLIST_JSON;
       if (raw) blocklist = JSON.parse(raw) as BlocklistEntry[];
-    } catch {
-      // Malformed env var — treat as empty blocklist
+    } catch (error) {
+      // Malformed env var — fall back to an empty blocklist so a config typo
+      // does not block deployments, but make the failure observable: a silent
+      // fallback here disables issuer compliance checks platform-wide with no
+      // diagnostic signal.
+      warnMalformedConfig('COMPLIANCE_BLOCKLIST_JSON', error);
     }
   }
 
@@ -81,8 +99,9 @@ export function loadComplianceConfig(override?: Partial<ComplianceConfig>): Comp
     try {
       const raw = process.env.COMPLIANCE_JURISDICTION_JSON;
       if (raw) jurisdictionRules = JSON.parse(raw) as JurisdictionRule[];
-    } catch {
-      // Malformed env var — treat as empty rules
+    } catch (error) {
+      // Malformed env var — fall back to empty rules (see note above).
+      warnMalformedConfig('COMPLIANCE_JURISDICTION_JSON', error);
     }
   }
 

--- a/packages/stellar/src/errors.ts
+++ b/packages/stellar/src/errors.ts
@@ -636,6 +636,57 @@ const ERROR_GUIDANCE_MAP: Record<StellarErrorCode, StellarErrorGuidance> = {
 };
 
 /**
+ * Extract a Soroban contract error code (`scv…`) from an arbitrary text blob and
+ * categorize it against {@link SOROBAN_ERROR_CODES}.
+ *
+ * Shared by the `Error`-instance and structured-object branches of
+ * {@link parseStellarError} so a Soroban simulation failure resolves to the same
+ * specific, actionable guidance regardless of whether it arrived as a thrown
+ * `Error` message or as a structured RPC/Horizon-style response object.
+ *
+ * @param text - Any string that might contain a Soroban error token
+ * @returns The categorized error, or `null` when no known `scv…` code is present
+ */
+function categorizeSorobanError(text: string): {
+  errorCode: StellarErrorCode;
+  title: string;
+  message: string;
+  retryable: boolean;
+  resultCode: string;
+} | null {
+  const match = text.match(/\b(scv[A-Z][a-zA-Z]+)\b/);
+  if (!match || !SOROBAN_ERROR_CODES[match[1]]) {
+    return null;
+  }
+
+  const sorobanCode = match[1];
+  const mapping = SOROBAN_ERROR_CODES[sorobanCode];
+
+  let errorCode: StellarErrorCode;
+  if (sorobanCode.includes('Panic') || sorobanCode.includes('Unwrap') || sorobanCode.includes('Assertion')) {
+    errorCode = 'SOROBAN_CONTRACT_PANIC';
+  } else if (sorobanCode.includes('Limit') || sorobanCode.includes('Exhausted')) {
+    errorCode = 'SOROBAN_RESOURCE_LIMIT_EXCEEDED';
+  } else if (sorobanCode.includes('Storage')) {
+    errorCode = 'SOROBAN_STORAGE_ERROR';
+  } else if (sorobanCode.includes('Auth') || sorobanCode.includes('Signature')) {
+    errorCode = 'SOROBAN_AUTH_ERROR';
+  } else if (sorobanCode.includes('Wasm') || sorobanCode.includes('Trap')) {
+    errorCode = 'SOROBAN_WASM_ERROR';
+  } else {
+    errorCode = 'SOROBAN_CONTRACT_ERROR';
+  }
+
+  return {
+    errorCode,
+    title: mapping.title,
+    message: mapping.message,
+    retryable: mapping.retryable,
+    resultCode: sorobanCode,
+  };
+}
+
+/**
  * Parse a Stellar SDK error or Horizon response error into a structured error object.
  *
  * @param error - The error to parse (can be Error, string, or object)
@@ -698,30 +749,13 @@ export function parseStellarError(
       errorMessage.includes('scv') ||
       errorMessage.includes('Soroban')
     ) {
-      // Try to extract Soroban error code
-      const sorobanCodeMatch = errorMessage.match(/\b(scv[A-Z][a-zA-Z]+)\b/);
-      if (sorobanCodeMatch && SOROBAN_ERROR_CODES[sorobanCodeMatch[1]]) {
-        const sorobanCode = sorobanCodeMatch[1];
-        const mapping = SOROBAN_ERROR_CODES[sorobanCode];
-        title = mapping.title;
-        message = mapping.message;
-        retryable = mapping.retryable;
-        resultCode = sorobanCode;
-
-        // Categorize Soroban error
-        if (sorobanCode.includes('Panic') || sorobanCode.includes('Unwrap') || sorobanCode.includes('Assertion')) {
-          errorCode = 'SOROBAN_CONTRACT_PANIC';
-        } else if (sorobanCode.includes('Limit') || sorobanCode.includes('Exhausted')) {
-          errorCode = 'SOROBAN_RESOURCE_LIMIT_EXCEEDED';
-        } else if (sorobanCode.includes('Storage')) {
-          errorCode = 'SOROBAN_STORAGE_ERROR';
-        } else if (sorobanCode.includes('Auth') || sorobanCode.includes('Signature')) {
-          errorCode = 'SOROBAN_AUTH_ERROR';
-        } else if (sorobanCode.includes('Wasm') || sorobanCode.includes('Trap')) {
-          errorCode = 'SOROBAN_WASM_ERROR';
-        } else {
-          errorCode = 'SOROBAN_CONTRACT_ERROR';
-        }
+      const soroban = categorizeSorobanError(errorMessage);
+      if (soroban) {
+        title = soroban.title;
+        message = soroban.message;
+        retryable = soroban.retryable;
+        resultCode = soroban.resultCode;
+        errorCode = soroban.errorCode;
       } else {
         // Generic Soroban error without specific code
         errorCode = 'SOROBAN_CONTRACT_ERROR';
@@ -797,6 +831,37 @@ export function parseStellarError(
       details = errObj.message;
     } else if (typeof errObj.detail === 'string') {
       details = errObj.detail;
+    }
+
+    // A Soroban simulation failure can arrive as a structured object (a
+    // Horizon-style { status, type, ... } body, or a raw RPC error object) with
+    // the contract error code nested in a message/detail/code/resultCode field
+    // rather than a top-level Error message. Route these through the same
+    // guidance map as string / Error-instance Soroban errors. Only overrides
+    // when a known scv* code is actually present, so non-Soroban structured
+    // errors (404 / 429 / 502 / 503 / 400) are left untouched.
+    let sorobanText = [
+      errObj.message,
+      errObj.detail,
+      errObj.code,
+      errObj.resultCode,
+      errObj.result_code,
+    ]
+      .filter((v): v is string => typeof v === 'string')
+      .join(' ');
+    try {
+      sorobanText += ' ' + JSON.stringify(errObj);
+    } catch {
+      // Circular structure — the named fields above are still covered.
+    }
+
+    const structuredSoroban = categorizeSorobanError(sorobanText);
+    if (structuredSoroban) {
+      title = structuredSoroban.title;
+      message = structuredSoroban.message;
+      retryable = structuredSoroban.retryable;
+      resultCode = structuredSoroban.resultCode;
+      errorCode = structuredSoroban.errorCode;
     }
   }
   // Handle string errors

--- a/packages/stellar/src/soroban-errors.test.ts
+++ b/packages/stellar/src/soroban-errors.test.ts
@@ -124,6 +124,46 @@ describe('Soroban Error Code Taxonomy', () => {
     });
   });
 
+  describe('parseStellarError with structured (non-Error-instance) Soroban errors', () => {
+    it('maps a plain object with a nested scv* code to the specific Soroban guidance, not UNKNOWN_ERROR', () => {
+      // Raw RPC-style error object: the contract code lives in a nested field,
+      // not an Error message.
+      const structuredError = {
+        status: 400,
+        type: 'invalid',
+        code: 'scvExceededLimit',
+        detail: 'transaction simulation failed',
+      };
+
+      const parsed = parseStellarError(structuredError);
+
+      expect(parsed.code).toBe('SOROBAN_RESOURCE_LIMIT_EXCEEDED');
+      expect(parsed.title).toBe('Resource Limit Exceeded');
+      expect(parsed.resultCode).toBe('scvExceededLimit');
+      expect(parsed.retryable).toBe(false);
+      expect(parsed.code).not.toBe('UNKNOWN_ERROR');
+      expect(parsed.code).not.toBe('MALFORMED_TRANSACTION');
+    });
+
+    it('maps a Horizon-style object whose message field carries the scv* token', () => {
+      const structuredError = {
+        message: 'host invocation failed: scvContractPanic while executing',
+      };
+
+      const parsed = parseStellarError(structuredError);
+
+      expect(parsed.code).toBe('SOROBAN_CONTRACT_PANIC');
+      expect(parsed.title).toBe('Contract Panic');
+    });
+
+    it('leaves non-Soroban structured errors unchanged', () => {
+      expect(parseStellarError({ status: 404 }).code).toBe('ACCOUNT_NOT_FOUND');
+      expect(parseStellarError({ status: 429 }).code).toBe('RATE_LIMITED');
+      expect(parseStellarError({ status: 503 }).code).toBe('ENDPOINT_UNREACHABLE');
+      expect(parseStellarError({ status: 400, type: 'invalid' }).code).toBe('MALFORMED_TRANSACTION');
+    });
+  });
+
   describe('Error Guidance for Soroban Errors', () => {
     it('should provide guidance for contract errors', () => {
       const guidance = getErrorGuidance('SOROBAN_CONTRACT_ERROR');

--- a/packages/stellar/src/soroban-ttl-manager.ts
+++ b/packages/stellar/src/soroban-ttl-manager.ts
@@ -33,7 +33,7 @@ import {
     BASE_FEE,
     SorobanDataBuilder,
 } from 'stellar-sdk';
-import { config, getSorobanRpcUrl, getNetworkPassphrase } from './config';
+import { getSorobanRpcUrl, getNetworkPassphrase } from './config';
 import { parseStellarError } from './errors';
 import type { LedgerEventEmitter } from './dex-price-feed';
 
@@ -253,24 +253,6 @@ export async function checkContractTtl(
     }
 }
 
-// ── Internal helpers ──────────────────────────────────────────────────────────
-
-const SOROBAN_RPC_URLS = {
-    mainnet: 'https://soroban-mainnet.stellar.org',
-    testnet: 'https://soroban-testnet.stellar.org',
-} as const;
-
-function getSorobanRpcUrl(): string {
-    return (
-        process.env.NEXT_PUBLIC_SOROBAN_RPC_URL ||
-        SOROBAN_RPC_URLS[config.stellar.network]
-    );
-}
-
-function getNetworkPassphrase(): string {
-    return config.stellar.network === 'mainnet' ? Networks.PUBLIC : Networks.TESTNET;
-}
-
 // ---------------------------------------------------------------------------
 // Automated TTL Renewal with Ledger-Sequence Awareness (#792)
 // ---------------------------------------------------------------------------
@@ -280,6 +262,20 @@ export const RENEWAL_QUEUE_THRESHOLD = 1_000;
 
 /** Trigger renewal when TTL remaining reaches this many ledgers (50% of threshold). */
 export const RENEWAL_TRIGGER_LEDGERS = 500;
+
+/**
+ * Maximum number of ledger keys packed into a single `ExtendFootprintTtl`
+ * renewal transaction.
+ *
+ * Soroban enforces hard per-transaction footprint and resource limits. A
+ * watchlist covering many deployed contracts can have a large number of
+ * entries reach their renewal urgency in the same tick; batching all of them
+ * into one transaction would exceed those limits and fail the whole batch at
+ * simulation/submission time — including entries nowhere near expiry. `_tick`
+ * therefore splits an oversized queue into sequential sub-batches of at most
+ * this size and attempts each independently.
+ */
+export const MAX_RENEWAL_BATCH_SIZE = 50;
 
 export interface RenewalAlert {
     type: 'renewal_failed';
@@ -403,22 +399,29 @@ export class AutomaticTTLRenewer {
 
         if (!shouldRenewNow) return;
 
-        // Batch all queued keys into a single renewal transaction
-        try {
-            await buildTtlExtensionTransaction(
-                queued,
-                this.sourcePublicKey,
-                this.options.thresholds,
-                this.options.txClient,
-            );
-        } catch (error: unknown) {
-            const parsed = parseStellarError(error);
-            this.options.onAlert({
-                type: 'renewal_failed',
-                keys: queued,
-                error: parsed.message,
-                timestamp: Date.now(),
-            });
+        // Split the queue into sub-batches capped at MAX_RENEWAL_BATCH_SIZE so a
+        // single renewal transaction cannot exceed Soroban's per-transaction
+        // footprint/resource limits. Each sub-batch is built and attempted
+        // independently: a failure in one does not prevent the others from being
+        // tried, and fires its own onAlert rather than aborting the whole tick.
+        for (let offset = 0; offset < queued.length; offset += MAX_RENEWAL_BATCH_SIZE) {
+            const subBatch = queued.slice(offset, offset + MAX_RENEWAL_BATCH_SIZE);
+            try {
+                await buildTtlExtensionTransaction(
+                    subBatch,
+                    this.sourcePublicKey,
+                    this.options.thresholds,
+                    this.options.txClient,
+                );
+            } catch (error: unknown) {
+                const parsed = parseStellarError(error);
+                this.options.onAlert({
+                    type: 'renewal_failed',
+                    keys: subBatch,
+                    error: parsed.message,
+                    timestamp: Date.now(),
+                });
+            }
         }
     }
 }

--- a/packages/stellar/src/soroban-ttl-renewal.test.ts
+++ b/packages/stellar/src/soroban-ttl-renewal.test.ts
@@ -7,8 +7,10 @@ import {
     AutomaticTTLRenewer,
     createAutoRenewer,
     buildContractInstanceKey,
+    buildContractDataKey,
     RENEWAL_QUEUE_THRESHOLD,
     RENEWAL_TRIGGER_LEDGERS,
+    MAX_RENEWAL_BATCH_SIZE,
 } from './soroban-ttl-manager';
 
 const CONTRACT_A = 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM';
@@ -169,6 +171,80 @@ describe('AutomaticTTLRenewer._tick', () => {
         expect(alert.type).toBe('renewal_failed');
         expect(typeof alert.error).toBe('string');
         expect(alert.keys).toHaveLength(1);
+    });
+});
+
+// ── Batch-size cap (oversized queue) ──────────────────────────────────────────
+
+describe('AutomaticTTLRenewer._tick — renewal batch size cap', () => {
+    /** Build an at-risk ttlClient mock returning one entry per key at the trigger threshold. */
+    function makeAtRiskTtlClient(keys: xdr.LedgerKey[], currentLedger: number) {
+        return {
+            getLatestLedger: vi.fn().mockResolvedValue({ sequence: currentLedger }),
+            getLedgerEntries: vi.fn().mockResolvedValue({
+                entries: keys.map((key) => ({
+                    key,
+                    xdr: {} as xdr.LedgerEntry,
+                    liveUntilLedgerSeq: currentLedger + RENEWAL_TRIGGER_LEDGERS,
+                })),
+                latestLedger: currentLedger,
+            }),
+        };
+    }
+
+    it('MAX_RENEWAL_BATCH_SIZE is a positive cap', () => {
+        expect(MAX_RENEWAL_BATCH_SIZE).toBeGreaterThan(0);
+    });
+
+    it('splits an oversized queue into multiple capped renewal transactions rather than one', async () => {
+        const currentLedger = 1000;
+        const keyCount = MAX_RENEWAL_BATCH_SIZE * 2 + 3; // exceeds a single batch
+        const keys = Array.from({ length: keyCount }, (_, i) =>
+            buildContractDataKey(CONTRACT_A, xdr.ScVal.scvU32(i)),
+        );
+        const ttlClient = makeAtRiskTtlClient(keys, currentLedger);
+        const txClient = makeTxClient();
+
+        const renewer = new AutomaticTTLRenewer(SOURCE_KEY, { ttlClient, txClient });
+        keys.forEach((k) => renewer.watch(k));
+        await renewer._tick();
+
+        const expectedBatches = Math.ceil(keyCount / MAX_RENEWAL_BATCH_SIZE);
+        expect(expectedBatches).toBeGreaterThan(1);
+        // One built transaction per sub-batch — never a single oversized batch.
+        expect(txClient.getAccount).toHaveBeenCalledTimes(expectedBatches);
+        expect(txClient.prepareTransaction).toHaveBeenCalledTimes(expectedBatches);
+    });
+
+    it('continues attempting later sub-batches after one sub-batch fails, alerting per failure', async () => {
+        const currentLedger = 1000;
+        const keyCount = MAX_RENEWAL_BATCH_SIZE * 3;
+        const keys = Array.from({ length: keyCount }, (_, i) =>
+            buildContractDataKey(CONTRACT_A, xdr.ScVal.scvU32(i)),
+        );
+        const ttlClient = makeAtRiskTtlClient(keys, currentLedger);
+
+        const fakeTx = { toXDR: vi.fn().mockReturnValue('renewal-tx-xdr') };
+        const fakeAccount = new Account(SOURCE_KEY, '1');
+        const prepareTransaction = vi
+            .fn()
+            .mockRejectedValueOnce(new Error('footprint resource limit exceeded'))
+            .mockResolvedValue(fakeTx);
+        const txClient = {
+            getAccount: vi.fn().mockResolvedValue(fakeAccount),
+            prepareTransaction,
+        };
+        const onAlert = vi.fn();
+
+        const renewer = new AutomaticTTLRenewer(SOURCE_KEY, { ttlClient, txClient, onAlert });
+        keys.forEach((k) => renewer.watch(k));
+        await renewer._tick();
+
+        // All 3 sub-batches attempted despite the first failing.
+        expect(prepareTransaction).toHaveBeenCalledTimes(3);
+        // Exactly one alert — for the sub-batch that failed, not the whole tick.
+        expect(onAlert).toHaveBeenCalledOnce();
+        expect(onAlert.mock.calls[0][0].keys).toHaveLength(MAX_RENEWAL_BATCH_SIZE);
     });
 });
 

--- a/supabase/migrations/020_fee_bump_usage_records.sql
+++ b/supabase/migrations/020_fee_bump_usage_records.sql
@@ -1,0 +1,73 @@
+-- Migration: 020_fee_bump_usage_records.sql
+-- Issue: #1111 — Persist Fee-Bump Usage Records So a Restart Cannot Silently
+--                Reset Monthly Billing Counters
+--
+-- Problem:
+--   orchestrateFeeBump() in @craft/stellar defaults to an in-memory
+--   FeeBumpUsageStore. A server restart mid-billing-period silently resets
+--   every user's fee-bump count and cumulative fees paid to zero, with no
+--   reconciliation against what was actually charged.
+--
+-- Fix:
+--   Provide a durable table backing SupabaseFeeBumpUsageStore
+--   (apps/backend/src/services/fee-bump-usage.service.ts). One row per user,
+--   upserted on each fee-bump.
+
+CREATE TABLE IF NOT EXISTS fee_bump_usage_records (
+  user_id UUID PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+
+  -- Number of platform-sponsored fee-bump transactions for this user.
+  count INTEGER NOT NULL DEFAULT 0 CHECK (count >= 0),
+
+  -- Cumulative fee paid on the user's behalf, in stroops.
+  total_fees_paid BIGINT NOT NULL DEFAULT 0 CHECK (total_fees_paid >= 0),
+
+  -- Timestamp of the most recent fee-bump.
+  last_used_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_fee_bump_usage_last_used
+  ON fee_bump_usage_records(last_used_at);
+
+-- Enable row level security
+ALTER TABLE fee_bump_usage_records ENABLE ROW LEVEL SECURITY;
+
+-- RLS Policy: users can read their own usage; service_role manages writes.
+CREATE POLICY "fee_bump_usage_select_policy" ON fee_bump_usage_records
+  FOR SELECT USING (
+    auth.uid() = user_id OR auth.role() = 'service_role'
+  );
+
+CREATE POLICY "fee_bump_usage_service_policy" ON fee_bump_usage_records
+  FOR ALL USING (auth.role() = 'service_role')
+  WITH CHECK (auth.role() = 'service_role');
+
+-- Keep updated_at current on every write.
+CREATE OR REPLACE FUNCTION update_fee_bump_usage_timestamp()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS fee_bump_usage_update_timestamp ON fee_bump_usage_records;
+CREATE TRIGGER fee_bump_usage_update_timestamp
+  BEFORE UPDATE ON fee_bump_usage_records
+  FOR EACH ROW
+  EXECUTE FUNCTION update_fee_bump_usage_timestamp();
+
+COMMENT ON TABLE fee_bump_usage_records IS
+  'Durable per-user fee-bump usage counters for monthly billing. Backs '
+  'SupabaseFeeBumpUsageStore so counts survive server restarts (issue #1111).';
+
+-- rollback: DROP TRIGGER IF EXISTS fee_bump_usage_update_timestamp ON fee_bump_usage_records;
+-- rollback: DROP FUNCTION IF EXISTS update_fee_bump_usage_timestamp;
+-- rollback: DROP POLICY IF EXISTS fee_bump_usage_service_policy ON fee_bump_usage_records;
+-- rollback: DROP POLICY IF EXISTS fee_bump_usage_select_policy ON fee_bump_usage_records;
+-- rollback: ALTER TABLE fee_bump_usage_records DISABLE ROW LEVEL SECURITY;
+-- rollback: DROP INDEX IF EXISTS idx_fee_bump_usage_last_used;
+-- rollback: DROP TABLE IF EXISTS fee_bump_usage_records;


### PR DESCRIPTION
…-bump durability, compliance config diagnostics

Resolves #1111, #1112, #1113, #1114.

#1112 — Cap TTL renewal batch size to stay within Soroban footprint limits
  * Add MAX_RENEWAL_BATCH_SIZE (50) to packages/stellar/src/soroban-ttl-manager.ts.
  * AutomaticTTLRenewer._tick now chunks the at-risk queue into sequential sub-batches of at most that size instead of packing every queued key into one ExtendFootprintTtl transaction that could exceed per-transaction footprint/resource limits and fail the whole batch at once.
  * Each sub-batch is built and attempted independently; a failure in one fires its own onAlert and does not prevent the remaining sub-batches from being tried.
  * Regression tests in soroban-ttl-renewal.test.ts: an oversized queue (> 2x the cap) produces ceil(n / cap) renewal transactions rather than one, and later sub-batches are still attempted after an earlier one fails.
  * Prerequisite fix in the same file: removed broken local redefinitions of getSorobanRpcUrl / getNetworkPassphrase that shadowed the correct ./config imports and referenced an undefined `Networks`, throwing a ReferenceError on every renewal build and blocking this issue's test path.

#1114 — Route structured Soroban contract errors through the same guidance map
  * Factor the "extract scv* code and categorize it" logic out of the Error-instance branch of parseStellarError into a shared categorizeSorobanError() helper.
  * The `typeof error === 'object'` branch now also runs that extraction over the object's message / detail / code / resultCode / result_code fields (plus a JSON.stringify fallback), so a Soroban simulation failure that arrives as a structured object resolves to the specific SOROBAN_* code and guidance instead of falling through to MALFORMED_TRANSACTION / UNKNOWN_ERROR.
  * Only overrides when a known scv* code is present; existing structured-error handling for 404 / 429 / 502 / 503 / 400 is unchanged.
  * Regression tests in soroban-errors.test.ts for a plain object with a nested scv* code and for non-Soroban structured errors staying put.

#1111 — Persist fee-bump usage records across restarts
  * Audit: a repo-wide grep found no production call site of orchestrateFeeBump today (only the definition, the barrel export and tests), so nothing currently relies on the in-memory default — but the durable store is now available for any call site that is added.
  * New apps/backend/src/services/fee-bump-usage.service.ts implementing FeeBumpUsageStore against Supabase, mirroring the read-then-upsert pattern used by PaymentIdempotencyService / MeteringService.
  * New migration 020_fee_bump_usage_records.sql for the backing table (one row per user, RLS scoped to owner / service_role).
  * Integration-style regression test asserting recorded usage survives a simulated service re-instantiation (restart) and that continued recording builds on the persisted counters rather than resetting them.

#1113 — Make malformed compliance blocklist configuration observable
  * loadComplianceConfig in packages/stellar/src/asset-compliance.ts replaces the silent empty catch blocks with a warnMalformedConfig() helper that console.warn's the offending env var name and the parse error before falling back to an empty list.
  * The safe empty-list fallback is retained so a config typo cannot block deployments, but it is no longer indistinguishable from an intentionally empty blocklist.
  * Regression tests in asset-compliance.test.ts: a malformed COMPLIANCE_BLOCKLIST_JSON / COMPLIANCE_JURISDICTION_JSON logs a warning naming the variable while still returning an empty list, and valid/absent config logs nothing.

Test runs
  * npm run test --workspace=@craft/stellar -- soroban-ttl-manager soroban-ttl-renewal -> soroban-ttl-manager.test.ts and soroban-ttl-renewal.test.ts pass (37 tests). Pre-existing, unrelated failures remain in soroban-ttl-manager.property.test.ts due to a vitest/fast-check env mismatch ("Cannot set property testPath"), identical before this change.
  * npm run test --workspace=@craft/stellar -- errors soroban-errors  -> 78 pass
  * npm run test --workspace=@craft/stellar -- asset-compliance        -> 17 pass
  * npm run test --workspace=@craft/backend --workspace=@craft/stellar -- fee-bump
    -> 5 pass (backend) + 18 pass (stellar)
    
Closes  #1111 
Closes #1112 
Closes #1113 
Closes #1114 