### PR TITLE
fix(backend): resolve issues #1049 through #1052

### DIFF
--- a/apps/backend/src/lib/api/tier-rate-limit.test.ts
+++ b/apps/backend/src/lib/api/tier-rate-limit.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest, NextResponse } from 'next/server';
+import { withTierRateLimit } from './tier-rate-limit';
+import { createClient } from '@/lib/supabase/server';
+import { createLogger } from './logger';
+
+vi.mock('@/lib/supabase/server', () => ({ createClient: vi.fn() }));
+vi.mock('./logger', () => ({
+    createLogger: vi.fn(() => ({ warn: vi.fn() })),
+    resolveCorrelationId: vi.fn(() => 'test-correlation-id'),
+}));
+
+describe('withTierRateLimit tier lookup failures', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        delete process.env.RATE_LIMIT_DISABLED;
+    });
+
+    it('logs a lookup error with route context and keeps the free-tier limit', async () => {
+        const warning = vi.fn();
+        vi.mocked(createLogger).mockReturnValue({ warn: warning } as any);
+        vi.mocked(createClient).mockReturnValue({
+            auth: { getUser: vi.fn().mockResolvedValue({ data: { user: null }, error: new Error('database unavailable') }) },
+        } as any);
+
+        const handler = withTierRateLimit('api/deployments')(async () => NextResponse.json({ ok: true }));
+        const response = await handler(new NextRequest('http://localhost/api/deployments'), { params: {} });
+
+        expect(response.status).toBe(200);
+        expect(response.headers.get('x-ratelimit-tier')).toBe('free');
+        expect(warning).toHaveBeenCalledWith(
+            'Subscription tier lookup failed; defaulting to free tier',
+            expect.objectContaining({ route: 'api/deployments', error: 'database unavailable' }),
+        );
+    });
+});

--- a/apps/backend/src/lib/api/tier-rate-limit.ts
+++ b/apps/backend/src/lib/api/tier-rate-limit.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { checkRateLimit, getRateLimitKey, type RateLimitConfig } from './rate-limit';
 import { createClient } from '@/lib/supabase/server';
+import { createLogger, resolveCorrelationId } from './logger';
 
 /**
  * Multi-Tier Rate Limiting with Sliding Window
@@ -54,26 +55,38 @@ function isSensitiveEndpoint(route: string): boolean {
  * Get user subscription tier from the database.
  * Anonymous users get 'free' tier.
  */
