### PR TITLE
fix(backend): resolve DLQ, Stripe, and graph scalability issues

### DIFF
--- a/apps/backend/src/lib/retry/exponential-backoff.ts
+++ b/apps/backend/src/lib/retry/exponential-backoff.ts
@@ -90,13 +90,11 @@ export function calculateBackoffDelay(
     const random = randomFn ?? Math.random;
     // Exponential backoff: initial * (multiplier ^ attempt)
     const exponential = initialDelayMs * Math.pow(multiplier, attempt);
+    const delay = Math.min(exponential, maxDelayMs);
 
     // Add jitter: ±10% of the pre-cap exponential value
-    const jitter = exponential * 0.1 * (Math.random() - 0.5) * 2;
-
-    // Add jitter: ±10% of the delay
-    const jitter = delay * 0.1 * (random() - 0.5) * 2;
-    return Math.max(0, delay + jitter);
+    const jitter = exponential * 0.1 * (random() - 0.5) * 2;
+    return Math.min(maxDelayMs, Math.max(0, delay + jitter));
 }
 
 /**

--- a/apps/backend/src/lib/webhook-dlq/dlq-auto-recovery.test.ts
+++ b/apps/backend/src/lib/webhook-dlq/dlq-auto-recovery.test.ts
@@ -26,6 +26,21 @@ describe('DLQAutoRecovery', () => {
         expect(reprocess).toHaveBeenCalledWith(entry.id);
     });
 
+    it('re-arms pending entries when a new recovery instance initializes', async () => {
+        const entry = captureEntry();
+        const reprocess = vi.spyOn(webhookDLQ, 'reprocess')
+            .mockResolvedValueOnce({ success: false, error: 'restart' })
+            .mockResolvedValueOnce({ success: true });
+
+        const firstRecovery = new DLQAutoRecovery({ now: () => 0, sleep: () => Promise.resolve() });
+        await firstRecovery.processDue();
+
+        const restartedRecovery = new DLQAutoRecovery({ now: () => 0, sleep: () => Promise.resolve() });
+        await restartedRecovery.initialize();
+
+        expect(reprocess).toHaveBeenNthCalledWith(2, entry.id);
+    });
+
     it('skips an entry that is not yet due', async () => {
         captureEntry();
         // Always fail so retry state is set after first call

--- a/apps/backend/src/lib/webhook-dlq/dlq-auto-recovery.ts
+++ b/apps/backend/src/lib/webhook-dlq/dlq-auto-recovery.ts
@@ -2,7 +2,9 @@
  * DLQ Auto-Recovery Orchestrator (#748)
  *
  * Polls the DLQ at a configurable interval and automatically retries
- * pending entries using exponential backoff with ±10% jitter.
+ * pending entries using exponential backoff with ±10% jitter. The poller's
+ * retryState is the source of truth; startup reconciliation re-arms entries
+ * whose in-memory schedule was lost during a process restart.
  *
  * Retry schedule (base delays): 1m, 2m, 4m, 8m, 16m, 32m → permanent failure
  *
@@ -69,7 +71,13 @@ export class DLQAutoRecovery {
     start(): void {
         if (this.running) return;
         this.running = true;
+        void this.initialize();
         this._scheduleNext();
+    }
+
+    /** Re-arm pending entries after a process restart. */
+    async initialize(): Promise<void> {
+        await this.processDue();
     }
 
     /** Stop the background polling loop. */

