### PR TITLE
fix: resolve issues #1057 #1058 #1060 #1062

### DIFF
--- a/apps/backend/src/services/audit-log-compaction.service.test.ts
+++ b/apps/backend/src/services/audit-log-compaction.service.test.ts
@@ -123,4 +123,78 @@ describe('AuditLogCompactionService', () => {
             expect.objectContaining({ email: null, ip_address: null, pii_redacted: true }),
         );
     });
+
+    it('warns and skips re-archiving rows that failed redaction recently', async () => {
+        const rows = [makeRow('r1', 100), makeRow('r2', 99)];
+        const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+        const failedPayload = JSON.stringify({ ids: ['r1', 'r2'], timestamp: Date.now() - 60_000 });
+        const failedDownload = vi.fn().mockResolvedValue({
+            data: { text: async () => failedPayload },
+            error: null,
+        });
+
+        const upload = vi.fn().mockResolvedValue({ error: null });
+        const list = vi.fn().mockResolvedValue({ data: [{ name: 'batch.ndjson' }], error: null });
+        const storage = { from: vi.fn().mockReturnValue({ upload, list, download: failedDownload }) };
+
+        const update = vi.fn().mockReturnValue({ error: null });
+        const inFn = vi.fn().mockReturnValue({ error: null });
+        const eqFn = vi.fn().mockReturnThis();
+        const ltFn = vi.fn().mockReturnThis();
+        const limitFn = vi.fn().mockResolvedValue({ data: rows, error: null });
+        const select = vi.fn().mockReturnValue({ lt: ltFn, eq: eqFn, limit: limitFn });
+        ltFn.mockReturnValue({ eq: eqFn });
+        eqFn.mockReturnValue({ limit: limitFn });
+        const from = vi.fn().mockReturnValue({ select, update: vi.fn().mockReturnValue({ in: inFn }) });
+
+        const supabase = { from, storage } as any;
+        const svc = new AuditLogCompactionService(supabase, { now: fixedNow });
+        const result = await svc.compact();
+
+        expect(result.errors).toBe(2);
+        expect(result.archived).toBe(0);
+        expect(result.redacted).toBe(0);
+        expect(consoleWarn).toHaveBeenCalled();
+        expect(upload).not.toHaveBeenCalled();
+
+        consoleWarn.mockRestore();
+        consoleError.mockRestore();
+    });
+
+    it('re-archives rows after the failed-redaction window expires', async () => {
+        const rows = [makeRow('r1', 100)];
+        const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+        const failedPayload = JSON.stringify({ ids: ['r1'], timestamp: Date.now() - 25 * 60 * 60 * 1000 });
+        const failedDownload = vi.fn().mockResolvedValue({
+            data: { text: async () => failedPayload },
+            error: null,
+        });
+
+        const upload = vi.fn().mockResolvedValue({ error: null });
+        const list = vi.fn().mockResolvedValue({ data: [{ name: 'batch.ndjson' }], error: null });
+        const storage = { from: vi.fn().mockReturnValue({ upload, list, download: failedDownload }) };
+
+        const update = vi.fn().mockReturnValue({ error: null });
+        const inFn = vi.fn().mockReturnValue({ error: null });
+        const eqFn = vi.fn().mockReturnThis();
+        const ltFn = vi.fn().mockReturnThis();
+        const limitFn = vi.fn().mockResolvedValue({ data: rows, error: null });
+        const select = vi.fn().mockReturnValue({ lt: ltFn, eq: eqFn, limit: limitFn });
+        ltFn.mockReturnValue({ eq: eqFn });
+        eqFn.mockReturnValue({ limit: limitFn });
+        const from = vi.fn().mockReturnValue({ select, update: vi.fn().mockReturnValue({ in: inFn }) });
+
+        const supabase = { from, storage } as any;
+        const svc = new AuditLogCompactionService(supabase, { now: fixedNow });
+        const result = await svc.compact();
+
+        expect(result.archived).toBe(1);
+        expect(result.redacted).toBe(1);
+        expect(upload).toHaveBeenCalledOnce();
+
+        consoleWarn.mockRestore();
+    });
 });

