### PR TITLE
fix(stellar): resolve runtime bugs in TTL manager, merge protection, multi-party issuance, and XDR serializer

### DIFF
--- a/packages/stellar/src/account-merge-protection.test.ts
+++ b/packages/stellar/src/account-merge-protection.test.ts
@@ -339,3 +339,58 @@ describe('managed-account registry', () => {
         expect(isManagedAccount(SOURCE_KP.publicKey())).toBe(true);
     });
 });
+
+// ── Regression: #1100 – balance check in open-trustline filter ───────────────
+
+describe('regression #1100 – zero-balance trustline must not block merge', () => {
+    it('allows merge when trustline has nonzero limit but zero balance', () => {
+        const merge: MergeOperation = {
+            sourceAccount: SOURCE_KP.publicKey(),
+            destination: DEST_KP.publicKey(),
+        };
+        // limit > 0, balance === '0' — not an "open" trustline per the docs
+        const state = makeAccountState({
+            trustlines: [
+                { assetCode: 'USDC', assetIssuer: 'GABC...', balance: '0', limit: '1000' },
+            ],
+        });
+
+        const decision = checkMergeAllowed(merge, state);
+
+        expect(decision.allowed).toBe(true);
+    });
+
+    it('allows merge when trustline has nonzero limit and zero decimal-string balance', () => {
+        const merge: MergeOperation = {
+            sourceAccount: SOURCE_KP.publicKey(),
+            destination: DEST_KP.publicKey(),
+        };
+        const state = makeAccountState({
+            trustlines: [
+                { assetCode: 'BTC', assetIssuer: 'GBBB...', balance: '0.0000000', limit: '500' },
+            ],
+        });
+
+        const decision = checkMergeAllowed(merge, state);
+
+        expect(decision.allowed).toBe(true);
+    });
+
+    it('still blocks merge when trustline has both nonzero limit and nonzero balance', () => {
+        const merge: MergeOperation = {
+            sourceAccount: SOURCE_KP.publicKey(),
+            destination: DEST_KP.publicKey(),
+        };
+        const state = makeAccountState({
+            trustlines: [
+                { assetCode: 'USDC', assetIssuer: 'GABC...', balance: '1', limit: '1000' },
+            ],
+        });
+
+        const decision = checkMergeAllowed(merge, state);
+
+        expect(decision.allowed).toBe(false);
+        if (decision.allowed) return;
+        expect(decision.reason).toMatch(/trustline/);
+    });
+});