--- a/apps/backend/src/services/dependency-graph.ts
+++ b/apps/backend/src/services/dependency-graph.ts
@@ -21,22 +21,28 @@ export class CircularDependencyError extends Error {
 
 export class DependencyGraph {
   private nodes = new Map<string, Set<string>>();
+  private dependents = new Map<string, Set<string>>();
 
   /** Add a node (idempotent). */
   addNode(id: string): void {
     if (!this.nodes.has(id)) this.nodes.set(id, new Set());
+    if (!this.dependents.has(id)) this.dependents.set(id, new Set());
   }
 
   /** Add a directed edge: `from` depends on `to`. */
   addEdge(from: string, to: string): void {
     this.addNode(from);
     this.addNode(to);
-    this.nodes.get(from)!.add(to);
+    if (this.nodes.get(from)!.add(to)) {
+      this.dependents.get(to)!.add(from);
+    }
   }
 
   /** Remove a directed edge. */
   removeEdge(from: string, to: string): void {
-    this.nodes.get(from)?.delete(to);
+    if (this.nodes.get(from)?.delete(to)) {
+      this.dependents.get(to)?.delete(from);
+    }
   }
 
   /** Direct dependencies of a node. */
@@ -90,15 +96,13 @@ export class DependencyGraph {
     while (queue.length) {
       const node = queue.shift()!;
       order.push(node);
-      // Reduce in-degree of every node that listed `node` as a dependency
-      for (const [id, deps] of this.nodes) {
-        if (deps.has(node)) {
-          const newDeg = (inDegree.get(id) ?? 0) - 1;
-          inDegree.set(id, newDeg);
-          if (newDeg === 0) {
-            queue.push(id);
-            queue.sort();
-          }
+      // Reduce in-degree only for nodes that list `node` as a dependency.
+      for (const id of this.dependents.get(node) ?? []) {
+        const newDeg = (inDegree.get(id) ?? 0) - 1;
+        inDegree.set(id, newDeg);
+        if (newDeg === 0) {
+          queue.push(id);
+          queue.sort();
         }
       }
     }
@@ -149,8 +153,8 @@ export class DependencyGraph {
 
       for (const node of ready) {
         processed.add(node);
-        for (const [id, deps] of this.nodes) {
-          if (!processed.has(id) && deps.has(node)) {
+        for (const id of this.dependents.get(node) ?? []) {
+          if (!processed.has(id)) {
             inDegree.set(id, (inDegree.get(id) ?? 0) - 1);
           }
         }

--- a/apps/backend/src/services/metered-billing.service.test.ts
+++ b/apps/backend/src/services/metered-billing.service.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockSupabase = vi.hoisted(() => ({
+  from: vi.fn(),
+}));
+const mockStripe = vi.hoisted(() => ({
+  subscriptions: { retrieve: vi.fn() },
+  subscriptionItems: { createUsageRecord: vi.fn() },
+}));
+
+vi.mock('@/lib/supabase/server', () => ({ createClient: () => mockSupabase }));
+vi.mock('@/lib/stripe/client', () => ({ stripe: mockStripe }));
+
+import { MeteringService } from './metered-billing.service';
+
+describe('MeteringService.reportPendingUsageToStripe()', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSupabase.from.mockImplementation((table: string) => {
+      if (table === 'profiles') {
+        return { select: () => ({ eq: () => ({ single: async () => ({
+          data: { stripe_subscription_id: 'sub_123' }, error: null,
+        }) }) }) };
+      }
+      return {
+        select: () => ({
+          eq: () => ({
+            eq: () => ({
+              is: async () => ({ data: [
+                { quantity: 1, operation_type: 'one' },
+                { quantity: 1, operation_type: 'two' },
+                { quantity: 1, operation_type: 'three' },
+                { quantity: 1, operation_type: 'four' },
+              ], error: null }),
+            }),
+          }),
+        }),
+      };
+    });
+    mockStripe.subscriptions.retrieve.mockResolvedValue({ items: { data: [
+      { id: 'si_123', price: { recurring: { usage_type: 'metered' } } },
+    ] } });
+  });
+
+  it('stops the batch after three consecutive Stripe failures', async () => {
+    const service = new MeteringService();
+    const report = vi.spyOn(service, 'reportUsageToStripe')
+      .mockResolvedValue({ success: false, error: 'Stripe unavailable' });
+
+    const result = await service.reportPendingUsageToStripe('user-123');
+
+    expect(report).toHaveBeenCalledTimes(3);
+    expect(result).toMatchObject({ reported: 0, failed: 3 });
+  });
+
+  it('resets the failure streak after a successful report', async () => {
+    const service = new MeteringService();
+    const report = vi.spyOn(service, 'reportUsageToStripe')
+      .mockResolvedValueOnce({ success: false, error: 'temporary' })
+      .mockResolvedValueOnce({ success: true })
+      .mockResolvedValue({ success: false, error: 'Stripe unavailable' });
+
+    const result = await service.reportPendingUsageToStripe('user-123');
+
+    expect(report).toHaveBeenCalledTimes(4);
+    expect(result).toMatchObject({ reported: 1, failed: 3 });
+  });
+});

--- a/apps/backend/src/services/metered-billing.service.ts
+++ b/apps/backend/src/services/metered-billing.service.ts
@@ -8,6 +8,8 @@
 import { stripe } from '@/lib/stripe/client';
 import { createClient } from '@/lib/supabase/server';
 
+const MAX_CONSECUTIVE_REPORT_FAILURES = 3;
+
 export interface UsageRecord {
   id: string;
   user_id: string;
@@ -335,6 +337,7 @@ export class MeteringService {
     // Report each usage record
     let reported = 0;
     let failed = 0;
+    let consecutiveFailures = 0;
     const errors: string[] = [];
 
     for (const record of pendingRecords || []) {
@@ -347,9 +350,19 @@ export class MeteringService {
 
       if (result.success) {
         reported++;
+        consecutiveFailures = 0;
       } else {
         failed++;
+        consecutiveFailures++;
         errors.push(`${record.operation_type}: ${result.error}`);
+        if (consecutiveFailures >= MAX_CONSECUTIVE_REPORT_FAILURES) {
+          console.warn('Stopping Stripe usage reporting after consecutive failures', {
+            userId,
+            consecutiveFailures,
+            remainingRecords: (pendingRecords?.length ?? 0) - reported - failed,
+          });
+          break;
+        }
       }
     }
 

--- a/apps/backend/tests/deployment/dependency-graph.test.ts
+++ b/apps/backend/tests/deployment/dependency-graph.test.ts
@@ -111,6 +111,27 @@ describe('Dependency graph — topological ordering', () => {
     ]);
     expect(g.topologicalOrder()).toEqual(['a', 'm', 'z']);
   });
+
+  it('preserves ordering for a large fan-out and fan-in graph', () => {
+    const nodes: DeploymentNode[] = [{ id: 'root', dependsOn: [] }];
+    for (let index = 0; index < 100; index++) {
+      nodes.push({ id: `branch-${index}`, dependsOn: ['root'] });
+    }
+    nodes.push({
+      id: 'release',
+      dependsOn: nodes.filter((node) => node.id.startsWith('branch-')).map((node) => node.id),
+    });
+
+    const graph = buildGraph(nodes);
+    const order = graph.topologicalOrder();
+    const levels = graph.executionLevels();
+
+    expect(order).toHaveLength(102);
+    expect(levels).toHaveLength(3);
+    expect(levels[0]).toEqual(['root']);
+    expect(levels[1]).toHaveLength(100);
+    expect(levels[2]).toEqual(['release']);
+  });
 });
 
 describe('Dependency graph — circular dependency detection', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,6 @@
                 "apps/*",
                 "packages/*"
             ],
-            "dependencies": {
-                "pathe": "^2.0.3"
-            },
             "devDependencies": {
                 "@fast-check/vitest": "^0.4.1",
                 "@turbo/gen": "^1.11.2",
@@ -9997,6 +9994,7 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
             "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/pathval": {
@@ -13974,9 +13972,230 @@
                 "react-dom": "^18.2.0"
             },
             "devDependencies": {
+                "@testing-library/jest-dom": "^6.1.5",
+                "@testing-library/react": "^14.1.2",
                 "@types/react": "^18.2.45",
                 "@types/react-dom": "^18.2.18",
-                "typescript": "^5.3.3"
+                "jsdom": "^23.0.1",
+                "typescript": "^5.3.3",
+                "vitest": "^1.1.0"
+            }
+        },
+        "packages/ui/node_modules/execa": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+            "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cross-spawn": "^7.0.3",
+                "get-stream": "^8.0.1",
+                "human-signals": "^5.0.0",
+                "is-stream": "^3.0.0",
+                "merge-stream": "^2.0.0",
+                "npm-run-path": "^5.1.0",
+                "onetime": "^6.0.0",
+                "signal-exit": "^4.1.0",
+                "strip-final-newline": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=16.17"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/execa?sponsor=1"
+            }
+        },
+        "packages/ui/node_modules/get-stream": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+            "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "packages/ui/node_modules/human-signals": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+            "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=16.17.0"
+            }
+        },
+        "packages/ui/node_modules/is-stream": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+            "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "packages/ui/node_modules/mimic-fn": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+            "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "packages/ui/node_modules/npm-run-path": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+            "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "path-key": "^4.0.0"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "packages/ui/node_modules/onetime": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+            "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mimic-fn": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "packages/ui/node_modules/path-key": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+            "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "packages/ui/node_modules/pathe": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+            "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "packages/ui/node_modules/signal-exit": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+            "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "packages/ui/node_modules/strip-final-newline": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+            "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "packages/ui/node_modules/vitest": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.6.1.tgz",
+            "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/expect": "1.6.1",
+                "@vitest/runner": "1.6.1",
+                "@vitest/snapshot": "1.6.1",
+                "@vitest/spy": "1.6.1",
+                "@vitest/utils": "1.6.1",
+                "acorn-walk": "^8.3.2",
+                "chai": "^4.3.10",
+                "debug": "^4.3.4",
+                "execa": "^8.0.1",
+                "local-pkg": "^0.5.0",
+                "magic-string": "^0.30.5",
+                "pathe": "^1.1.1",
+                "picocolors": "^1.0.0",
+                "std-env": "^3.5.0",
+                "strip-literal": "^2.0.0",
+                "tinybench": "^2.5.1",
+                "tinypool": "^0.8.3",
+                "vite": "^5.0.0",
+                "vite-node": "1.6.1",
+                "why-is-node-running": "^2.2.2"
+            },
+            "bin": {
+                "vitest": "vitest.mjs"
+            },
+            "engines": {
+                "node": "^18.0.0 || >=20.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "@edge-runtime/vm": "*",
+                "@types/node": "^18.0.0 || >=20.0.0",
+                "@vitest/browser": "1.6.1",
+                "@vitest/ui": "1.6.1",
+                "happy-dom": "*",
+                "jsdom": "*"
+            },
+            "peerDependenciesMeta": {
+                "@edge-runtime/vm": {
+                    "optional": true
+                },
+                "@types/node": {
+                    "optional": true
+                },
+                "@vitest/browser": {
+                    "optional": true
+                },
+                "@vitest/ui": {
+                    "optional": true
+                },
+                "happy-dom": {
+                    "optional": true
+                },
+                "jsdom": {
+                    "optional": true
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

- Reconcile pending DLQ entries immediately when auto-recovery initializes, so a restart re-arms schedules instead of abandoning them.
- Stop a Stripe usage-reporting batch after three consecutive failures while preserving progress across transient failures.
- Maintain reverse dependency adjacency so topological ordering and execution levels walk edges instead of rescanning every node.
- Complete the existing exponential-backoff helper so backend recovery tests compile and use the configured random source.

## Validation

- Focused backend tests: 42 passed across dependency graph, DLQ recovery, and metered billing suites.
- Diagnostics: no errors in touched source or test files.
- Backend lint remains blocked by unrelated pre-existing errors in other files.

Closes #1064
Closes #1065
Closes #1066
Closes #1064