--- a/apps/backend/src/services/audit-log-compaction.service.ts
+++ b/apps/backend/src/services/audit-log-compaction.service.ts
@@ -37,6 +37,7 @@ export interface CompactionResult {
 }
 
 const PII_FIELDS = ['email', 'ip_address'] as const;
+const FAILED_REDACTIONS_PATH = 'compaction-state/failed-redactions.json';
 
 export class AuditLogCompactionService {
     private readonly retentionDays: number;
@@ -85,6 +86,20 @@ export class AuditLogCompactionService {
 
         if (!rows || rows.length === 0) return result;
 
+        const ids = rows.map((r: Record<string, unknown>) => r['id'] as string);
+
+        const failedBatch = await this._getFailedRedactions();
+        if (failedBatch && this._isSameBatch(ids, failedBatch.ids)) {
+            const ageMs = Date.now() - failedBatch.timestamp;
+            if (ageMs < 24 * 60 * 60 * 1000) {
+                console.warn(
+                    `[audit-compaction] Skipping re-archive of ${ids.length} rows that failed redaction ${Math.round(ageMs / 1000)}s ago`
+                );
+                result.errors += rows.length;
+                return result;
+            }
+        }
+
         // Step 1 – Archive to cold storage
         const archiveError = await this._archive(rows, cutoffIso);
         if (archiveError) {
@@ -94,7 +109,6 @@ export class AuditLogCompactionService {
         result.archived += rows.length;
 
         // Step 2 – Redact PII in-database
-        const ids = rows.map((r: Record<string, unknown>) => r['id'] as string);
         const redactUpdate: Record<string, unknown> = { pii_redacted: true };
         for (const field of PII_FIELDS) {
             redactUpdate[field] = null;
@@ -108,8 +122,10 @@ export class AuditLogCompactionService {
         if (updateError) {
             console.error('[audit-compaction] Failed to redact PII', updateError.message);
             result.errors += rows.length;
+            await this._setFailedRedactions(ids);
         } else {
             result.redacted += rows.length;
+            await this._clearFailedRedactions(ids);
         }
 
         return result;
@@ -149,6 +165,68 @@ export class AuditLogCompactionService {
     }
 
     // ── Private ───────────────────────────────────────────────────────────────
+
+    private async _getFailedRedactions(): Promise<{ ids: string[]; timestamp: number } | null> {
+        try {
+            const { data, error } = await this.supabase
+                .storage
+                .from(this.archiveBucket)
+                .download(FAILED_REDACTIONS_PATH);
+
+            if (error || !data) return null;
+
+            const text = await data.text();
+            if (!text.trim()) return null;
+
+            const parsed = JSON.parse(text);
+            if (!Array.isArray(parsed.ids)) return null;
+
+            return {
+                ids: parsed.ids as string[],
+                timestamp: typeof parsed.timestamp === 'number' ? parsed.timestamp : Date.now(),
+            };
+        } catch {
+            return null;
+        }
+    }
+
+    private async _setFailedRedactions(ids: string[]): Promise<void> {
+        try {
+            const payload = JSON.stringify({ ids, timestamp: Date.now() });
+            await this.supabase.storage
+                .from(this.archiveBucket)
+                .upload(FAILED_REDACTIONS_PATH, payload, { contentType: 'application/json', upsert: true });
+        } catch (err) {
+            console.error('[audit-compaction] Failed to persist failed-redaction state', err);
+        }
+    }
+
+    private async _clearFailedRedactions(ids: string[]): Promise<void> {
+        try {
+            const existing = await this._getFailedRedactions();
+            if (!existing) return;
+
+            const remaining = existing.ids.filter((id) => !ids.includes(id));
+            if (remaining.length === 0) {
+                await this.supabase.storage
+                    .from(this.archiveBucket)
+                    .remove([FAILED_REDACTIONS_PATH]);
+            } else {
+                const payload = JSON.stringify({ ids: remaining, timestamp: Date.now() });
+                await this.supabase.storage
+                    .from(this.archiveBucket)
+                    .upload(FAILED_REDACTIONS_PATH, payload, { contentType: 'application/json', upsert: true });
+            }
+        } catch (err) {
+            console.error('[audit-compaction] Failed to clear failed-redaction state', err);
+        }
+    }
+
+    private _isSameBatch(ids: string[], other: string[]): boolean {
+        if (ids.length !== other.length) return false;
+        const set = new Set(ids);
+        return other.every((id) => set.has(id));
+    }
 
     private async _archive(rows: Record<string, unknown>[], cutoffIso: string): Promise<Error | null> {
         const dateKey = cutoffIso.slice(0, 10); // YYYY-MM-DD

--- a/apps/backend/src/services/env-sync.service.test.ts
+++ b/apps/backend/src/services/env-sync.service.test.ts
@@ -1,0 +1,260 @@
+/**
+ * EnvSyncService retry-idempotency tests (#1057)
+ *
+ * Verifies that sync() converges to the same final state regardless of which
+ * operations already partially succeeded before a retry.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EnvSyncService, type EnvVar } from './env-sync.service';
+
+type EnvTarget = 'production' | 'preview' | 'development';
+type EnvType = 'plain' | 'secret' | 'encrypted';
+
+interface VercelEnvRecord {
+    id: string;
+    key: string;
+    value: string;
+    target: EnvTarget[];
+    type: EnvType;
+}
+
+let idCounter = 0;
+
+function makeRecord(variable: EnvVar): VercelEnvRecord {
+    return {
+        id: `env_${++idCounter}`,
+        key: variable.key,
+        value: variable.value,
+        target: [...variable.target] as EnvTarget[],
+        type: variable.type as EnvType,
+    };
+}
+
+type MockApi = {
+    listEnvVars: ReturnType<typeof vi.fn>;
+    createEnvVar: ReturnType<typeof vi.fn>;
+    updateEnvVar: ReturnType<typeof vi.fn>;
+    deleteEnvVar: ReturnType<typeof vi.fn>;
+    store: VercelEnvRecord[];
+};
+
+function makeMockApi(store: VercelEnvRecord[]): MockApi {
+    return {
+        store,
+        listEnvVars: vi.fn(async () => [...store]),
+        createEnvVar: vi.fn(async (_pid: string, variable: EnvVar) => {
+            const existing = store.findIndex(
+                (r) => r.key === variable.key && r.target.sort().join() === [...variable.target].sort().join(),
+            );
+            if (existing >= 0) {
+                store[existing] = { ...store[existing], value: variable.value, type: variable.type as EnvType };
+                return store[existing];
+            }
+            const record = makeRecord(variable);
+            store.push(record);
+            return record;
+        }),
+        updateEnvVar: vi.fn(
+            async (_pid: string, envId: string, patch: { value?: string; type?: string }) => {
+                const idx = store.findIndex((r) => r.id === envId);
+                if (idx === -1) throw new Error('Not found');
+                store[idx] = { ...store[idx], ...patch };
+                return store[idx];
+            },
+        ),
+        deleteEnvVar: vi.fn(async (_pid: string, envId: string) => {
+            const idx = store.findIndex((r) => r.id === envId);
+            if (idx !== -1) store.splice(idx, 1);
+        }),
+    };
+}
+
+const PROJECT_ID = 'prj_retry_idempotency_test';
+
+describe('EnvSyncService — retry idempotency (#1057)', () => {
+    beforeEach(() => {
+        idCounter = 0;
+        vi.clearAllMocks();
+    });
+
+    it('retries after a partial create failure and converges without duplicates', async () => {
+        const store: VercelEnvRecord[] = [];
+        let createCallCount = 0;
+
+        const api: MockApi = {
+            store,
+            listEnvVars: vi.fn(async () => [...store]),
+            createEnvVar: vi.fn(async (_pid: string, variable: EnvVar) => {
+                createCallCount++;
+                if (createCallCount === 2) {
+                    const err = new Error('transient failure');
+                    (err as any).status = 500;
+                    throw err;
+                }
+                const existing = store.findIndex(
+                    (r) => r.key === variable.key && r.target.sort().join() === [...variable.target].sort().join(),
+                );
+                if (existing >= 0) {
+                    store[existing] = { ...store[existing], value: variable.value, type: variable.type as EnvType };
+                    return store[existing];
+                }
+                const record = makeRecord(variable);
+                store.push(record);
+                return record;
+            }),
+            updateEnvVar: vi.fn(async (_pid: string, envId: string, patch: { value?: string; type?: string }) => {
+                const idx = store.findIndex((r) => r.id === envId);
+                if (idx === -1) throw new Error('Not found');
+                store[idx] = { ...store[idx], ...patch };
+                return store[idx];
+            }),
+            deleteEnvVar: vi.fn(async (_pid: string, envId: string) => {
+                const idx = store.findIndex((r) => r.id === envId);
+                if (idx !== -1) store.splice(idx, 1);
+            }),
+        };
+
+        const service = new EnvSyncService(api, {
+            maxAttempts: 3,
+            baseDelayMs: 0,
+            maxDelayMs: 0,
+            sleep: () => Promise.resolve(),
+        });
+
+        const vars: EnvVar[] = [
+            { key: 'KEY_A', value: 'value-a', target: ['production'], type: 'plain' },
+            { key: 'KEY_B', value: 'value-b', target: ['production'], type: 'plain' },
+        ];
+
+        const result = await service.sync(PROJECT_ID, vars);
+
+        expect(result.created).toBe(1);
+        expect(result.updated).toBe(0);
+        expect(result.deleted).toBe(0);
+        expect(store.filter((r) => r.key === 'KEY_A')).toHaveLength(1);
+        expect(store.filter((r) => r.key === 'KEY_B')).toHaveLength(1);
+    });
+
+    it('retries after a partial delete failure and converges correctly', async () => {
+        const store: VercelEnvRecord[] = [
+            makeRecord({ key: 'KEY_A', value: 'value-a', target: ['production'], type: 'plain' }),
+            makeRecord({ key: 'KEY_B', value: 'value-b', target: ['production'], type: 'plain' }),
+        ];
+        let deleteCallCount = 0;
+
+        const api: MockApi = {
+            store,
+            listEnvVars: vi.fn(async () => [...store]),
+            createEnvVar: vi.fn(async () => makeRecord({ key: 'NEW', value: 'new', target: ['production'], type: 'plain' })),
+            updateEnvVar: vi.fn(async () => ({}) as any),
+            deleteEnvVar: vi.fn(async (_pid: string, envId: string) => {
+                deleteCallCount++;
+                if (deleteCallCount === 1) {
+                    const err = new Error('transient failure');
+                    (err as any).status = 500;
+                    throw err;
+                }
+                const idx = store.findIndex((r) => r.id === envId);
+                if (idx !== -1) store.splice(idx, 1);
+            }),
+        };
+
+        const service = new EnvSyncService(api, {
+            maxAttempts: 3,
+            baseDelayMs: 0,
+            maxDelayMs: 0,
+            sleep: () => Promise.resolve(),
+        });
+
+        const result = await service.sync(PROJECT_ID, []);
+
+        expect(result.deleted).toBe(2);
+        expect(store).toHaveLength(0);
+    });
+
+    it('treats create already-exists error as a no-op success on retry', async () => {
+        const store: VercelEnvRecord[] = [];
+        let createCallCount = 0;
+
+        const api: MockApi = {
+            store,
+            listEnvVars: vi.fn(async () => [...store]),
+            createEnvVar: vi.fn(async (_pid: string, variable: EnvVar) => {
+                createCallCount++;
+                if (createCallCount === 1) {
+                    const record = makeRecord(variable);
+                    store.push(record);
+                    const err = new Error('already exists');
+                    (err as any).status = 409;
+                    throw err;
+                }
+                const existing = store.findIndex(
+                    (r) => r.key === variable.key && r.target.sort().join() === [...variable.target].sort().join(),
+                );
+                if (existing >= 0) {
+                    return store[existing];
+                }
+                const record = makeRecord(variable);
+                store.push(record);
+                return record;
+            }),
+            updateEnvVar: vi.fn(async () => ({}) as any),
+            deleteEnvVar: vi.fn(async () => {}),
+        };
+
+        const service = new EnvSyncService(api, {
+            maxAttempts: 3,
+            baseDelayMs: 0,
+            maxDelayMs: 0,
+            sleep: () => Promise.resolve(),
+        });
+
+        const vars: EnvVar[] = [
+            { key: 'KEY_A', value: 'value-a', target: ['production'], type: 'plain' },
+        ];
+
+        const result = await service.sync(PROJECT_ID, vars);
+
+        expect(result.created).toBe(1);
+        expect(store.filter((r) => r.key === 'KEY_A')).toHaveLength(1);
+    });
+
+    it('treats delete not-found error as already-deleted on retry', async () => {
+        const store: VercelEnvRecord[] = [
+            makeRecord({ key: 'KEY_A', value: 'value-a', target: ['production'], type: 'plain' }),
+        ];
+        let deleteCallCount = 0;
+
+        const api: MockApi = {
+            store,
+            listEnvVars: vi.fn(async () => [...store]),
+            createEnvVar: vi.fn(async () => ({}) as any),
+            updateEnvVar: vi.fn(async () => ({}) as any),
+            deleteEnvVar: vi.fn(async (_pid: string, envId: string) => {
+                deleteCallCount++;
+                if (deleteCallCount === 1) {
+                    const idx = store.findIndex((r) => r.id === envId);
+                    if (idx !== -1) store.splice(idx, 1);
+                    const err = new Error('not found');
+                    (err as any).status = 404;
+                    throw err;
+                }
+                const idx = store.findIndex((r) => r.id === envId);
+                if (idx !== -1) store.splice(idx, 1);
+            }),
+        };
+
+        const service = new EnvSyncService(api, {
+            maxAttempts: 3,
+            baseDelayMs: 0,
+            maxDelayMs: 0,
+            sleep: () => Promise.resolve(),
+        });
+
+        const result = await service.sync(PROJECT_ID, []);
+
+        expect(result.deleted).toBe(1);
+        expect(store).toHaveLength(0);
+    });
+});

--- a/apps/backend/src/services/env-sync.service.ts
+++ b/apps/backend/src/services/env-sync.service.ts
@@ -64,6 +64,30 @@ export interface EnvSyncResult {
     deleted: number;
 }
 
+function isAlreadyExistsError(err: unknown): boolean {
+    if (err && typeof err === 'object') {
+        const obj = err as Record<string, unknown>;
+        if (obj.status === 409) return true;
+        if (typeof obj.message === 'string') {
+            const msg = obj.message.toLowerCase();
+            if (msg.includes('already exists') || msg.includes('duplicate')) return true;
+        }
+    }
+    return false;
+}
+
+function isNotFoundError(err: unknown): boolean {
+    if (err && typeof err === 'object') {
+        const obj = err as Record<string, unknown>;
+        if (obj.status === 404) return true;
+        if (typeof obj.message === 'string') {
+            const msg = obj.message.toLowerCase();
+            if (msg.includes('not found')) return true;
+        }
+    }
+    return false;
+}
+
 /**
  * Converts VercelEnvVar[] to a normalized format with target metadata.
  */
@@ -113,16 +137,30 @@ export class EnvSyncService {
                         }
                         existingMap.delete(mapKey);
                     } else {
-                        await this.api.createEnvVar(projectId, variable);
-                        created++;
+                        try {
+                            await this.api.createEnvVar(projectId, variable);
+                            created++;
+                        } catch (err) {
+                            if (isAlreadyExistsError(err)) {
+                                created++;
+                            } else {
+                                throw err;
+                            }
+                        }
                     }
                 }
 
-                // Remaining entries in existingMap are stale — delete them
                 let deleted = 0;
                 for (const stale of existingMap.values()) {
-                    await this.api.deleteEnvVar(projectId, stale.id);
-                    deleted++;
+                    try {
+                        await this.api.deleteEnvVar(projectId, stale.id);
+                        deleted++;
+                    } catch (err) {
+                        if (!isNotFoundError(err)) {
+                            throw err;
+                        }
+                        deleted++;
+                    }
                 }
 
                 return { created, updated, deleted };

--- a/apps/backend/src/services/health-monitor.fault-injection.test.ts
+++ b/apps/backend/src/services/health-monitor.fault-injection.test.ts
@@ -25,7 +25,9 @@ vi.mock('@/lib/supabase/server', () => ({
 
 // ── Analytics mock ────────────────────────────────────────────────────────────
 
-const mockRecordUptimeCheck = vi.fn().mockResolvedValue(undefined);
+const { mockRecordUptimeCheck } = vi.hoisted(() => ({
+    mockRecordUptimeCheck: vi.fn().mockResolvedValue(undefined),
+}));
 
 vi.mock('./analytics.service', () => ({
     analyticsService: { recordUptimeCheck: mockRecordUptimeCheck },

--- a/apps/backend/src/services/health-monitor.service.test.ts
+++ b/apps/backend/src/services/health-monitor.service.test.ts
@@ -17,7 +17,9 @@ vi.mock('@/lib/supabase/server', () => ({
 
 // ── Analytics mock ────────────────────────────────────────────────────────────
 
-const mockRecordUptimeCheck = vi.fn().mockResolvedValue(undefined);
+const { mockRecordUptimeCheck } = vi.hoisted(() => ({
+    mockRecordUptimeCheck: vi.fn().mockResolvedValue(undefined),
+}));
 
 vi.mock('./analytics.service', () => ({
     analyticsService: { recordUptimeCheck: mockRecordUptimeCheck },
@@ -131,5 +133,117 @@ describe('HealthMonitorService — checkDeploymentHealth', () => {
         await service.checkDeploymentHealth('deploy-1');
 
         expect(mockRecordUptimeCheck).toHaveBeenCalledWith('deploy-1', false);
+    });
+});
+
+describe('HealthMonitorService — checkAllDeployments concurrency', () => {
+    let service: HealthMonitorService;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        service = new HealthMonitorService();
+    });
+
+    it('caps concurrent health checks to the configured limit', async () => {
+        const concurrency = 3;
+        const deploymentCount = 10;
+        const deployments = Array.from({ length: deploymentCount }, (_, i) => ({
+            id: `dep-${i}`,
+            deployment_url: `https://app-${i}.vercel.app`,
+        }));
+
+        let peakConcurrent = 0;
+        let currentConcurrent = 0;
+
+        const innerEq = vi.fn().mockResolvedValue({
+            data: deployments.map(d => ({ id: d.id })),
+            error: null,
+        });
+        const listChain = {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnValue({ eq: innerEq }),
+        };
+
+        let urlCallCount = 0;
+        mockFrom.mockImplementation(() => {
+            if (urlCallCount === 0) {
+                urlCallCount++;
+                return listChain;
+            }
+            const dep = deployments[urlCallCount - 1];
+            urlCallCount++;
+            const chain = {
+                select: vi.fn().mockReturnThis(),
+                eq: vi.fn().mockReturnThis(),
+                single: vi.fn().mockResolvedValue({
+                    data: { deployment_url: dep?.deployment_url },
+                    error: null,
+                }),
+            };
+            return chain;
+        });
+
+        mockFetch.mockImplementation(async () => {
+            currentConcurrent++;
+            peakConcurrent = Math.max(peakConcurrent, currentConcurrent);
+            await new Promise((r) => setTimeout(r, 10));
+            currentConcurrent--;
+            return { ok: true, status: 200 };
+        });
+
+        process.env.HEALTH_CHECK_CONCURRENCY = String(concurrency);
+        const results = await service.checkAllDeployments();
+        delete process.env.HEALTH_CHECK_CONCURRENCY;
+
+        expect(results).toHaveLength(deploymentCount);
+        expect(peakConcurrent).toBeLessThanOrEqual(concurrency);
+    });
+
+    it('returns results for all deployments even when some fail', async () => {
+        const deployments = [
+            { id: 'dep-1', deployment_url: 'https://app-1.vercel.app' },
+            { id: 'dep-2', deployment_url: 'https://app-2.vercel.app' },
+            { id: 'dep-3', deployment_url: 'https://app-3.vercel.app' },
+        ];
+
+        const innerEq = vi.fn().mockResolvedValue({
+            data: deployments.map(d => ({ id: d.id })),
+            error: null,
+        });
+        const listChain = {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnValue({ eq: innerEq }),
+        };
+
+        let urlCallCount = 0;
+        mockFrom.mockImplementation(() => {
+            if (urlCallCount === 0) {
+                urlCallCount++;
+                return listChain;
+            }
+            const dep = deployments[urlCallCount - 1];
+            urlCallCount++;
+            const chain = {
+                select: vi.fn().mockReturnThis(),
+                eq: vi.fn().mockReturnThis(),
+                single: vi.fn().mockResolvedValue({
+                    data: { deployment_url: dep?.deployment_url },
+                    error: null,
+                }),
+            };
+            return chain;
+        });
+
+        mockFetch
+            .mockResolvedValueOnce({ ok: true, status: 200 })
+            .mockRejectedValueOnce(new Error('network error'))
+            .mockResolvedValueOnce({ ok: true, status: 200 });
+
+        const results = await service.checkAllDeployments();
+
+        expect(results).toHaveLength(3);
+        expect(results[0].isHealthy).toBe(true);
+        expect(results[1].isHealthy).toBe(false);
+        expect(results[2].isHealthy).toBe(true);
     });
 });

--- a/apps/backend/src/services/health-monitor.service.ts
+++ b/apps/backend/src/services/health-monitor.service.ts
@@ -100,7 +100,8 @@ export class HealthMonitorService {
     > {
         const supabase = createClient();
 
-        // Get all active deployments
+        const startTime = Date.now();
+
         const { data: deployments } = await supabase
             .from('deployments')
             .select('id')
@@ -111,15 +112,22 @@ export class HealthMonitorService {
             return [];
         }
 
-        const results = await Promise.all(
-            deployments.map(async (deployment) => {
+        const results = await pMap(
+            deployments,
+            async (deployment) => {
                 const health = await this.checkDeploymentHealth(deployment.id);
                 return {
                     deploymentId: deployment.id,
                     isHealthy: health.isHealthy,
                     responseTime: health.responseTime,
                 };
-            })
+            },
+            parseInt(process.env.HEALTH_CHECK_CONCURRENCY || '20', 10),
+        );
+
+        const durationMs = Date.now() - startTime;
+        console.log(
+            `[health-monitor] Sweep completed: ${deployments.length} deployments checked in ${durationMs}ms`
         );
 
         return results;
@@ -228,6 +236,57 @@ export class HealthMonitorService {
             poolMetrics: metrics,
         };
     }
+}
+
+async function pMap<T, R>(
+    items: T[],
+    fn: (item: T) => Promise<R>,
+    concurrency: number,
+): Promise<R[]> {
+    const results: R[] = new Array(items.length);
+    let index = 0;
+    let activeCount = 0;
+    let resolve: (() => void) | null = null;
+
+    const errors: Error[] = [];
+
+    function done() {
+        activeCount--;
+        if (resolve && activeCount === 0) {
+            resolve();
+        }
+    }
+
+    function runNext() {
+        while (activeCount < concurrency && index < items.length) {
+            const currentIndex = index++;
+            activeCount++;
+            fn(items[currentIndex])
+                .then((result) => {
+                    results[currentIndex] = result;
+                    done();
+                    runNext();
+                })
+                .catch((err) => {
+                    errors.push(err);
+                    done();
+                    runNext();
+                });
+        }
+    }
+
+    return new Promise((res) => {
+        resolve = res;
+        runNext();
+        if (activeCount === 0 && index === items.length) {
+            res();
+        }
+    }).then(() => {
+        if (errors.length > 0) {
+            throw errors[0];
+        }
+        return results;
+    });
 }
 
 // Export singleton instance

--- a/apps/backend/src/services/webhook-delivery.service.test.ts
+++ b/apps/backend/src/services/webhook-delivery.service.test.ts
@@ -379,6 +379,68 @@ describe('WebhookDeliveryService', () => {
             expect(result.newDeliveryId).toMatch(/^replay-/);
         });
 
+        it('produces a replay-<timestamp>-<8charhex> style delivery ID', async () => {
+            const service = new WebhookDeliveryService();
+
+            const originalDelivery = {
+                id: 'uuid-1',
+                delivery_id: 'del-original',
+                event_type: 'push',
+                payload: {},
+                headers: {},
+                status: 'failed',
+            };
+
+            const replayedDelivery = {
+                id: 'uuid-2',
+                delivery_id: 'replay-placeholder',
+                event_type: 'push',
+                payload: {},
+                headers: {},
+                status: 'received',
+                replayed_from_delivery_id: 'del-original',
+            };
+
+            mockFrom.mockReturnValueOnce({
+                select: vi.fn().mockReturnValue({
+                    eq: vi.fn().mockReturnValue({
+                        single: vi.fn().mockResolvedValue({
+                            data: originalDelivery,
+                            error: null,
+                        }),
+                    }),
+                }),
+            });
+
+            const insertMock = vi.fn().mockReturnValue({
+                select: vi.fn().mockReturnValue({
+                    single: vi.fn().mockResolvedValue({
+                        data: replayedDelivery,
+                        error: null,
+                    }),
+                }),
+            });
+            mockFrom.mockReturnValueOnce({
+                insert: insertMock,
+            });
+
+            const before = Date.now();
+            const result = await service.replayDelivery('del-original');
+            const after = Date.now();
+
+            expect(result.success).toBe(true);
+            expect(result.newDeliveryId).toBeDefined();
+            const id = result.newDeliveryId!;
+            expect(id.startsWith('replay-')).toBe(true);
+            const parts = id.split('-');
+            expect(parts.length).toBe(3);
+            const timestamp = Number(parts[1]);
+            expect(timestamp).toBeGreaterThanOrEqual(before);
+            expect(timestamp).toBeLessThanOrEqual(after);
+            expect(parts[2].length).toBe(8);
+            expect(/^[0-9a-f]{8}$/.test(parts[2])).toBe(true);
+        });
+
         it('handles original delivery not found', async () => {
             const service = new WebhookDeliveryService();
 

--- a/apps/backend/src/services/webhook-delivery.service.ts
+++ b/apps/backend/src/services/webhook-delivery.service.ts
@@ -17,6 +17,7 @@
 
 import { createClient } from '@/lib/supabase/server';
 import { createLogger } from '@/lib/api/logger';
+import { randomUUID } from 'node:crypto';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -292,7 +293,7 @@ export class WebhookDeliveryService {
             }
 
             // Generate a new delivery ID for the replay
-            const newDeliveryId = `replay-${Date.now()}-${crypto.randomUUID().substring(0, 8)}`;
+            const newDeliveryId = `replay-${Date.now()}-${randomUUID().substring(0, 8)}`;
 
             // Create a new delivery record for the replay
             const { data: replayed, error: insertError } = await supabase

--- a/apps/frontend/src/services/health-monitor.service.test.ts
+++ b/apps/frontend/src/services/health-monitor.service.test.ts
@@ -17,7 +17,9 @@ vi.mock('@/lib/supabase/server', () => ({
 
 // ── Analytics mock ────────────────────────────────────────────────────────────
 
-const mockRecordUptimeCheck = vi.fn().mockResolvedValue(undefined);
+const { mockRecordUptimeCheck } = vi.hoisted(() => ({
+    mockRecordUptimeCheck: vi.fn().mockResolvedValue(undefined),
+}));
 
 vi.mock('./analytics.service', () => ({
     analyticsService: { recordUptimeCheck: mockRecordUptimeCheck },


### PR DESCRIPTION
## Summary
- #1057: Make EnvSyncService.sync resilient to retrying after partial failures
- #1058: Bound HealthMonitorService.checkAllDeployments concurrency
- #1060: Make repeated audit-log PII redaction failures observable
- #1062: Use explicit node:crypto import in WebhookDeliveryService.replayDelivery

## Changes
### #1057 - EnvSyncService retry safety
- Added explicit handling for create already-exists errors (treat as no-op)
- Added explicit handling for delete not-found errors (treat as already-deleted)
- Added env-sync.service.test.ts coverage for partial-failure-then-retry scenarios

### #1058 - Health check concurrency cap
- Replaced unbounded Promise.all with bounded concurrency pMap in checkAllDeployments
- Concurrency cap configurable via HEALTH_CHECK_CONCURRENCY env var (default 20)
- Added total sweep duration logging for observability
- Added test asserting peak concurrent checks never exceed the configured cap

### #1060 - Audit-log compaction observability
- Added failed-redaction state tracking using storage file
- Skip re-archiving rows that recently failed redaction (24h window)
- Log warning when same rows fail redaction across multiple compact() invocations
- Added audit-log-compaction.service.test.ts coverage for repeated-failure scenarios

### #1062 - Explicit crypto import
- Replaced implicit global crypto.randomUUID() with explicit import from node:crypto
- Added regression test asserting replay ID format is unchanged

## Test Plan
All new and updated tests pass:
```bash
npm run test --workspace=@craft/backend -- env-sync
npm run test --workspace=@craft/backend -- health-monitor
npm run test --workspace=@craft/backend -- audit-log-compaction
npm run test --workspace=@craft/backend -- webhook-delivery
```

Closes #1057
Closes #1058
Closes #1060
Closes #1062