--- a/packages/stellar/src/account-merge-protection.ts
+++ b/packages/stellar/src/account-merge-protection.ts
@@ -168,9 +168,9 @@ export function checkMergeAllowed(
     accountState: AccountState,
     expectedDestination?: string,
 ): MergeDecision {
-    // Check open trustlines (non-zero balance or limit)
+    // Check open trustlines (limit > 0 AND balance > 0, per module documentation)
     const openTrustlines = accountState.trustlines.filter(
-        (t) => Number(t.limit) > 0,
+        (t) => Number(t.limit) > 0 && Number(t.balance) > 0,
     );
     if (openTrustlines.length > 0) {
         return {

--- a/packages/stellar/src/multi-party-issuance.test.ts
+++ b/packages/stellar/src/multi-party-issuance.test.ts
@@ -319,3 +319,96 @@ describe('error handling', () => {
         expect(result.error).toMatch(/Signature does not match claimed co-signer/);
     });
 });
+
+// ── Regression: #1101 – co-signer must sign the session's base transaction ───
+
+describe('regression #1101 – reject co-signer signatures against a different transaction', () => {
+    it('rejects a validly-signed but different transaction from a legitimate co-signer', () => {
+        const baseTxXdr = buildBaseTxXdr();
+        const session = createIssuanceSession({ required: 2, total: 3 }, baseTxXdr);
+
+        // Build a *different* transaction (different sequence number / operations)
+        const differentTxXdr = buildBaseTxXdr(); // fresh call gives new seq "1000" but same builder—
+        // To guarantee it differs, sign a different payload:
+        const differentAccount = {
+            accountId: () => SOURCE_KP.publicKey(),
+            sequenceNumber: () => '9999',
+            incrementSequenceNumber: () => {},
+        } as any;
+        const { TransactionBuilder: TB, BASE_FEE: BF, Operation: Op, Asset: As, Networks: Ns } =
+            require('stellar-sdk');
+        const altTxXdr = new TB(differentAccount, { fee: BF, networkPassphrase: Ns.TESTNET })
+            .addOperation(Op.payment({
+                destination: SIGNER_C.publicKey(),
+                asset: As.native(),
+                amount: '99',
+            }))
+            .setTimeout(60)
+            .build()
+            .toXDR();
+
+        const signedAltTx = signTxXdr(altTxXdr, SIGNER_A);
+
+        const result = addCoSignerSignature(
+            session.id,
+            SIGNER_A.publicKey(),
+            signedAltTx,
+            NETWORK,
+        );
+
+        expect(result.ok).toBe(false);
+        if (result.ok) return;
+        expect(result.error).toMatch(/does not match the session base transaction/);
+    });
+
+    it('the mismatch error is distinct from an invalid-signature error', () => {
+        const baseTxXdr = buildBaseTxXdr();
+        const session = createIssuanceSession({ required: 2, total: 3 }, baseTxXdr);
+
+        const differentAccount = {
+            accountId: () => SOURCE_KP.publicKey(),
+            sequenceNumber: () => '8888',
+            incrementSequenceNumber: () => {},
+        } as any;
+        const { TransactionBuilder: TB, BASE_FEE: BF, Operation: Op, Asset: As, Networks: Ns } =
+            require('stellar-sdk');
+        const altTxXdr = new TB(differentAccount, { fee: BF, networkPassphrase: Ns.TESTNET })
+            .addOperation(Op.payment({
+                destination: SIGNER_B.publicKey(),
+                asset: As.native(),
+                amount: '1',
+            }))
+            .setTimeout(60)
+            .build()
+            .toXDR();
+
+        const signedAltTx = signTxXdr(altTxXdr, SIGNER_A);
+
+        const mismatchResult = addCoSignerSignature(
+            session.id,
+            SIGNER_A.publicKey(),
+            signedAltTx,
+            NETWORK,
+        );
+
+        expect(mismatchResult.ok).toBe(false);
+        if (mismatchResult.ok) return;
+        // Must say "transaction" not "signature"
+        expect(mismatchResult.error).not.toMatch(/Signature does not match/);
+        expect(mismatchResult.error).toMatch(/transaction/i);
+    });
+
+    it('still accepts a correctly-signed base transaction after the fix', () => {
+        const baseTxXdr = buildBaseTxXdr();
+        const session = createIssuanceSession({ required: 2, total: 3 }, baseTxXdr);
+
+        const result = addCoSignerSignature(
+            session.id,
+            SIGNER_A.publicKey(),
+            signTxXdr(baseTxXdr, SIGNER_A),
+            NETWORK,
+        );
+
+        expect(result.ok).toBe(true);
+    });
+});

--- a/packages/stellar/src/multi-party-issuance.ts
+++ b/packages/stellar/src/multi-party-issuance.ts
@@ -178,6 +178,19 @@ export function addCoSignerSignature(
         return { ok: false, error: 'Invalid signed transaction XDR' };
     }
 
+    // Verify the submitted transaction matches the session's base transaction.
+    // Compare transaction hashes on the unsigned envelopes so that differences
+    // in source/sequence/operations/timeBounds are all caught in one check.
+    const baseTx = TransactionBuilder.fromXDR(session.baseTxXdr, networkPassphrase) as Transaction;
+    const baseHash = baseTx.hash().toString('hex');
+    const submittedHash = parsedTx.hash().toString('hex');
+    if (submittedHash !== baseHash) {
+        return {
+            ok: false,
+            error: 'Submitted transaction does not match the session base transaction',
+        };
+    }
+
     // Verify that at least one signature matches the claimed co-signer's public key
     const signerKeypair = Keypair.fromPublicKey(signerPublicKey);
     const txHash = parsedTx.hash();

--- a/packages/stellar/src/soroban-ttl-manager.test.ts
+++ b/packages/stellar/src/soroban-ttl-manager.test.ts
@@ -308,3 +308,43 @@ describe('TTL constants', () => {
         expect(DEFAULT_EXTEND_TO_LEDGERS).toBeGreaterThan(DEFAULT_WARNING_LEDGERS);
     });
 });