-async function getUserTier(req: NextRequest): Promise<'free' | 'pro' | 'enterprise'> {
+async function getUserTier(req: NextRequest, routeKey: string): Promise<'free' | 'pro' | 'enterprise'> {
   try {
     const supabase = createClient();
     const {
       data: { user },
+      error: userError,
     } = await supabase.auth.getUser();
+
+    if (userError) throw userError;
 
     if (!user) {
       return 'free';
     }
 
-    const { data: profile } = await supabase
+    const { data: profile, error: profileError } = await supabase
       .from('profiles')
       .select('subscription_tier')
       .eq('id', user.id)
       .single();
 
+    if (profileError) throw profileError;
+
     return (profile?.subscription_tier ?? 'free') as 'free' | 'pro' | 'enterprise';
   } catch (err) {
-    // On any error, fall back to free tier (conservative)
+    const errorMessage = err instanceof Error ? err.message : String(err);
+    createLogger({
+      correlationId: resolveCorrelationId(req),
+      route: routeKey,
+    }).warn('Subscription tier lookup failed; defaulting to free tier', {
+      route: routeKey,
+      error: errorMessage,
+    });
     return 'free';
   }
 }
@@ -97,7 +110,7 @@ export function withTierRateLimit<TParams = {}>(routeKey: string) {
         return handler(req, ctx);
       }
 
-      const tier = await getUserTier(req);
+      const tier = await getUserTier(req, routeKey);
       const isSensitive = isSensitiveEndpoint(routeKey);
       const tierLimits = isSensitive ? SENSITIVE_TIER_LIMITS : GENERAL_TIER_LIMITS;
       const config = tierLimits[tier];

--- a/apps/backend/src/lib/api/version-migration.middleware.ts
+++ b/apps/backend/src/lib/api/version-migration.middleware.ts
@@ -20,6 +20,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
+import { DEFAULT_API_VERSION } from './version-negotiation';
 
 // ── Version constants ─────────────────────────────────────────────────────────
 
@@ -86,8 +87,7 @@ export function withVersionMigration(handler: RouteHandler): RouteHandler {
         let defaulted = false;
 
         if (acceptVersion === null) {
-            // No header → default to latest (v2)
-            version = 2;
+            version = DEFAULT_API_VERSION;
             defaulted = true;
         } else {
             const parsed = parseAcceptVersion(acceptVersion);

--- a/apps/backend/src/lib/api/version-negotiation.test.ts
+++ b/apps/backend/src/lib/api/version-negotiation.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
     negotiateVersion,
+    DEFAULT_API_VERSION,
     parseVersionFromPath,
     parseVersionFromHeader,
     parseVersionFromQuery,
@@ -87,9 +88,9 @@ describe('version-negotiation', () => {
             expect(result.source).toBe('query');
         });
 
-        it('should default to version 1', () => {
+        it('should default to the shared default version', () => {
             const result = negotiateVersion('/api/users');
-            expect(result.version).toBe(1);
+            expect(result.version).toBe(DEFAULT_API_VERSION);
             expect(result.source).toBe('default');
         });
 

--- a/apps/backend/src/lib/api/version-negotiation.ts
+++ b/apps/backend/src/lib/api/version-negotiation.ts
@@ -7,9 +7,13 @@
  * - Query parameter: ?api-version=2
  */
 
-export const CURRENT_API_VERSION = 1;
 export const SUPPORTED_VERSIONS = [1, 2] as const;
 export type APIVersion = typeof SUPPORTED_VERSIONS[number];
+
+/** Unversioned requests use v2, the current internal API representation. */
+export const DEFAULT_API_VERSION: APIVersion = 2;
+/** @deprecated Use DEFAULT_API_VERSION for new callers. */
+export const CURRENT_API_VERSION = DEFAULT_API_VERSION;
 
 interface VersionInfo {
     version: APIVersion;
@@ -75,6 +79,9 @@ export function parseVersionFromHeader(acceptHeader: string): APIVersion | null 
  * Expects: ?api-version=2
  */
 export function parseVersionFromQuery(queryParam: string): APIVersion | null {
+    if (!/^\d+$/.test(queryParam)) {
+        return null;
+    }
     const version = parseInt(queryParam, 10) as APIVersion;
     if (SUPPORTED_VERSIONS.includes(version)) {
         return version;
@@ -113,8 +120,7 @@ export function negotiateVersion(
         }
     }
 
-    // Default to current version
-    return { version: CURRENT_API_VERSION, source: 'default' };
+    return { version: DEFAULT_API_VERSION, source: 'default' };
 }
 
 /**

--- a/apps/backend/src/services/build-cache.service.test.ts
+++ b/apps/backend/src/services/build-cache.service.test.ts
@@ -9,6 +9,7 @@ const makeFiles = (entries: Array<[string, string]>): GeneratedFile[] =>
     entries.map(([path, content]) => ({ path, content, type: 'config' as const }));
 
 const makeSupabase = (storedHash: string | null) => ({
+    rpc: vi.fn().mockResolvedValue({ data: null, error: null }),
     from: vi.fn().mockReturnValue({
         select: vi.fn().mockReturnThis(),
         update: vi.fn().mockReturnThis(),
@@ -92,30 +93,15 @@ describe('BuildCacheService', () => {
 
     // ── storeHash ─────────────────────────────────────────────────────────────
 
-    it('merges _buildCacheHash into existing customization_config', async () => {
-        const mockUpdate = vi.fn().mockReturnValue({
-            eq: vi.fn().mockResolvedValue({}),
-        });
-        const supabase = {
-            from: vi.fn().mockReturnValue({
-                select: vi.fn().mockReturnThis(),
-                update: mockUpdate,
-                eq: vi.fn().mockReturnThis(),
-                single: vi.fn().mockResolvedValue({
-                    data: { customization_config: { existingKey: 'value' } },
-                }),
-            }),
-        } as any;
+    it('updates only the build cache key through the atomic JSONB merge RPC', async () => {
+        const supabase = makeSupabase(null) as any;
 
         await service.storeHash(supabase, 'dep-1', 'abc123');
 
-        expect(mockUpdate).toHaveBeenCalledWith(
-            expect.objectContaining({
-                customization_config: expect.objectContaining({
-                    existingKey: 'value',
-                    _buildCacheHash: 'abc123',
-                }),
-            }),
-        );
+        expect(supabase.rpc).toHaveBeenCalledWith('set_deployment_build_cache_hash', {
+            p_deployment_id: 'dep-1',
+            p_hash: 'abc123',
+        });
+        expect(supabase.from).not.toHaveBeenCalledWith('deployments');
     });
 });

--- a/apps/backend/src/services/build-cache.service.ts
+++ b/apps/backend/src/services/build-cache.service.ts
@@ -11,8 +11,8 @@
  *   - If the hash is unchanged → cache hit → skip the build.
  *
  * The hash is stored in the `deployments` table under the
- * `customization_config` JSONB column at key `_buildCacheHash` so no
- * schema migration is required.
+ * `customization_config` JSONB column at key `_buildCacheHash`. Writes use a
+ * database-side JSONB merge so concurrent stages preserve other fields.
  *
  * Cache status is surfaced in deployment logs via DeploymentLogsService.
  */
@@ -85,21 +85,10 @@ export class BuildCacheService {
         deploymentId: string,
         contentHash: string,
     ): Promise<void> {
-        // Merge _buildCacheHash into the existing customization_config JSONB
-        const { data } = await supabase
-            .from('deployments')
-            .select('customization_config')
-            .eq('id', deploymentId)
-            .single();
-
-        const existing = (data?.customization_config as Record<string, unknown>) ?? {};
-
-        await supabase
-            .from('deployments')
-            .update({
-                customization_config: { ...existing, _buildCacheHash: contentHash },
-            })
-            .eq('id', deploymentId);
+        await supabase.rpc('set_deployment_build_cache_hash', {
+            p_deployment_id: deploymentId,
+            p_hash: contentHash,
+        });
     }
 }
 

--- a/apps/backend/src/services/job-queue.service.test.ts
+++ b/apps/backend/src/services/job-queue.service.test.ts
@@ -112,17 +112,31 @@ function makeSupabaseMock(
                             select: vi.fn().mockImplementation(() =>
                                 Promise.resolve({ data: apply(), error: null }),
                             ),
+                            then: vi.fn((resolve: (result: unknown) => unknown) =>
+                                Promise.resolve(resolve({ data: apply(), error: null }))),
                         };
                     }),
                     select: vi.fn().mockImplementation(() =>
                         Promise.resolve({ data: apply(), error: null }),
                     ),
+                    then: vi.fn((resolve: (result: unknown) => unknown) =>
+                        Promise.resolve(resolve({ data: apply(), error: null }))),
                 };
                 return chain;
             };
             return makeChain(jobs);
         }),
         eq: vi.fn().mockReturnThis(),
