### PR TITLE
fix(stellar): cap rate-limit backoff, surface price-feed & deserializ…

### DIFF
--- a/packages/stellar/src/dex-price-feed.test.ts
+++ b/packages/stellar/src/dex-price-feed.test.ts
@@ -177,4 +177,43 @@ describe('subscribeLedgerPriceFeed', () => {
 
         expect(onUpdate).toHaveBeenCalledTimes(3);
     });
+
+    it('surfaces a sustained fetch failure through onError on every ledger while staying subscribed (#1116)', async () => {
+        const { emitter, emit, handlers } = makeEmitter();
+        const failure = new Error('expired credentials');
+        const fetcher: OrderBookFetcher = { fetch: vi.fn().mockRejectedValue(failure) };
+        const onUpdate = vi.fn();
+        const onError = vi.fn();
+
+        const unsubscribe = subscribeLedgerPriceFeed(emitter, fetcher, onUpdate, onError);
+
+        emit(2000);
+        emit(2001);
+        emit(2002);
+        await new Promise(r => setTimeout(r, 20));
+
+        // Observability: onError fired once per failed ledger with the error + triggering event.
+        expect(onError).toHaveBeenCalledTimes(3);
+        expect(onError.mock.calls[0][0]).toBe(failure);
+        expect(onError.mock.calls[0][1]).toEqual({ sequence: 2000 });
+        expect(onError.mock.calls[2][1]).toEqual({ sequence: 2002 });
+
+        // Resilience unchanged: no price updates, subscription still active.
+        expect(onUpdate).not.toHaveBeenCalled();
+        expect(handlers.size).toBe(1);
+
+        unsubscribe();
+    });
+
+    it('does not require an onError callback (#1116)', async () => {
+        const { emitter, emit } = makeEmitter();
+        const fetcher: OrderBookFetcher = { fetch: vi.fn().mockRejectedValue(new Error('network')) };
+        const onUpdate = vi.fn();
+
+        expect(() => subscribeLedgerPriceFeed(emitter, fetcher, onUpdate)).not.toThrow();
+        emit(3000);
+        await new Promise(r => setTimeout(r, 10));
+
+        expect(onUpdate).not.toHaveBeenCalled();
+    });
 });

--- a/packages/stellar/src/dex-price-feed.ts
+++ b/packages/stellar/src/dex-price-feed.ts
@@ -344,22 +344,42 @@ export interface OrderBookFetcher {
  * Subscribe to ledger-close events and call `onUpdate` with a freshly
  * computed `EnrichedDexPriceResult` on every new ledger.
  *
+ * A single failing `fetcher.fetch()` never tears the subscription down — the
+ * stream stays alive and keeps trying on the next ledger. That resilience,
+ * however, previously made a *persistent* failure (expired credentials, a
+ * renamed Horizon endpoint, a network partition) indistinguishable from a quiet
+ * market: the subscription stops producing updates while remaining technically
+ * active, with nothing logged. Pass `onError` to observe and alert on sustained
+ * failures; it is invoked once per failed ledger event with the thrown error and
+ * the triggering `LedgerEvent`, and its own exceptions are ignored so a broken
+ * handler cannot break the feed.
+ *
  * @param emitter  - Source of `'ledger'` events (e.g. Horizon SSE stream)
  * @param fetcher  - Fetches the current order book snapshot on demand
  * @param onUpdate - Called with the enriched price result after each ledger
+ * @param onError  - Optional; called with `(error, ledger)` each time a per-ledger
+ *                   fetch fails. Does not change the resilience behaviour — the
+ *                   subscription stays alive regardless.
  * @returns Unsubscribe function – call it to stop receiving updates
  */
 export function subscribeLedgerPriceFeed(
     emitter: LedgerEventEmitter,
     fetcher: OrderBookFetcher,
     onUpdate: PriceFeedUpdateHandler,
+    onError?: (error: unknown, ledger: LedgerEvent) => void,
 ): () => void {
-    const handler = async (_ledger: LedgerEvent) => {
+    const handler = async (ledger: LedgerEvent) => {
         try {
             const book = await fetcher.fetch();
             onUpdate(computeEnrichedDexPrice(book));
-        } catch {
-            // Swallow individual fetch errors; the stream stays alive
+        } catch (error) {
+            // Swallow individual fetch errors; the stream stays alive.
+            // Surface them through onError so callers can alert on sustained failures.
+            try {
+                onError?.(error, ledger);
+            } catch {
+                // A misbehaving error handler must not break the feed.
+            }
         }
     };
 

--- a/packages/stellar/src/horizon-client.test.ts
+++ b/packages/stellar/src/horizon-client.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect, vi } from 'vitest';
-import { HorizonClient, CircuitBreaker, computeBackoffMs } from './horizon-client';
+import { HorizonClient, CircuitBreaker, computeBackoffMs, MAX_BACKOFF_DELAY_MS } from './horizon-client';
 
 const BASE_URL = 'https://horizon-testnet.stellar.org';
 
@@ -61,6 +61,31 @@ describe('computeBackoffMs', () => {
     const { delayMs: d2 } = computeBackoffMs({}, 2);
     expect(d1).toBe(d0 * 2);
     expect(d2).toBe(d0 * 4);
+  });
+
+  it('caps a far-future X-RateLimit-Reset delay instead of returning it unbounded (#1115)', () => {
+    // Reset one hour in the future (clock skew / Horizon anomaly / bad proxy).
+    const farFutureReset = Math.floor(Date.now() / 1000) + 3600;
+    const { delayMs, reason } = computeBackoffMs(
+      { 'x-ratelimit-remaining': '1', 'x-ratelimit-reset': String(farFutureReset) },
+      0,
+    );
+
+    // Without the cap this would be ~3_600_000 ms.
+    expect(delayMs).toBe(MAX_BACKOFF_DELAY_MS);
+    expect(delayMs).toBeLessThanOrEqual(MAX_BACKOFF_DELAY_MS);
+    expect(reason).toContain('rate_limit_low_remaining');
+    expect(reason).toContain('capped');
+  });
+
+  it('does not mark a within-cap reset delay as capped (#1115)', () => {
+    const resetSec = Math.floor(Date.now() / 1000) + 2;
+    const { delayMs, reason } = computeBackoffMs(
+      { 'x-ratelimit-remaining': '1', 'x-ratelimit-reset': String(resetSec) },
+      0,
+    );
+    expect(delayMs).toBeLessThanOrEqual(MAX_BACKOFF_DELAY_MS);
+    expect(reason).not.toContain('capped');
   });
 });
 

