### PR TITLE
fix(backend): resolve issues #1053 through #1056

### DIFF
--- a/apps/backend/docs/VERCEL_DOMAIN_LIFECYCLE.md
+++ b/apps/backend/docs/VERCEL_DOMAIN_LIFECYCLE.md
@@ -178,13 +178,13 @@ Remove domain ──┬─→ FAIL → Return { success: false, partialFailureRe
                 │
                 └─→ SUCCESS → Clean up aliases
                                │
-                               ├─→ ALL SUCCESS → Return { success: true, aliasesRemoved: N }
+                               ├─→ ALL SUCCESS → Return { success: true, aliasesMatched: N }
                                │
                                └─→ SOME FAIL   → Return { 
                                                     success: true,
                                                     partialFailure: true,
                                                     partialFailureReason: "...",
-                                                    aliasesRemoved: N
+                                                    aliasesMatched: N
                                                   }
 ```
 
@@ -193,7 +193,7 @@ Remove domain ──┬─→ FAIL → Return { success: false, partialFailureRe
 interface RemoveDomainResult {
   success: boolean;
   domain: string;
-  aliasesRemoved: number;
+  aliasesMatched: number;
   partialFailure?: boolean;
   partialFailureReason?: string;
 }
@@ -208,7 +208,7 @@ const result = await vercelDomainLifecycle.removeDomainWithCleanup(
 );
 
 if (result.success) {
-  console.log(`✅ Domain removed, ${result.aliasesRemoved} aliases cleaned up`);
+  console.log(`Domain removed, ${result.aliasesMatched} matching aliases found`);
   
   if (result.partialFailure) {
     console.warn(`⚠️ Partial failure: ${result.partialFailureReason}`);
@@ -441,7 +441,7 @@ npm test vercel-custom-domain-configuration.property.test.ts
 {
   "success": true,
   "domain": "app.example.com",
-  "aliasesRemoved": 2
+  "aliasesMatched": 2
 }
 ```
 

--- a/apps/backend/src/lib/github/scope-validator.test.ts
+++ b/apps/backend/src/lib/github/scope-validator.test.ts
@@ -5,6 +5,7 @@ import {
   fetchAndValidateScopes,
   clearScopeValidationCache,
   REQUIRED_SCOPES,
+  MAX_SCOPE_VALIDATION_CACHE_ENTRIES,
 } from './scope-validator';
 
 vi.stubGlobal('fetch', vi.fn());
@@ -283,6 +284,23 @@ describe('scope-validator', () => {
       expect(mockFetch).toHaveBeenCalledOnce();
 
       vi.useRealTimers();
+    });
+
+    it('evicts the oldest entry when the cache reaches its maximum size', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        headers: new Map([['X-OAuth-Scopes', 'repo, read:user']]),
+      });
+
+      for (let index = 0; index < MAX_SCOPE_VALIDATION_CACHE_ENTRIES; index++) {
+        await fetchAndValidateScopes(`token-${index}`);
+      }
+
+      mockFetch.mockClear();
+      await fetchAndValidateScopes(`token-${MAX_SCOPE_VALIDATION_CACHE_ENTRIES}`);
+      await fetchAndValidateScopes('token-0');
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/apps/backend/src/lib/github/scope-validator.ts
+++ b/apps/backend/src/lib/github/scope-validator.ts
@@ -40,12 +40,22 @@ const SCOPE_VALIDATION_CACHE_TTL_MS = parseInt(
     10,
 ); // 5 minutes default
 
+/** Maximum number of validation results held in memory. */
+export const MAX_SCOPE_VALIDATION_CACHE_ENTRIES = 1_000;
+
 interface CacheEntry {
     result: ScopeValidationResult;
     expiresAt: number;
 }
 
 const scopeValidationCache = new Map<string, CacheEntry>();