+        lt: vi.fn((_col: string, value: unknown) => ({
+            then: vi.fn((resolve: (result: unknown) => unknown) => Promise.resolve(resolve({
+                data: jobs.filter((job) =>
+                    job.status === 'running' &&
+                    job.started_at !== null &&
+                    new Date(job.started_at).getTime() < new Date(value as string).getTime(),
+                ),
+                error: null,
+            }))),
+        })),
         order: vi.fn().mockReturnThis(),
         then: vi.fn().mockImplementation((cb: any) => Promise.resolve(cb({ data: jobs, error: null }))),
     };
@@ -673,6 +687,7 @@ describe('recoverStalledJobs', () => {
         const supabase = makeSupabaseMock([job]);
         vi.mocked(createClient).mockReturnValue(supabase as any);
         const service = new JobQueueService(1);
+        const staleWorkerSnapshot = { ...job };
 
         // Step 1: recover the stalled job (sets status back to pending, worker_id to null)
         await service.recoverStalledJobs();
@@ -685,22 +700,59 @@ describe('recoverStalledJobs', () => {
         const { data: claimedData } = await supabase.rpc('claim_next_job', { p_worker_id: 'worker-b' });
         expect(claimedData).toBeTruthy();
         const attemptsAfterClaim = claimedData?.[0]?.attempts;
-        // The original worker had attempts=1; claim bumps to 2
-        expect(attemptsAfterClaim).toBe(2);
+        // Recovery consumes an attempt, then worker B's claim consumes another.
+        expect(attemptsAfterClaim).toBe(3);
 
         // Step 3: worker A (original) tries to complete with its stale attempts value
         // _executeJob's completion UPDATE now includes .eq('attempts', job.attempts)
         // where job.attempts is still 1 (the stale value from when worker A claimed it)
         // The DB row now has attempts=2, so the UPDATE should affect 0 rows
         // We call _executeJob directly with the original job object (still has attempts=1)
-        await (service as any)._executeJob(job);
+        await (service as any)._executeJob(staleWorkerSnapshot);
 
         // Verify: the job should still be running (claimed by worker B), not completed
         const finalJob = supabase._jobs.find((j: JobRecord) => j.id === 'job-fencing');
         // Worker B claimed it, so it should be running (not completed by stale worker A)
         expect(finalJob?.status).toBe('running');
         expect(finalJob?.worker_id).toBe('worker-b');
-        expect(finalJob?.attempts).toBe(2);
+        expect(finalJob?.attempts).toBe(3);
+    });
+
+    it('moves a repeatedly stalled job to the DLQ after max_attempts recoveries', async () => {
+        const stalledAt = new Date(Date.now() - STALLED_JOB_TIMEOUT_MS - 1000).toISOString();
+        const job: JobRecord = {
+            id: 'job-repeatedly-stalled',
+            job_type: 'test',
+            priority: 'normal',
+            status: 'running',
+            payload: {},
+            attempts: 0,
+            max_attempts: 3,
+            scheduled_at: stalledAt,
+            started_at: stalledAt,
+            worker_id: 'dead-worker',
+            created_at: stalledAt,
+            updated_at: stalledAt,
+            result: null,
+            error_message: null,
+            completed_at: null,
+            dead_at: null,
+        };
+        const supabase = makeSupabaseMock([job]);
+        vi.mocked(createClient).mockReturnValue(supabase as any);
+        const service = new JobQueueService(1);
+
+        for (let recovery = 0; recovery < job.max_attempts; recovery++) {
+            job.status = 'running';
+            job.started_at = stalledAt;
+            await service.recoverStalledJobs();
+        }
+
+        expect(supabase._dlq).toHaveLength(1);
+        expect(supabase._dlq[0].original_job_id).toBe(job.id);
+        expect(supabase._dlq[0].failure_reason).toContain('stalled');
+        expect(job.status).toBe('dead');
+        expect(job.attempts).toBe(job.max_attempts);
     });
 });
 