--- a/packages/stellar/src/horizon-client.ts
+++ b/packages/stellar/src/horizon-client.ts
@@ -108,9 +108,21 @@ export class CircuitBreaker {
 // ── Adaptive retry helper ──────────────────────────────────────────────────────
 
 /**
+ * Upper bound for the rate-limit-derived backoff delay.
+ *
+ * The X-RateLimit-Reset header is server-supplied and can be far in the future
+ * because of a Horizon anomaly, a misbehaving proxy, or clock drift between the
+ * client and the server. Without a ceiling, a single retry attempt could block
+ * the caller for minutes or hours. Cap it at a few seconds so a retry never
+ * outlives a reasonable request timeout.
+ */
+export const MAX_BACKOFF_DELAY_MS = 5_000;
+
+/**
  * Computes the backoff delay in ms for a given response.
  *
- * - If X-RateLimit-Remaining < 10, delays until X-RateLimit-Reset (epoch seconds).
+ * - If X-RateLimit-Remaining < 10, delays until X-RateLimit-Reset (epoch seconds),
+ *   clamped to {@link MAX_BACKOFF_DELAY_MS}.
  * - Otherwise uses exponential backoff: 200 * 2^attempt ms.
  */
 export function computeBackoffMs(
@@ -122,8 +134,13 @@ export function computeBackoffMs(
 
   if (remaining < 10 && reset > 0) {
     const nowSec = Math.floor(Date.now() / 1000);
-    const delayMs = Math.max(0, (reset - nowSec) * 1000);
-    return { delayMs, reason: `rate_limit_low_remaining (${remaining} left, reset in ${reset - nowSec}s)` };
+    const uncappedDelayMs = Math.max(0, (reset - nowSec) * 1000);
+    const delayMs = Math.min(uncappedDelayMs, MAX_BACKOFF_DELAY_MS);
+    const capped = delayMs < uncappedDelayMs;
+    const reason =
+      `rate_limit_low_remaining (${remaining} left, reset in ${reset - nowSec}s` +
+      (capped ? `, capped ${uncappedDelayMs}ms->${delayMs}ms)` : `)`);
+    return { delayMs, reason };
   }
 
   const delayMs = 200 * Math.pow(2, attempt);

--- a/packages/stellar/src/multi-party-issuance.test.ts
+++ b/packages/stellar/src/multi-party-issuance.test.ts
@@ -227,6 +227,59 @@ describe('session timeout expiry', () => {
         expect(result.error).toMatch(/expired/);
     });
 
+    it('addCoSignerSignature and expireTimedOutSessions agree at exactly expiresAt (#1118)', () => {
+        const baseTxXdr = buildBaseTxXdr();
+        const signedByA = signTxXdr(baseTxXdr, SIGNER_A);
+
+        const session = createIssuanceSession(
+            { required: 2, total: 3, timeoutMs: 60_000 },
+            baseTxXdr,
+        );
+        const exactlyExpiresAt = session.expiresAt;
+
+        // `now > expiresAt` is false at the boundary → NOT expired.
+        const count = expireTimedOutSessions(exactlyExpiresAt);
+        expect(count).toBe(0);
+        expect(getIssuanceSession(session.id)!.state).toBe('pending');
+
+        // addCoSignerSignature, evaluated at the identical instant, must not treat it as expired.
+        const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(exactlyExpiresAt);
+        try {
+            const result = addCoSignerSignature(session.id, SIGNER_A.publicKey(), signedByA, NETWORK);
+            expect(result.ok).toBe(true);
+        } finally {
+            nowSpy.mockRestore();
+        }
+        expect(getIssuanceSession(session.id)!.state).not.toBe('expired');
+    });
+
+    it('addCoSignerSignature and expireTimedOutSessions agree one ms past expiresAt (#1118)', () => {
+        const baseTxXdr = buildBaseTxXdr();
+        const signedByA = signTxXdr(baseTxXdr, SIGNER_A);
+
+        const sessionForExpire = createIssuanceSession(
+            { required: 2, total: 3, timeoutMs: 60_000 },
+            baseTxXdr,
+        );
+        const count = expireTimedOutSessions(sessionForExpire.expiresAt + 1);
+        expect(count).toBe(1);
+        expect(getIssuanceSession(sessionForExpire.id)!.state).toBe('expired');
+
+        const session2 = createIssuanceSession(
+            { required: 2, total: 3, timeoutMs: 60_000 },
+            baseTxXdr,
+        );
+        const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(session2.expiresAt + 1);
+        try {
+            const result = addCoSignerSignature(session2.id, SIGNER_A.publicKey(), signedByA, NETWORK);
+            expect(result.ok).toBe(false);
+            if (!result.ok) expect(result.error).toMatch(/expired/);
+        } finally {
+            nowSpy.mockRestore();
+        }
+        expect(getIssuanceSession(session2.id)!.state).toBe('expired');
+    });
+
     it('does not expire approved or issued sessions', () => {
         const baseTxXdr = buildBaseTxXdr();
         const session = createIssuanceSession(

--- a/packages/stellar/src/multi-party-issuance.ts
+++ b/packages/stellar/src/multi-party-issuance.ts
@@ -153,7 +153,7 @@ export function addCoSignerSignature(
     }
 
     // Expire sessions that exceeded the timeout
-    if (Date.now() > session.expiresAt) {
+    if (isSessionExpired(session, Date.now())) {
         session.state = 'expired';
         return { ok: false, error: 'Session has expired' };
     }
@@ -259,7 +259,7 @@ export function expireTimedOutSessions(_now: number = Date.now()): number {
             session.state !== 'approved' &&
             session.state !== 'issued' &&
             session.state !== 'expired' &&
-            _now > session.expiresAt
+            isSessionExpired(session, _now)
         ) {
             session.state = 'expired';
             expired++;
@@ -272,6 +272,20 @@ export function expireTimedOutSessions(_now: number = Date.now()): number {
 // ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------
+
+/**
+ * Single source of truth for "has this session passed its expiry deadline?".
+ *
+ * `addCoSignerSignature` and `expireTimedOutSessions` both gate on session
+ * expiry; routing both through this helper keeps their semantics identical and
+ * prevents drift if the rule later changes (e.g. `>=` or a grace period).
+ *
+ * @param session - Session whose `expiresAt` is compared against `now`.
+ * @param now     - Current timestamp in ms (epoch).
+ */
+function isSessionExpired(session: IssuanceSession, now: number): boolean {
+    return now > session.expiresAt;
+}
 
 /**
  * Merge the signatures from multiple signed transaction XDRs into a single

--- a/packages/stellar/src/soroban-xdr-deserializer.test.ts
+++ b/packages/stellar/src/soroban-xdr-deserializer.test.ts
@@ -282,6 +282,40 @@ describe('deserializeScValAs', () => {
         const val = xdr.ScVal.scvBool(false);
         expect(deserializeScValAs(val)).toBe(false);
     });
+
+    it('names the ScVal discriminant in the message when JS typeof is ambiguous (#1117)', () => {
+        // A scvMap deserializes to an object, so `typeof value` is just "object" —
+        // useless for telling a map apart from a vec. The message must say scvMap.
+        const mapVal = xdr.ScVal.scvMap([
+            new xdr.ScMapEntry({ key: xdr.ScVal.scvSymbol('k'), val: xdr.ScVal.scvU32(1) }),
+        ]);
+        try {
+            deserializeScValAs<string>(mapVal, (v): v is string => typeof v === 'string');
+            expect.unreachable('guard should have failed');
+        } catch (e) {
+            expect(e).toBeInstanceOf(SorobanDeserializationError);
+            const err = e as SorobanDeserializationError;
+            expect(err.message).toContain('scvMap');
+            // The diagnostic property is still populated as before.
+            expect(err.scvType).toBe('scvMap');
+        }
+    });
+
+    it('names the ScVal discriminant for an ambiguous bigint variant (#1117)', () => {
+        // Every 64/128/256-bit integer variant is `bigint` at runtime; the message
+        // must disambiguate which one (scvI128 here).
+        const i128Val = xdr.ScVal.scvI128(
+            new xdr.Int128Parts({ hi: new xdr.Int64(0n), lo: new xdr.Uint64(1000n) }),
+        );
+        try {
+            deserializeScValAs<number>(i128Val, (v): v is number => typeof v === 'number');
+            expect.unreachable('guard should have failed');
+        } catch (e) {
+            const err = e as SorobanDeserializationError;
+            expect(err.message).toContain('scvI128');
+            expect(err.scvType).toBe('scvI128');
+        }
+    });
 });
 
 // ── Serialization (inverse of deserialization) ────────────────────────────────

--- a/packages/stellar/src/soroban-xdr-deserializer.ts
+++ b/packages/stellar/src/soroban-xdr-deserializer.ts
@@ -232,9 +232,15 @@ export function deserializeScValAs<T extends SorobanValue>(
 ): T {
     const value = deserializeScVal(scVal);
     if (guard && !guard(value)) {
+        const scvType = scVal.switch().name;
         throw new SorobanDeserializationError(
-            `Deserialized value did not match expected type (got ${typeof value})`,
-            scVal.switch().name,
+            // Report the ScVal discriminant (e.g. scvMap, scvI128), not just the
+            // JS runtime type — `typeof value` is `object` for both maps and vecs
+            // and `bigint` for every 64/128/256-bit integer variant, so it can't
+            // tell you which shape actually came back.
+            `Deserialized value did not match expected type ` +
+                `(got ScVal ${scvType}, JS typeof ${typeof value})`,
+            scvType,
         );
     }
     return value as T;


### PR DESCRIPTION
…er diagnostics, dedupe issuance expiry

Resolves four independent robustness/observability issues in @craft/stellar.

#1115 — Cap adaptive rate-limit backoff derived from Horizon headers
  computeBackoffMs turned the X-RateLimit-Reset header into a sleep duration
  with no upper bound, so a far-future or clock-skewed reset value could block
  a caller inside the retry loop for minutes or hours. Added a
  MAX_BACKOFF_DELAY_MS constant (5s) and clamped the rate-limit-derived delay
  to it. The reason string now reports the clamp
  ("rate_limit_low_remaining (... capped 3600000ms->5000ms)") for observability.
  The exponential-backoff branch is unchanged. Regression tests cover a
  far-future reset (delay capped) and a within-cap reset (not marked capped).

#1116 — Surface OrderBookFetcher failures from the ledger-triggered price feed
  subscribeLedgerPriceFeed swallowed every per-ledger fetch error with a bare
  catch, so a persistently failing fetcher silently stopped producing price
  updates while the subscription stayed "alive". Added an optional
  onError(error, ledger) callback, invoked from the existing catch block once
  per failed ledger; a throwing handler is itself caught so it cannot break the
  feed. The single-failure resilience behaviour is unchanged. JSDoc documents
  the parameter and the observability gap. Regression tests assert onError
  fires on every failed ledger while the subscription stays active, and that
  the callback remains optional.

#1117 — Report the ScVal discriminant instead of the JS runtime type on a
        failed type guard
  deserializeScValAs reported guard failures with "got <typeof value>", which
  is "object" for every map/vec and "bigint" for every 64/128/256-bit integer
  variant. The message now includes the actual ScVal discriminant
  ("got ScVal scvMap, JS typeof object"); the scvType diagnostic property is
  still populated. Regression tests assert the discriminant appears in the
  message for a scvMap guard failure and for an ambiguous bigint (scvI128)
  case.

#1118 — Extract a single shared session-expiry check for multi-party issuance
  addCoSignerSignature and expireTimedOutSessions each open-coded the same
  "now > expiresAt" comparison, inviting future drift. Both now call a private
  isSessionExpired(session, now) helper. No behaviour change. A regression test
  asserts both code paths treat a session at exactly expiresAt identically
  (neither expired) and one millisecond past it identically (both expired).

Tests:
  npm run test --workspace=@craft/stellar -- horizon-client            19 passed
  npm run test --workspace=@craft/stellar -- dex-price-feed            (dex-price-feed.test.ts) 16 passed
  npm run test --workspace=@craft/stellar -- soroban-xdr-deserializer  new #1117 tests passed (3 unrelated
                                                                       pre-existing serializeScVal failures untouched)
  npm run test --workspace=@craft/stellar -- multi-party-issuance      20 passed

Closes #1118 
Closes #1117 
Closes #1116 
Closes #1115 