+
+// ── Regression: #1099 – Networks import ──────────────────────────────────────
+
+describe('regression #1099 – buildTtlExtensionTransaction does not throw ReferenceError', () => {
+    it('resolves without ReferenceError when using a mocked client (mainnet config)', async () => {
+        const client = makeTxClient();
+        const key = makeKey();
+
+        // If Networks was not imported, getNetworkPassphrase() would throw
+        // "ReferenceError: Networks is not defined" at transaction-build time.
+        await expect(
+            buildTtlExtensionTransaction([key], SOURCE_KEY, {}, client),
+        ).resolves.not.toThrow();
+    });
+
+    it('returns a string XDR result (not a ReferenceError rejection)', async () => {
+        const client = makeTxClient();
+        const key = makeKey();
+
+        const result = await buildTtlExtensionTransaction([key], SOURCE_KEY, {}, client);
+
+        expect(typeof result).toBe('string');
+        expect(result.length).toBeGreaterThan(0);
+    });
+
+    it('checkContractTtl does not surface a ReferenceError when TTL is near expiry', async () => {
+        const currentLedger = 1000;
+        const liveUntil = 1000 + DEFAULT_WARNING_LEDGERS - 1;
+        const ttlClient = makeTtlClient(liveUntil, currentLedger);
+        const txClient = makeTxClient();
+
+        // If Networks is missing, the ok:false branch would contain "Networks is not defined"
+        const result = await checkContractTtl(CONTRACT_ID, SOURCE_KEY, {}, ttlClient, txClient);
+
+        expect(result.ok).toBe(true);
+        if (!result.ok) {
+            expect(result.error).not.toMatch(/Networks is not defined/);
+        }
+    });
+});

--- a/packages/stellar/src/soroban-ttl-manager.ts
+++ b/packages/stellar/src/soroban-ttl-manager.ts
@@ -32,6 +32,7 @@ import {
     Operation,
     BASE_FEE,
     SorobanDataBuilder,
+    Networks,
 } from 'stellar-sdk';
 import { config, getSorobanRpcUrl, getNetworkPassphrase } from './config';
 import { parseStellarError } from './errors';

--- a/packages/stellar/src/soroban-xdr-deserializer.test.ts
+++ b/packages/stellar/src/soroban-xdr-deserializer.test.ts
@@ -419,3 +419,47 @@ describe('serializeScVal – error handling', () => {
         expect(() => serializeScVal(value, 'invalid' as any)).toThrow(SorobanSerializationError);
     });
 });
+
+// ── Regression: #1102 – explicit hint must throw instead of silently wrapping ─
+
+describe('regression #1102 – out-of-range values with explicit hint throw SorobanSerializationError', () => {
+    it('throws when hint is i32 and value exceeds i32 max (2147483647)', () => {
+        // 3_000_000_000 is a valid u32 but out of i32 range — must throw, not wrap
+        expect(() => serializeScVal(3_000_000_000, 'i32')).toThrow(SorobanSerializationError);
+    });
+
+    it('throws when hint is i32 and value is exactly i32 max + 1', () => {
+        expect(() => serializeScVal(2_147_483_648, 'i32')).toThrow(SorobanSerializationError);
+    });
+
+    it('throws when hint is u32 and value is negative', () => {
+        expect(() => serializeScVal(-1, 'u32')).toThrow(SorobanSerializationError);
+    });
+
+    it('throws when hint is u32 and value is -2147483648 (valid i32, invalid u32)', () => {
+        expect(() => serializeScVal(-2_147_483_648, 'u32')).toThrow(SorobanSerializationError);
+    });
+
+    it('does NOT throw for a value that legitimately fits i32 with hint i32', () => {
+        // 2_147_483_647 is INT32_MAX — must succeed
+        expect(() => serializeScVal(2_147_483_647, 'i32')).not.toThrow();
+        expect(() => serializeScVal(-2_147_483_648, 'i32')).not.toThrow();
+    });
+
+    it('does NOT throw for a value that legitimately fits u32 with hint u32', () => {
+        expect(() => serializeScVal(4_294_967_295, 'u32')).not.toThrow();
+        expect(() => serializeScVal(0, 'u32')).not.toThrow();
+    });
+
+    it('the thrown error is SorobanSerializationError not a silent wrap', () => {
+        // Without the fix, scvI32(3_000_000_000 | 0) would silently produce -1294967296
+        let caughtError: unknown;
+        try {
+            serializeScVal(3_000_000_000, 'i32');
+        } catch (e) {
+            caughtError = e;
+        }
+        expect(caughtError).toBeInstanceOf(SorobanSerializationError);
+        expect((caughtError as SorobanSerializationError).valueType).toBe('number');
+    });
+});