--- a/apps/backend/src/services/job-queue.service.ts
+++ b/apps/backend/src/services/job-queue.service.ts
@@ -399,28 +399,7 @@ export class JobQueueService {
         const exhausted = newAttempts >= job.max_attempts;
 
         if (exhausted) {
-            // Move to DLQ
-            await supabase.from('job_dlq').insert({
-                original_job_id: job.id,
-                job_type: job.job_type,
-                priority: job.priority,
-                payload: job.payload,
-                failure_reason: reason,
-                attempts: newAttempts,
-                reprocess_status: 'pending',
-            });
-
-            await supabase
-                .from('job_queue')
-                .update({
-                    status: 'dead',
-                    attempts: newAttempts,
-                    error_message: reason,
-                    dead_at: new Date().toISOString(),
-                    updated_at: new Date().toISOString(),
-                })
-                .eq('id', job.id)
-                .eq('attempts', job.attempts);
+            await this._moveToDLQ(job, reason, newAttempts);
         } else {
             await supabase
                 .from('job_queue')
@@ -434,6 +413,32 @@ export class JobQueueService {
                 .eq('id', job.id)
                 .eq('attempts', job.attempts);
         }
+    }
+
+    private async _moveToDLQ(job: JobRecord, reason: string, attempts: number): Promise<void> {
+        const supabase = createClient();
+
+        await supabase.from('job_dlq').insert({
+            original_job_id: job.id,
+            job_type: job.job_type,
+            priority: job.priority,
+            payload: job.payload,
+            failure_reason: reason,
+            attempts,
+            reprocess_status: 'pending',
+        });
+
+        await supabase
+            .from('job_queue')
+            .update({
+                status: 'dead',
+                attempts,
+                error_message: reason,
+                dead_at: new Date().toISOString(),
+                updated_at: new Date().toISOString(),
+            })
+            .eq('id', job.id)
+            .eq('attempts', job.attempts);
     }
 
     /**
@@ -452,8 +457,8 @@ export class JobQueueService {
     // ── Stalled job recovery ───────────────────────────────────────────────────
 
     /**
-     * Requeue jobs that have been `running` beyond STALLED_JOB_TIMEOUT_MS.
-     * Call periodically from a cron handler to recover from crashed workers.
+    * Recover jobs that have been `running` beyond STALLED_JOB_TIMEOUT_MS.
+    * A recovery consumes an attempt just like a handler failure.
      */
     async recoverStalledJobs(): Promise<number> {
         const supabase = createClient();
@@ -461,17 +466,18 @@ export class JobQueueService {
 
         const { data, error } = await supabase
             .from('job_queue')
-            .update({
-                status: 'pending',
-                worker_id: null,
-                updated_at: new Date().toISOString(),
-            })
+            .select('*')
             .eq('status', 'running')
-            .lt('started_at', cutoff)
-            .select('id');
+            .lt('started_at', cutoff);
 
         if (error) throw new Error(`recoverStalledJobs failed: ${error.message}`);
-        return (data ?? []).length;
+
+        let recovered = 0;
+        for (const job of (data ?? []) as JobRecord[]) {
+            await this._failJob(job, `Job stalled beyond ${STALLED_JOB_TIMEOUT_MS}ms`);
+            recovered++;
+        }
+        return recovered;
     }
 }
 

--- a/apps/backend/tests/api/version-migration.test.ts
+++ b/apps/backend/tests/api/version-migration.test.ts
@@ -19,6 +19,7 @@ import {
     parseAcceptVersion,
     withVersionMigration,
 } from '@/lib/api/version-migration.middleware';
+import { DEFAULT_API_VERSION } from '@/lib/api/version-negotiation';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -124,7 +125,7 @@ describe('withVersionMigration', () => {
         const res = await wrapped(makeRequest({ repository: { name: 'r' } }));
 
         expect(res.status).toBe(200);
-        expect(res.headers.get('x-api-version')).toBe('2');
+        expect(res.headers.get('x-api-version')).toBe(String(DEFAULT_API_VERSION));
         expect(res.headers.get('x-api-deprecation-warning')).toMatch(/Accept-Version/);
     });
 

--- a/supabase/migrations/018_atomic_deployment_build_cache_hash.sql
+++ b/supabase/migrations/018_atomic_deployment_build_cache_hash.sql
@@ -1,0 +1,21 @@
+-- Merge the build cache marker in the database so concurrent deployment stages
+-- cannot overwrite unrelated customization_config fields.
+
+CREATE OR REPLACE FUNCTION set_deployment_build_cache_hash(
+    p_deployment_id UUID,
+    p_hash TEXT
+)
+RETURNS VOID
+LANGUAGE SQL
+SECURITY DEFINER
+AS $$
+    UPDATE deployments
+    SET customization_config = COALESCE(customization_config, '{}'::jsonb)
+        || jsonb_build_object('_buildCacheHash', p_hash),
+        updated_at = NOW()
+    WHERE id = p_deployment_id;
+$$;
+
+GRANT EXECUTE ON FUNCTION set_deployment_build_cache_hash(UUID, TEXT) TO service_role;
+
+-- rollback: DROP FUNCTION IF EXISTS set_deployment_build_cache_hash(UUID, TEXT);


### PR DESCRIPTION
## Summary

- Count stalled job recoveries against `max_attempts` and move repeatedly stalled jobs to the DLQ.
- Replace build cache read-modify-write with an atomic database-side JSONB merge.
- Share the default API version between negotiation and migration middleware.
- Log subscription tier lookup failures while preserving the fail-safe `free` tier.

## Validation

- Focused issue tests: 66 passed.
- Direct ESLint on changed TypeScript files: passed.
- `git diff --check`: passed.
- Full backend typecheck/lint remain blocked by pre-existing syntax errors in unrelated files.

Closes #1049
Closes #1050
Closes #1051
Closes #1052