+
+function evictOldestScopeValidationEntry(): void {
+    const oldestKey = scopeValidationCache.keys().next().value;
+    if (oldestKey !== undefined) {
+        scopeValidationCache.delete(oldestKey);
+    }
+}
 
 function hashToken(token: string): string {
     return createHash('sha256').update(token).digest('hex');
@@ -180,6 +190,9 @@ export async function fetchAndValidateScopes(
     const result = validateScopes(grantedScopes);
 
     // Cache successful validations
+    if (scopeValidationCache.size >= MAX_SCOPE_VALIDATION_CACHE_ENTRIES) {
+        evictOldestScopeValidationEntry();
+    }
     scopeValidationCache.set(tokenHash, {
         result,
         expiresAt: Date.now() + SCOPE_VALIDATION_CACHE_TTL_MS,

--- a/apps/backend/src/services/cleanup.orphaned-artifacts.test.ts
+++ b/apps/backend/src/services/cleanup.orphaned-artifacts.test.ts
@@ -65,6 +65,8 @@ describe('CleanupService.purgeOrphanedArtifacts', () => {
     it('derives the deployment id from both folder and flat artifact paths', () => {
         expect(deploymentIdFromArtifactPath('dep-1/bundle.zip')).toBe('dep-1');
         expect(deploymentIdFromArtifactPath('dep-2.zip')).toBe('dep-2');
+        expect(deploymentIdFromArtifactPath('dep-2.tar.gz')).toBe('dep-2');
+        expect(deploymentIdFromArtifactPath('dep-2.json.zlib')).toBe('dep-2');
         expect(deploymentIdFromArtifactPath('dep-3')).toBe('dep-3');
     });
 

--- a/apps/backend/src/services/cleanup.service.ts
+++ b/apps/backend/src/services/cleanup.service.ts
@@ -87,11 +87,11 @@ const ORPHAN_BATCH_LIMIT = 100;
 /**
  * Derive the deployment id an artifact belongs to from its object path.
  * Supports both `<deploymentId>/bundle.zip` (folder) and `<deploymentId>.zip`
- * (flat) layouts: take the first path segment, then strip any file extension.
+ * (flat) layouts: take the first path segment, then strip the extension suffix.
  */
 export function deploymentIdFromArtifactPath(path: string): string {
     const firstSegment = path.split('/')[0] ?? path;
-    return firstSegment.replace(/\.[^.]+$/, '');
+    return firstSegment.split('.')[0] ?? firstSegment;
 }
 
 // ── Service ───────────────────────────────────────────────────────────────────

--- a/apps/backend/src/services/deployment-log-batcher.service.test.ts
+++ b/apps/backend/src/services/deployment-log-batcher.service.test.ts
@@ -61,7 +61,7 @@ describe('DeploymentLogBatcher', () => {
         expect(insert).toHaveBeenCalledOnce();
     });
 
-    it('applies backpressure when pending flushes exceed limit', async () => {
+    it('waits for in-flight flushes when pending flushes reach the limit', async () => {
         const { supabase, from } = makeSupabase();
         let resolveInsert!: () => void;
         const blocked = new Promise<void>((res) => { resolveInsert = res; });
@@ -74,9 +74,15 @@ describe('DeploymentLogBatcher', () => {
         for (let i = 0; i < 11; i++) {
             appends.push(batcher.append({ deploymentId: 'd1', level: 'info', message: `m${i}` }));
         }
-        // The 11th append should wait; resolve the blocked inserts
+
+        let eleventhSettled = false;
+        appends[10].then(() => { eleventhSettled = true; });
+        await Promise.resolve();
+        expect(eleventhSettled).toBe(false);
+
         resolveInsert();
         await Promise.all(appends);
+        expect(eleventhSettled).toBe(true);
     });
 
     it('does not double-flush on explicit flush() when timer already fired', async () => {

--- a/apps/backend/src/services/deployment-log-batcher.service.ts
+++ b/apps/backend/src/services/deployment-log-batcher.service.ts
@@ -10,8 +10,8 @@
  *
  * Guarantees:
  *   - Entries within a batch are ordered by timestamp before insert.
- *   - When the pending queue exceeds 10 batches, `append` awaits the flush
- *     to apply backpressure.
+ *   - When 10 batches are in flight, `append` waits for one to finish before
+ *     accepting another entry.
  */
 
 import type { SupabaseClient } from '@supabase/supabase-js';
@@ -39,6 +39,7 @@ export class DeploymentLogBatcher {
     private queue: QueuedEntry[] = [];
     private timer: ReturnType<typeof setTimeout> | null = null;
     private pendingFlushes = 0;
+    private readonly inFlightFlushes = new Set<Promise<void>>();
 
     constructor(
         private readonly supabase: SupabaseClient,
@@ -48,12 +49,12 @@ export class DeploymentLogBatcher {
 
     /**
      * Enqueue a log entry for batched writing.
-     * Blocks (awaits current flush) when backpressure limit is reached.
+        * Blocks until in-flight flush pressure drops below the limit.
      */
     async append(entry: LogEntry): Promise<void> {
         // Backpressure: too many in-flight batches
-        if (this.pendingFlushes >= MAX_PENDING_BATCHES) {
-            await this._flush();
+        while (this.pendingFlushes >= MAX_PENDING_BATCHES) {
+            await Promise.race(this.inFlightFlushes);
         }
 
         this.queue.push({ ...entry, timestamp: entry.timestamp ?? new Date().toISOString() });
@@ -91,13 +92,21 @@ export class DeploymentLogBatcher {
         }));
 
         this.pendingFlushes++;
-        try {
-            const { error } = await this.supabase.from('deployment_logs').insert(rows);
-            if (error) {
-                console.error('[log-batcher] Failed to flush batch', { count: rows.length, error: error.message });
+        const flushPromise = (async () => {
+            try {
+                const { error } = await this.supabase.from('deployment_logs').insert(rows);
+                if (error) {
+                    console.error('[log-batcher] Failed to flush batch', { count: rows.length, error: error.message });
+                }
+            } finally {
+                this.pendingFlushes--;
             }
+        })();
+        this.inFlightFlushes.add(flushPromise);
+        try {
+            await flushPromise;
         } finally {
-            this.pendingFlushes--;
+            this.inFlightFlushes.delete(flushPromise);
         }
     }
 

--- a/apps/backend/src/services/vercel-domain-lifecycle.adversarial.test.ts
+++ b/apps/backend/src/services/vercel-domain-lifecycle.adversarial.test.ts
@@ -139,7 +139,7 @@ describe('VercelDomainLifecycleService — adversarial parallel tests', () => {
 
             // Remove is unaffected
             expect(removeResult.success).toBe(true);
-            expect(removeResult.aliasesRemoved).toBe(0);
+            expect(removeResult.aliasesMatched).toBe(0);
         });
     });
 
@@ -358,7 +358,7 @@ describe('VercelDomainLifecycleService — adversarial parallel tests', () => {
             );
 
             expect(removeResult.success).toBe(true);
-            expect(removeResult.aliasesRemoved).toBe(1);
+            expect(removeResult.aliasesMatched).toBe(1);
             expect(mockClient.removeDomain).toHaveBeenCalledTimes(1);
         });
     });

--- a/apps/backend/src/services/vercel-domain-lifecycle.service.test.ts
+++ b/apps/backend/src/services/vercel-domain-lifecycle.service.test.ts
@@ -291,7 +291,7 @@ describe('VercelDomainLifecycleService', () => {
 
             expect(result.success).toBe(true);
             expect(result.domain).toBe('example.com');
-            expect(result.aliasesRemoved).toBe(0);
+            expect(result.aliasesMatched).toBe(0);
             expect(result.partialFailure).toBeUndefined();
             expect(mockClient.removeDomain).toHaveBeenCalledWith('example.com', 'prj_123');
         });
@@ -315,7 +315,7 @@ describe('VercelDomainLifecycleService', () => {
 
             expect(result.success).toBe(true);
             expect(result.domain).toBe('example.com');
-            expect(result.aliasesRemoved).toBe(3);
+            expect(result.aliasesMatched).toBe(3);
             expect(result.partialFailure).toBeUndefined();
             expect(mockClient.listDeploymentAliases).toHaveBeenCalledTimes(2);
         });
@@ -331,7 +331,7 @@ describe('VercelDomainLifecycleService', () => {
 
             expect(result.success).toBe(false);
             expect(result.domain).toBe('example.com');
-            expect(result.aliasesRemoved).toBe(0);
+            expect(result.aliasesMatched).toBe(0);
             expect(result.partialFailureReason).toBe('Vercel API error');
             expect(mockClient.listDeploymentAliases).not.toHaveBeenCalled();
         });
@@ -350,7 +350,7 @@ describe('VercelDomainLifecycleService', () => {
 
             expect(result.success).toBe(true);
             expect(result.domain).toBe('example.com');
-            expect(result.aliasesRemoved).toBe(1);
+            expect(result.aliasesMatched).toBe(1);
             expect(result.partialFailure).toBe(true);
             expect(result.partialFailureReason).toContain('Alias cleanup encountered errors');
             expect(result.partialFailureReason).toContain('deployment dpl_2');
@@ -366,7 +366,7 @@ describe('VercelDomainLifecycleService', () => {
 
             expect(result.success).toBe(true);
             expect(result.domain).toBe('example.com');
-            expect(result.aliasesRemoved).toBe(0);
+            expect(result.aliasesMatched).toBe(0);
             expect(mockClient.listDeploymentAliases).not.toHaveBeenCalled();
         });
 
@@ -385,7 +385,7 @@ describe('VercelDomainLifecycleService', () => {
             );
 
             expect(result.success).toBe(true);
-            expect(result.aliasesRemoved).toBe(2); // Only example.com and app.example.com
+            expect(result.aliasesMatched).toBe(2); // Only example.com and app.example.com
         });
 
         it('handles multiple deployment alias cleanup errors gracefully', async () => {
@@ -402,7 +402,7 @@ describe('VercelDomainLifecycleService', () => {
             );
 
             expect(result.success).toBe(true);
-            expect(result.aliasesRemoved).toBe(1);
+            expect(result.aliasesMatched).toBe(1);
             expect(result.partialFailure).toBe(true);
             expect(result.partialFailureReason).toContain('deployment dpl_1: Error 1');
             expect(result.partialFailureReason).toContain('deployment dpl_2: Error 2');

--- a/apps/backend/src/services/vercel-domain-lifecycle.service.ts
+++ b/apps/backend/src/services/vercel-domain-lifecycle.service.ts
@@ -101,8 +101,8 @@ export interface RemoveDomainResult {
     success: boolean;
     /** The domain that was acted on. */
     domain: string;
-    /** Number of deployment aliases that were removed during cleanup. */
-    aliasesRemoved: number;
+    /** Number of deployment aliases matching the removed domain. */
+    aliasesMatched: number;
     /**
      * True when the domain was removed but alias cleanup encountered an error.
      * The caller should log and optionally schedule a retry of the cleanup step.
@@ -330,24 +330,24 @@ export class VercelDomainLifecycleService {
             return {
                 success: false,
                 domain,
-                aliasesRemoved: 0,
+                aliasesMatched: 0,
                 partialFailureReason: err instanceof Error ? err.message : 'Failed to remove domain from Vercel',
             };
         }
 
         // Step b: Clean up deployment aliases pointing at this domain.
         if (deploymentIds.length === 0) {
-            return { success: true, domain, aliasesRemoved: 0 };
+            return { success: true, domain, aliasesMatched: 0 };
         }
 
-        let aliasesRemoved = 0;
+        let aliasesMatched = 0;
         const cleanupErrors: string[] = [];
 
         for (const deploymentId of deploymentIds) {
             try {
                 const aliases = await this._vercel.listDeploymentAliases(deploymentId);
                 const matching = aliases.filter((a) => a.alias === domain || a.alias.endsWith(`.${domain}`));
-                aliasesRemoved += matching.length;
+                aliasesMatched += matching.length;
                 // Note: Vercel alias deletion is handled at the project-domain level
                 // (removing the project domain effectively deactivates the alias).
                 // We count matches here for observability.
@@ -361,13 +361,13 @@ export class VercelDomainLifecycleService {
             return {
                 success: true,
                 domain,
-                aliasesRemoved,
+                aliasesMatched,
                 partialFailure: true,
                 partialFailureReason: `Alias cleanup encountered errors: ${cleanupErrors.join('; ')}`,
             };
         }
 
-        return { success: true, domain, aliasesRemoved };
+        return { success: true, domain, aliasesMatched };
     }
 
     // ── Convenience: get DNS records for a domain without touching Vercel ─────


### PR DESCRIPTION
## Summary

- Make `DeploymentLogBatcher` wait for tracked in-flight flushes when the pending ceiling is reached.
- Rename the domain cleanup count to `aliasesMatched` to reflect that aliases are enumerated, not deleted.
- Bound GitHub scope-validation cache growth with oldest-first eviction.
- Parse deployment IDs correctly from flat artifact names with multi-part extensions.

## Validation

- `npm run test --workspace=@craft/backend -- deployment-log-batcher.service.test.ts scope-validator.test.ts cleanup.orphaned-artifacts.test.ts vercel-domain-lifecycle.service.test.ts vercel-domain-lifecycle.adversarial.test.ts` (78 tests passed)
- Backend lint/typecheck remain blocked by pre-existing syntax errors in unrelated files.

Closes #1053
Closes #1054
Closes #1055
Closes #1056