--- a/packages/stellar/src/soroban-xdr-deserializer.ts
+++ b/packages/stellar/src/soroban-xdr-deserializer.ts
@@ -278,8 +278,20 @@ export function serializeScVal(value: SorobanValue, hint?: ScValTypeHint): xdr.S
             );
         }
         if (hint === 'u32') {
+            if (value < 0 || value > 4_294_967_295) {
+                throw new SorobanSerializationError(
+                    `Number ${value} is out of range for u32 (0 to 4294967295)`,
+                    'number',
+                );
+            }
             return xdr.ScVal.scvU32(value >>> 0);
         } else if (hint === 'i32') {
+            if (value < -2_147_483_648 || value > 2_147_483_647) {
+                throw new SorobanSerializationError(
+                    `Number ${value} is out of range for i32 (-2147483648 to 2147483647)`,
+                    'number',
+                );
+            }
             return xdr.ScVal.scvI32(value | 0);
         } else if (value >= 0) {
             return xdr.ScVal.scvU32(value >>> 0);


### PR DESCRIPTION
## Summary

Fixes four bugs in `packages/stellar` that caused incorrect runtime behaviour. All changes are isolated to the affected files with regression tests added for each.

---

### #1099 — Fix missing `Networks` import crashing TTL extension transaction building

**File:** `packages/stellar/src/soroban-ttl-manager.ts`

`getNetworkPassphrase()` referenced `Networks.PUBLIC` / `Networks.TESTNET` but `Networks` was never in the import list. Every call path through `buildTtlExtensionTransaction`, `checkContractTtl`, and `AutomaticTTLRenewer._tick` threw `ReferenceError: Networks is not defined` at runtime.

**Fix:** Added `Networks` to the `stellar-sdk` import statement.

---

### #1100 — Enforce documented balance condition in account-merge trustline protection

**File:** `packages/stellar/src/account-merge-protection.ts`

The module doc states merges are blocked for trustlines with `limit > 0 AND balance > 0`, but the filter only checked `Number(t.limit) > 0`. Accounts that had fully spent down a custom-asset balance to zero were incorrectly blocked from merging.

**Fix:** Updated the `openTrustlines` filter to also require `Number(t.balance) > 0`.

---

### #1101 — Verify co-signer transactions are identical before merging signatures

**File:** `packages/stellar/src/multi-party-issuance.ts`

`addCoSignerSignature` validated the signature was cryptographically correct but never verified the signed transaction matched the session's `baseTxXdr`. A co-signer who signed a different transaction would have their signature silently accepted.

**Fix:** Transaction hashes are compared against `baseTxXdr` before the signature check. A mismatch returns a distinct error (`'Submitted transaction does not match the session base transaction'`), clearly differentiated from an invalid-signature error.

---

### #1102 — Throw instead of silently truncating out-of-range values when an explicit ScVal hint is provided

**File:** `packages/stellar/src/soroban-xdr-deserializer.ts`

With `hint: 'i32'`, a value like `3_000_000_000` (valid `u32`, out of `i32` range) was silently wrapped via `| 0` to `-1294967296` instead of throwing. Same issue for `hint: 'u32'` with a negative value.

**Fix:** Added explicit per-hint range guards before calling `scvI32`/`scvU32`, throwing `SorobanSerializationError` on a mismatch.

---

## Tests

| File | New test suite | Tests added |
|------|---------------|-------------|
| `soroban-ttl-manager.test.ts` | `regression #1099` | 3 |
| `account-merge-protection.test.ts` | `regression #1100` | 3 |
| `multi-party-issuance.test.ts` | `regression #1101` | 3 |
| `soroban-xdr-deserializer.test.ts` | `regression #1102` | 7 |

All new tests pass. The 3 pre-existing failures in `soroban-xdr-deserializer.test.ts` were already failing on `main` before this branch and are unrelated.

## Checklist

- [x] `Networks` imported — no more `ReferenceError` in TTL paths
- [x] Merge protection checks both `limit > 0` and `balance > 0`
- [x] Co-signer transaction identity verified before signature is stored
- [x] Explicit `i32`/`u32` hints throw on out-of-range values instead of wrapping silently
- [x] Regression tests added for all four fixes
- [x] No pre-existing tests broken by these changes

Closes #1099, closes #1100, closes #1101, closes #1102
