### PR TITLE
fix(backend): repair retry, provider, and realtime flows

### DIFF
--- a/apps/backend/src/lib/retry/exponential-backoff.test.ts
+++ b/apps/backend/src/lib/retry/exponential-backoff.test.ts
@@ -63,8 +63,13 @@ describe('exponential-backoff', () => {
         });
 
         it('should respect max delay', () => {
-            const delay = calculateBackoffDelay(10, 100, 500, 2);
-            expect(delay).toBeLessThanOrEqual(550); // 500 + 10% jitter
+            const delay = calculateBackoffDelay(10, 100, 500, 2, () => 1);
+            expect(delay).toBe(500);
+        });
+
+        it('should honor a custom random function', () => {
+            expect(calculateBackoffDelay(0, 100, 1000, 2, () => 0)).toBe(90);
+            expect(calculateBackoffDelay(0, 100, 1000, 2, () => 1)).toBe(110);
         });
 
         it('should add jitter', () => {

--- a/apps/backend/src/lib/retry/exponential-backoff.ts
+++ b/apps/backend/src/lib/retry/exponential-backoff.ts
@@ -90,13 +90,11 @@ export function calculateBackoffDelay(
     const random = randomFn ?? Math.random;
     // Exponential backoff: initial * (multiplier ^ attempt)
     const exponential = initialDelayMs * Math.pow(multiplier, attempt);
+    const delay = Math.min(exponential, maxDelayMs);
 
-    // Add jitter: ±10% of the pre-cap exponential value
-    const jitter = exponential * 0.1 * (Math.random() - 0.5) * 2;
-
-    // Add jitter: ±10% of the delay
+    // Add jitter: ±10% of the capped delay
     const jitter = delay * 0.1 * (random() - 0.5) * 2;
-    return Math.max(0, delay + jitter);
+    return Math.min(maxDelayMs, Math.max(0, delay + jitter));
 }
 
 /**

--- a/apps/backend/src/services/multi-provider-auth.service.test.ts
+++ b/apps/backend/src/services/multi-provider-auth.service.test.ts
@@ -117,6 +117,15 @@ describe('MultiProviderAuthService', () => {
         });
     });
 
+    it('throws when connecting Stellar fails through RPC', async () => {
+        const supabase = makeSupabase();
+        supabase.rpc.mockResolvedValueOnce({ error: { message: 'database unavailable' } });
+        const { multiProviderAuthService } = await import('./multi-provider-auth.service');
+
+        await expect(multiProviderAuthService.connectStellar(supabase, 'user-1', 'GXYZ'))
+            .rejects.toThrow('Failed to connect Stellar wallet: database unavailable');
+    });
+
     // ── disconnectProvider ────────────────────────────────────────────────────
 
     it('clears GitHub fields on disconnect', async () => {
@@ -149,6 +158,15 @@ describe('MultiProviderAuthService', () => {
             p_user_id: 'user-1',
             p_provider: 'stellar',
         });
+    });
+
+    it('throws when disconnecting Stellar fails through RPC', async () => {
+        const supabase = makeSupabase();
+        supabase.rpc.mockResolvedValueOnce({ error: { message: 'database unavailable' } });
+        const { multiProviderAuthService } = await import('./multi-provider-auth.service');
+
+        await expect(multiProviderAuthService.disconnectProvider(supabase, 'user-1', 'stellar'))
+            .rejects.toThrow('Failed to disconnect Stellar: database unavailable');
     });
 
     // ── getConnectionStatus ───────────────────────────────────────────────────
@@ -254,7 +272,7 @@ describe('MultiProviderAuthService', () => {
 
         expect(connectRes.provider).toBe('stellar');
         expect(disconnectRes.provider).toBe('stellar');
-        expect(supabase.rpc).toHaveBeenCalledWith('connect_stellar_provider', expect.objectContaining({ p_public_key: 'GCONCURRENT' }));
-        expect(supabase.rpc).toHaveBeenCalledWith('disconnect_stellar_provider', expect.objectContaining({ p_user_id: 'user-1' }));
+        expect(supabase.rpc).toHaveBeenCalledWith('set_provider_connection', expect.objectContaining({ p_value: expect.objectContaining({ publicKey: 'GCONCURRENT' }) }));
+        expect(supabase.rpc).toHaveBeenCalledWith('remove_provider_connection', expect.objectContaining({ p_user_id: 'user-1' }));
     });
 });

--- a/apps/backend/src/services/multi-provider-auth.service.ts
+++ b/apps/backend/src/services/multi-provider-auth.service.ts
@@ -108,22 +108,7 @@ export class MultiProviderAuthService {
             p_value: { publicKey, connectedAt: new Date().toISOString() },
         });
 
-            const existing = (data?.provider_connections as Record<string, unknown>) ?? {};
-            const updated = {
-                ...existing,
-                stellar: { publicKey, connectedAt },
-            };
-
-            const { error } = await supabase
-                .from('profiles')
-                .update({
-                    provider_connections: updated,
-                    updated_at: new Date().toISOString(),
-                })
-                .eq('id', userId);
-
-            if (error) throw new Error(`Failed to connect Stellar wallet: ${error.message}`);
-        }
+        if (error) throw new Error(`Failed to connect Stellar wallet: ${error.message}`);
 
         return { userId, provider: 'stellar', connected: true };
     }
@@ -160,16 +145,7 @@ export class MultiProviderAuthService {
                 p_provider: 'stellar',
             });
 
-                const { error } = await supabase
-                    .from('profiles')
-                    .update({
-                        provider_connections: rest,
-                        updated_at: new Date().toISOString(),
-                    })
-                    .eq('id', userId);
-
-                if (error) throw new Error(`Failed to disconnect Stellar: ${error.message}`);
-            }
+            if (error) throw new Error(`Failed to disconnect Stellar: ${error.message}`);
         }
 
         return { userId, provider, connected: false };

--- a/apps/backend/src/services/supabase-realtime-subscription.service.ts
+++ b/apps/backend/src/services/supabase-realtime-subscription.service.ts
@@ -81,28 +81,42 @@ export class SupabaseRealtimeSubscriptionService {
         this.connectionState = 'reconnecting';
         this.reconnectAttempts = 0;
 
-        const result = await retryWithBackoff(
-            async () => {
-                this.reconnectAttempts++;
-                if (this.reconnectAttempts >= this.reconnectAttemptsMax) {
-                    // Switch to polling
-                    this.connectionState = 'polling';
-                    this.startPolling(userId, onUpdate);
-                } else {
-                    // Retry with exponential backoff
-                    this.connectionState = 'reconnecting';
-                    const delayMs = this.reconnectDelayMs * Math.pow(2, this.reconnectAttempts - 1);
-                    this.reconnectTimeout = setTimeout(attemptConnect, delayMs);
-                }
-            }
-        };
-
-        if (result.success) {
+        try {
+            this.reconnectAttempts++;
+            await this.realtime.subscribe('deployments', userId);
             this.connectionState = 'connected';
             this.reconnectAttempts = 0;
-        } else {
-            this.connectionState = 'polling';
-            this.startPolling(userId, onUpdate);
+        } catch {
+            if (this.reconnectAttempts >= this.reconnectAttemptsMax) {
+                this.connectionState = 'polling';
+                this.startPolling(userId, onUpdate);
+            } else {
+                void retryWithBackoff(
+                    async () => {
+                        this.reconnectAttempts++;
+                        this.connectionState = 'reconnecting';
+                        try {
+                            await this.realtime.subscribe('deployments', userId);
+                        } catch (error) {
+                            throw new Error(
+                                `Realtime subscription failed: ${error instanceof Error ? error.message : String(error)}`,
+                            );
+                        }
+                    },
+                    {
+                        maxAttempts: this.reconnectAttemptsMax - 1,
+                        initialDelayMs: this.reconnectDelayMs,
+                    },
+                ).then((result) => {
+                    if (result.success) {
+                        this.connectionState = 'connected';
+                        this.reconnectAttempts = 0;
+                    } else {
+                        this.connectionState = 'polling';
+                        this.startPolling(userId, onUpdate);
+                    }
+                });
+            }
         }
 
         // Return unsubscribe function


### PR DESCRIPTION
## Summary
- Restore capped, injectable-jitter exponential backoff and add regression coverage.
- Remove orphaned Stellar provider migration code and surface RPC failures.
- Make realtime subscription retries invoke the client, retry failed connections, and fall back to polling correctly.

## Validation
- `npm run test --workspace=@craft/backend -- multi-provider-auth` (40 passed)
- `npm run test --workspace=@craft/backend -- supabase-realtime-recovery.integration supabase-realtime-chaos` (23 passed)
- `npm run test --workspace=@craft/backend -- exponential-backoff -t 'calculateBackoffDelay'` (5 passed)
- Backend typecheck remains blocked by unrelated pre-existing syntax errors in the DNS route and schema validator.

Closes #1043
Closes #1044
Closes #1045
Closes #1043