### PR TITLE
fix(backend): update the domain-removal route response to match the c…

### DIFF
--- a/apps/backend/src/app/api/deployments/[id]/domains/[domain]/route.test.ts
+++ b/apps/backend/src/app/api/deployments/[id]/domains/[domain]/route.test.ts
@@ -3,7 +3,7 @@ import { NextRequest } from 'next/server';
 
 const mockGetUser = vi.fn();
 const mockFrom = vi.fn();
-const mockRemoveDomain = vi.fn();
+const mockRemoveDomainWithCleanup = vi.fn();
 
 vi.mock('@/lib/supabase/server', () => ({
     createClient: () => ({
@@ -12,15 +12,10 @@ vi.mock('@/lib/supabase/server', () => ({
     }),
 }));
 
-vi.mock('@/services/vercel.service', () => ({
-    VercelService: vi.fn().mockImplementation(() => ({
-        removeDomain: mockRemoveDomain,
+vi.mock('@/services/vercel-domain-lifecycle.service', () => ({
+    VercelDomainLifecycleService: vi.fn().mockImplementation(() => ({
+        removeDomainWithCleanup: mockRemoveDomainWithCleanup,
     })),
-    VercelApiError: class VercelApiError extends Error {
-        constructor(message: string, public code: string) {
-            super(message);
-        }
-    },
 }));
 
 const fakeUser = { id: 'user-1' };
@@ -87,7 +82,7 @@ describe('DELETE /api/deployments/[id]/domains/[domain]', () => {
         expect((await res.json()).error).toMatch(/no vercel project/i);
     });
 
-    it('returns 200 and clears custom_domain when it matches', async () => {
+    it('returns 200 with aliasesMatched and clears custom_domain when it matches', async () => {
         const mockUpdate = vi.fn(() => ({ eq: vi.fn().mockResolvedValue({ error: null }) }));
         mockFrom
             .mockReturnValueOnce(makeSupabaseQuery([{ data: { user_id: fakeUser.id }, error: null }]))
@@ -102,7 +97,11 @@ describe('DELETE /api/deployments/[id]/domains/[domain]', () => {
                 })),
             })
             .mockReturnValueOnce({ update: mockUpdate });
-        mockRemoveDomain.mockResolvedValue(undefined);
+        mockRemoveDomainWithCleanup.mockResolvedValue({
+            success: true,
+            domain: 'example.com',
+            aliasesMatched: 2,
+        });
 
         const { DELETE } = await import('./route');
         const res = await DELETE(makeRequest(), { params });
@@ -110,10 +109,11 @@ describe('DELETE /api/deployments/[id]/domains/[domain]', () => {
         const body = await res.json();
         expect(body.deleted).toBe(true);
         expect(body.domain).toBe('example.com');
+        expect(body.aliasesMatched).toBe(2);
         expect(mockUpdate).toHaveBeenCalledWith({ custom_domain: null });
     });
 
-    it('returns 200 and does not clear custom_domain when it differs', async () => {
+    it('returns 200 with aliasesMatched: 0 and does not clear custom_domain when it differs', async () => {
         mockFrom
             .mockReturnValueOnce(makeSupabaseQuery([{ data: { user_id: fakeUser.id }, error: null }]))
             .mockReturnValueOnce({
@@ -126,14 +126,20 @@ describe('DELETE /api/deployments/[id]/domains/[domain]', () => {
                     })),
                 })),
             });
-        mockRemoveDomain.mockResolvedValue(undefined);
+        mockRemoveDomainWithCleanup.mockResolvedValue({
+            success: true,
+            domain: 'example.com',
+            aliasesMatched: 0,
+        });
 
         const { DELETE } = await import('./route');
         const res = await DELETE(makeRequest(), { params });
         expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.aliasesMatched).toBe(0);
     });
 
-    it('returns 500 when removeDomain throws unexpectedly', async () => {
+    it('returns 200 with partialFailure fields when alias cleanup partially fails', async () => {
         mockFrom
             .mockReturnValueOnce(makeSupabaseQuery([{ data: { user_id: fakeUser.id }, error: null }]))
             .mockReturnValueOnce({
@@ -146,7 +152,42 @@ describe('DELETE /api/deployments/[id]/domains/[domain]', () => {
                     })),
                 })),
             });
-        mockRemoveDomain.mockRejectedValue(new Error('Vercel API error'));
+        mockRemoveDomainWithCleanup.mockResolvedValue({
+            success: true,
+            domain: 'example.com',
+            aliasesMatched: 1,
+            partialFailure: true,
+            partialFailureReason: 'Alias cleanup encountered errors: deployment dep-2: 503',
+        });
+
+        const { DELETE } = await import('./route');
+        const res = await DELETE(makeRequest(), { params });
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.aliasesMatched).toBe(1);
+        expect(body.partialFailure).toBe(true);
+        expect(body.partialFailureReason).toMatch(/alias cleanup/i);
+    });
+
+    it('returns 500 when removeDomainWithCleanup reports failure', async () => {
+        mockFrom
+            .mockReturnValueOnce(makeSupabaseQuery([{ data: { user_id: fakeUser.id }, error: null }]))
+            .mockReturnValueOnce({
+                select: vi.fn(() => ({
+                    eq: vi.fn(() => ({
+                        single: vi.fn().mockResolvedValue({
+                            data: { vercel_project_id: 'prj_1', custom_domain: null },
+                            error: null,
+                        }),
+                    })),
+                })),
+            });
+        mockRemoveDomainWithCleanup.mockResolvedValue({
+            success: false,
+            domain: 'example.com',
+            aliasesMatched: 0,
+            partialFailureReason: 'Failed to remove domain from Vercel',
+        });
 
         const { DELETE } = await import('./route');
         expect((await DELETE(makeRequest(), { params })).status).toBe(500);

--- a/apps/backend/src/app/api/deployments/[id]/domains/[domain]/route.ts
+++ b/apps/backend/src/app/api/deployments/[id]/domains/[domain]/route.ts
@@ -8,7 +8,7 @@
  *   Requires a valid session (401) and ownership of the deployment (403).
  *
  * Responses:
- *   200 — Domain removed successfully
+ *   200 — Domain removed successfully; includes `aliasesMatched` count
  *   404 — Deployment not found or no Vercel project configured
  *   401 — Not authenticated
  *   403 — Not authorized for this deployment
@@ -19,9 +19,9 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { withDeploymentAuth } from '@/lib/api/with-auth';
-import { VercelService } from '@/services/vercel.service';
+import { VercelDomainLifecycleService } from '@/services/vercel-domain-lifecycle.service';
 
-const vercel = new VercelService();
+const lifecycleService = new VercelDomainLifecycleService();
 
 export const DELETE = withDeploymentAuth<{ id: string; domain: string }>(
     async (_req: NextRequest, { params, supabase }) => {
@@ -42,11 +42,14 @@ export const DELETE = withDeploymentAuth<{ id: string; domain: string }>(
             );
         }
 
-        try {
-            await vercel.removeDomain(params.domain, deployment.vercel_project_id);
-        } catch (err: unknown) {
+        const result = await lifecycleService.removeDomainWithCleanup(
+            params.domain,
+            deployment.vercel_project_id,
+        );
+
+        if (!result.success) {
             return NextResponse.json(
-                { error: (err as Error).message ?? 'Failed to remove domain' },
+                { error: result.partialFailureReason ?? 'Failed to remove domain' },
                 { status: 500 },
             );
         }
@@ -59,6 +62,14 @@ export const DELETE = withDeploymentAuth<{ id: string; domain: string }>(
                 .eq('id', params.id);
         }
 
-        return NextResponse.json({ domain: params.domain, deleted: true });
+        return NextResponse.json({
+            domain: params.domain,
+            deleted: true,
+            aliasesMatched: result.aliasesMatched,
+            ...(result.partialFailure && {
+                partialFailure: true,
+                partialFailureReason: result.partialFailureReason,
+            }),
+        });
     },
 );


### PR DESCRIPTION
closes #1144 
closes #1145 

…orrected aliasesRemoved/aliasesMatched contract

- Replace direct VercelService.removeDomain() call with VercelDomainLifecycleService.removeDomainWithCleanup() in the DELETE handler
- Surface aliasesMatched (not aliasesRemoved) in the 200 response body, consistent with the RemoveDomainResult interface in the lifecycle service
- Include partialFailure / partialFailureReason in the response when alias cleanup encounters errors after the domain has been removed
- Update route.test.ts: swap VercelService mock for VercelDomainLifecycleService mock and assert on aliasesMatched in all relevant test cases; add new cases for partialFailure and success:false

Closes #1144