### PR TITLE
test(backend): add unit coverage for mutation-testing helpers, rollout strategies, and tracing utilities

### DIFF
--- a/apps/backend/src/lib/tracing.test.ts
+++ b/apps/backend/src/lib/tracing.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect } from 'vitest';
+import {
+    startTrace,
+    newSpan,
+    parseTraceparent,
+    withSpan,
+    TRACEPARENT_HEADER,
+    type TraceContext,
+} from './tracing';
+
+describe('startTrace', () => {
+    it('generates a new root trace context with valid IDs', () => {
+        const ctx = startTrace();
+
+        expect(ctx.traceId).toMatch(/^[0-9a-f]{32}$/);
+        expect(ctx.spanId).toMatch(/^[0-9a-f]{16}$/);
+        expect(ctx.traceparent).toBe(`00-${ctx.traceId}-${ctx.spanId}-01`);
+    });
+
+    it('generates a unique traceId on each call', () => {
+        const ctx1 = startTrace();
+        const ctx2 = startTrace();
+
+        expect(ctx1.traceId).not.toBe(ctx2.traceId);
+    });
+
+    it('generates a unique spanId on each call', () => {
+        const ctx1 = startTrace();
+        const ctx2 = startTrace();
+
+        expect(ctx1.spanId).not.toBe(ctx2.spanId);
+    });
+});
+
+describe('newSpan', () => {
+    it('creates a child span within an existing trace', () => {
+        const traceId = 'a'.repeat(32);
+        const ctx = newSpan(traceId);
+
+        expect(ctx.traceId).toBe(traceId);
+        expect(ctx.spanId).toMatch(/^[0-9a-f]{16}$/);
+        expect(ctx.traceparent).toBe(`00-${traceId}-${ctx.spanId}-01`);
+    });
+
+    it('preserves the traceId from parent context', () => {
+        const traceId = 'b'.repeat(32);
+        const root = newSpan(traceId);
+        const child = newSpan(root.traceId);
+
+        expect(child.traceId).toBe(traceId);
+    });
+
+    it('generates a unique spanId for each child', () => {
+        const traceId = 'c'.repeat(32);
+        const span1 = newSpan(traceId);
+        const span2 = newSpan(traceId);
+
+        expect(span1.spanId).not.toBe(span2.spanId);
+    });
+});
+
+describe('parseTraceparent', () => {
+    it('parses a valid traceparent header', () => {
+        const header = '00-12345678901234567890123456789012-1234567890123456-01';
+        const ctx = parseTraceparent(header);
+
+        expect(ctx).not.toBeNull();
+        expect(ctx?.traceId).toBe('12345678901234567890123456789012');
+        expect(ctx?.spanId).toBe('1234567890123456');
+        expect(ctx?.traceparent).toBe(header);
+    });
+
+    it('returns null for null header', () => {
+        expect(parseTraceparent(null)).toBeNull();
+    });
+
+    it('returns null for undefined header', () => {
+        expect(parseTraceparent(undefined)).toBeNull();
+    });
+
+    it('returns null for empty string', () => {
+        expect(parseTraceparent('')).toBeNull();
+    });
+
+    it('returns null for malformed header (wrong version)', () => {
+        const header = '01-12345678901234567890123456789012-1234567890123456-01';
+        expect(parseTraceparent(header)).toBeNull();
+    });
+
+    it('returns null for malformed header (too few parts)', () => {
+        const header = '00-12345678901234567890123456789012-01';
+        expect(parseTraceparent(header)).toBeNull();
+    });
+
+    it('returns null for invalid traceId length', () => {
+        const header = '00-1234567890-1234567890123456-01';
+        expect(parseTraceparent(header)).toBeNull();
+    });
+
+    it('returns null for invalid spanId length', () => {
+        const header = '00-12345678901234567890123456789012-1234-01';
+        expect(parseTraceparent(header)).toBeNull();
+    });
+
+    it('returns null for non-hex characters in traceId', () => {
+        const header = '00-zzzz5678901234567890123456789012-1234567890123456-01';
+        expect(parseTraceparent(header)).toBeNull();
+    });
+});
+
+describe('withSpan', () => {
+    it('wraps an async function and returns result with span info', async () => {
+        const traceId = 'a'.repeat(32);
+        const result = await withSpan('test-span', traceId, async () => 'hello');
+
+        expect(result.result).toBe('hello');
+        expect(result.traceId).toBe(traceId);
+        expect(result.spanId).toMatch(/^[0-9a-f]{16}$/);
+        expect(result.durationMs).toBeGreaterThanOrEqual(0);
+        expect(result.span.name).toBe('test-span');
+        expect(result.span.status).toBe('ok');
+    });
+
+    it('records attributes on the span', async () => {
+        const traceId = 'b'.repeat(32);
+        const result = await withSpan(
+            'test-span',
+            traceId,
+            async () => 'ok',
+            { deploymentId: 'dep-123', userId: 'user-456' },
+        );
+
+        expect(result.span.attributes.deploymentId).toBe('dep-123');
+        expect(result.span.attributes.userId).toBe('user-456');
+    });
+
+    it('propagates traceId to the span', async () => {
+        const traceId = 'c'.repeat(32);
+        const result = await withSpan('test-span', traceId, async (ctx: TraceContext) => {
+            expect(ctx.traceId).toBe(traceId);
+            return 'done';
+        });
+
+        expect(result.span.traceId).toBe(traceId);
+    });
+
+    it('records error span and re-throws on failure', async () => {
+        const traceId = 'd'.repeat(32);
+        const error = new Error('test error');
+
+        await expect(
+            withSpan('failing-span', traceId, async () => {
+                throw error;
+            }),
+        ).rejects.toThrow('test error');
+    });
+
+    it('records exception event attributes on error', async () => {
+        const traceId = 'e'.repeat(32);
+        const error = new TypeError('bad type');
+
+        try {
+            await withSpan('error-span', traceId, async () => {
+                throw error;
+            });
+        } catch (e: any) {
+            const span = e.__span;
+            expect(span).toBeDefined();
+            expect(span.status).toBe('error');
+            expect(span.events).toHaveLength(1);
+            expect(span.events[0].name).toBe('exception');
+            expect(span.events[0].attributes['exception.type']).toBe('TypeError');
+            expect(span.events[0].attributes['exception.message']).toBe('bad type');
+        }
+    });
+
+    it('generates a fresh spanId for each invocation (correlation-ID propagation)', async () => {
+        const traceId = 'f'.repeat(32);
+        const result1 = await withSpan('span-a', traceId, async () => 'a');
+        const result2 = await withSpan('span-b', traceId, async () => 'b');
+
+        expect(result1.spanId).not.toBe(result2.spanId);
+    });
+
+    it('does not throw when no incoming correlation ID is present (generates fresh)', async () => {
+        const result = await withSpan(
+            'root-span',
+            startTrace().traceId,
+            async () => 'success',
+        );
+
+        expect(result.result).toBe('success');
+        expect(result.span.status).toBe('ok');
+    });
+});
+
+describe('TRACEPARENT_HEADER', () => {
+    it('is "traceparent"', () => {
+        expect(TRACEPARENT_HEADER).toBe('traceparent');
+    });
+});

--- a/apps/backend/src/services/mutation-testing.helpers.test.ts
+++ b/apps/backend/src/services/mutation-testing.helpers.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from 'vitest';
+import {
+    VALID_STATE_TRANSITIONS,
+    assertValidTransition,
+    assertInvalidTransition,
+    getInvalidTransitions,
+    assertTerminalState,
+    assertNonTerminalState,
+    assertAllStatesReachable,
+    assertNoCycles,
+} from './mutation-testing.helpers';
+import type { DeploymentStatusType } from '@craft/types';
+
+const ALL_STATES: DeploymentStatusType[] = [
+    'pending',
+    'generating',
+    'validating',
+    'signing',
+    'creating_repo',
+    'pushing_code',
+    'deploying',
+    'verifying_contract',
+    'completed',
+    'failed',
+];
+
+describe('assertValidTransition', () => {
+    it('does not throw for a valid transition', () => {
+        expect(() => assertValidTransition('pending', 'generating')).not.toThrow();
+    });
+
+    it('does not throw for pending → failed', () => {
+        expect(() => assertValidTransition('pending', 'failed')).not.toThrow();
+    });
+
+    it('throws for an invalid transition', () => {
+        expect(() => assertValidTransition('completed', 'pending')).toThrow();
+    });
+
+    it('throws for a self-loop on terminal state', () => {
+        expect(() => assertValidTransition('completed', 'completed')).toThrow();
+    });
+
+    it('throws when fromState has no allowed transitions (empty array)', () => {
+        expect(() => assertValidTransition('failed', 'pending')).toThrow();
+    });
+});
+
+describe('assertInvalidTransition', () => {
+    it('does not throw for an invalid transition', () => {
+        expect(() => assertInvalidTransition('completed', 'pending')).not.toThrow();
+    });
+
+    it('throws for a valid transition', () => {
+        expect(() => assertInvalidTransition('pending', 'generating')).toThrow();
+    });
+
+    it('does not throw when both states are terminal', () => {
+        expect(() => assertInvalidTransition('completed', 'failed')).not.toThrow();
+    });
+});
+
+describe('getInvalidTransitions', () => {
+    it('returns all states for a terminal state', () => {
+        const invalid = getInvalidTransitions('completed');
+        expect(invalid).toEqual(ALL_STATES);
+    });
+
+    it('excludes valid transitions from the result', () => {
+        const invalid = getInvalidTransitions('pending');
+        expect(invalid).not.toContain('generating');
+        expect(invalid).not.toContain('failed');
+        expect(invalid).toContain('validating');
+        expect(invalid).toContain('completed');
+    });
+
+    it('returns empty array for a state that transitions to all others (boundary)', () => {
+        // pending only transitions to generating and failed, so invalid should have 8 states
+        const invalid = getInvalidTransitions('pending');
+        expect(invalid).toHaveLength(8);
+    });
+});
+
+describe('assertTerminalState', () => {
+    it('does not throw for terminal state "completed"', () => {
+        expect(() => assertTerminalState('completed')).not.toThrow();
+    });
+
+    it('does not throw for terminal state "failed"', () => {
+        expect(() => assertTerminalState('failed')).not.toThrow();
+    });
+
+    it('throws for a non-terminal state', () => {
+        expect(() => assertTerminalState('pending')).toThrow();
+    });
+
+    it('throws for deploying (has transitions)', () => {
+        expect(() => assertTerminalState('deploying')).toThrow();
+    });
+});
+
+describe('assertNonTerminalState', () => {
+    it('does not throw for a non-terminal state', () => {
+        expect(() => assertNonTerminalState('pending')).not.toThrow();
+    });
+
+    it('does not throw for deploying', () => {
+        expect(() => assertNonTerminalState('deploying')).not.toThrow();
+    });
+
+    it('throws for terminal state "completed"', () => {
+        expect(() => assertNonTerminalState('completed')).toThrow();
+    });
+
+    it('throws for terminal state "failed"', () => {
+        expect(() => assertNonTerminalState('failed')).toThrow();
+    });
+});
+
+describe('assertAllStatesReachable', () => {
+    it('does not throw — all states reachable from pending', () => {
+        expect(() => assertAllStatesReachable()).not.toThrow();
+    });
+});
+
+describe('assertNoCycles', () => {
+    it('does not throw — the deployment DAG has no cycles', () => {
+        expect(() => assertNoCycles()).not.toThrow();
+    });
+});
+
+describe('VALID_STATE_TRANSITIONS', () => {
+    it('has exactly 10 states', () => {
+        expect(Object.keys(VALID_STATE_TRANSITIONS)).toHaveLength(10);
+    });
+
+    it('every state in the map is a DeploymentStatusType', () => {
+        for (const state of Object.keys(VALID_STATE_TRANSITIONS)) {
+            expect(ALL_STATES).toContain(state);
+        }
+    });
+
+    it('terminal states have empty transition arrays', () => {
+        expect(VALID_STATE_TRANSITIONS.completed).toEqual([]);
+        expect(VALID_STATE_TRANSITIONS.failed).toEqual([]);
+    });
+
+    it('pending transitions include generating and failed', () => {
+        expect(VALID_STATE_TRANSITIONS.pending).toContain('generating');
+        expect(VALID_STATE_TRANSITIONS.pending).toContain('failed');
+    });
+});

--- a/apps/backend/src/services/rollout-strategy.service.test.ts
+++ b/apps/backend/src/services/rollout-strategy.service.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect } from 'vitest';
+import {
+    RolloutEngine,
+    BlueGreenSwitcher,
+    ROLLBACK_ERROR_RATE_THRESHOLD,
+    ROLLBACK_LATENCY_THRESHOLD_MS,
+    type DeploymentVersion,
+} from './rollout-strategy.service';
+
+const HEALTHY_STABLE: DeploymentVersion = {
+    id: 'stable-v1',
+    errorRate: 0.01,
+    p99LatencyMs: 200,
+};
+
+const HEALTHY_CANDIDATE: DeploymentVersion = {
+    id: 'candidate-v2',
+    errorRate: 0.02,
+    p99LatencyMs: 300,
+};
+
+describe('RolloutEngine — setTrafficPercent boundary values', () => {
+    it('accepts 0 as a valid lower boundary', () => {
+        const engine = new RolloutEngine(HEALTHY_STABLE, HEALTHY_CANDIDATE);
+        engine.setTrafficPercent(0);
+        expect(engine.canaryPercent).toBe(0);
+        expect(engine.status).toBe('pending');
+    });
+
+    it('accepts 100 as a valid upper boundary', () => {
+        const engine = new RolloutEngine(HEALTHY_STABLE, HEALTHY_CANDIDATE);
+        engine.setTrafficPercent(100);
+        expect(engine.canaryPercent).toBe(100);
+        expect(engine.status).toBe('promoted');
+    });
+
+    it('throws RangeError for negative percent', () => {
+        const engine = new RolloutEngine(HEALTHY_STABLE, HEALTHY_CANDIDATE);
+        expect(() => engine.setTrafficPercent(-1)).toThrow(RangeError);
+        expect(() => engine.setTrafficPercent(-0.001)).toThrow(RangeError);
+    });
+
+    it('throws RangeError for percent > 100', () => {
+        const engine = new RolloutEngine(HEALTHY_STABLE, HEALTHY_CANDIDATE);
+        expect(() => engine.setTrafficPercent(101)).toThrow(RangeError);
+        expect(() => engine.setTrafficPercent(100.001)).toThrow(RangeError);
+    });
+
+    it('sets status to in_progress for a mid-range value', () => {
+        const engine = new RolloutEngine(HEALTHY_STABLE, HEALTHY_CANDIDATE);
+        engine.setTrafficPercent(50);
+        expect(engine.status).toBe('in_progress');
+    });
+});
+
+describe('RolloutEngine — evaluateAndMaybeRollback at thresholds', () => {
+    it('rolls back when error rate is exactly at threshold (>=)', () => {
+        const candidate: DeploymentVersion = {
+            id: 'candidate-at-threshold',
+            errorRate: ROLLBACK_ERROR_RATE_THRESHOLD,
+            p99LatencyMs: 100,
+        };
+        const engine = new RolloutEngine(HEALTHY_STABLE, candidate);
+        engine.setTrafficPercent(50);
+
+        expect(engine.evaluateAndMaybeRollback()).toBe(true);
+        expect(engine.status).toBe('rolled_back');
+        expect(engine.canaryPercent).toBe(0);
+    });
+
+    it('does NOT roll back when error rate is just below threshold', () => {
+        const candidate: DeploymentVersion = {
+            id: 'candidate-below-threshold',
+            errorRate: ROLLBACK_ERROR_RATE_THRESHOLD - 0.0001,
+            p99LatencyMs: 100,
+        };
+        const engine = new RolloutEngine(HEALTHY_STABLE, candidate);
+        engine.setTrafficPercent(50);
+
+        expect(engine.evaluateAndMaybeRollback()).toBe(false);
+        expect(engine.status).toBe('in_progress');
+    });
+
+    it('rolls back when p99 latency exceeds threshold (>)', () => {
+        const candidate: DeploymentVersion = {
+            id: 'candidate-over-latency',
+            errorRate: 0.01,
+            p99LatencyMs: ROLLBACK_LATENCY_THRESHOLD_MS + 1,
+        };
+        const engine = new RolloutEngine(HEALTHY_STABLE, candidate);
+        engine.setTrafficPercent(50);
+
+        expect(engine.evaluateAndMaybeRollback()).toBe(true);
+        expect(engine.status).toBe('rolled_back');
+    });
+
+    it('does NOT roll back when p99 latency is exactly at threshold (<=)', () => {
+        const candidate: DeploymentVersion = {
+            id: 'candidate-at-latency',
+            errorRate: 0.01,
+            p99LatencyMs: ROLLBACK_LATENCY_THRESHOLD_MS,
+        };
+        const engine = new RolloutEngine(HEALTHY_STABLE, candidate);
+        engine.setTrafficPercent(50);
+
+        expect(engine.evaluateAndMaybeRollback()).toBe(false);
+        expect(engine.status).toBe('in_progress');
+    });
+
+    it('does not roll back when candidate is healthy', () => {
+        const engine = new RolloutEngine(HEALTHY_STABLE, HEALTHY_CANDIDATE);
+        engine.setTrafficPercent(75);
+
+        expect(engine.evaluateAndMaybeRollback()).toBe(false);
+        expect(engine.status).toBe('in_progress');
+        expect(engine.canaryPercent).toBe(75);
+    });
+});
+
+describe('BlueGreenSwitcher — switchToStandby', () => {
+    it('switches to standby when standby version is healthy', () => {
+        const switcher = new BlueGreenSwitcher(HEALTHY_STABLE, HEALTHY_CANDIDATE, 'blue');
+        expect(switcher.active).toBe('blue');
+
+        const result = switcher.switchToStandby();
+
+        expect(result).toBe(true);
+        expect(switcher.active).toBe('green');
+        expect(switcher.standby).toBe('blue');
+    });
+
+    it('does NOT switch when standby version is unhealthy (high error rate)', () => {
+        const unhealthyCandidate: DeploymentVersion = {
+            id: 'candidate-unhealthy',
+            errorRate: ROLLBACK_ERROR_RATE_THRESHOLD,
+            p99LatencyMs: 100,
+        };
+        const switcher = new BlueGreenSwitcher(HEALTHY_STABLE, unhealthyCandidate, 'blue');
+
+        const result = switcher.switchToStandby();
+
+        expect(result).toBe(false);
+        expect(switcher.active).toBe('blue');
+    });
+
+    it('does NOT switch when standby version exceeds latency threshold', () => {
+        const slowCandidate: DeploymentVersion = {
+            id: 'candidate-slow',
+            errorRate: 0.01,
+            p99LatencyMs: ROLLBACK_LATENCY_THRESHOLD_MS + 1,
+        };
+        const switcher = new BlueGreenSwitcher(HEALTHY_STABLE, slowCandidate, 'blue');
+
+        const result = switcher.switchToStandby();
+
+        expect(result).toBe(false);
+        expect(switcher.active).toBe('blue');
+    });
+
+    it('activeVersion and standbyVersion reflect the initial color', () => {
+        const switcher = new BlueGreenSwitcher(HEALTHY_STABLE, HEALTHY_CANDIDATE, 'green');
+        expect(switcher.active).toBe('green');
+        expect(switcher.activeVersion()).toBe(HEALTHY_CANDIDATE);
+        expect(switcher.standbyVersion()).toBe(HEALTHY_STABLE);
+    });
+
+    it('after switching, activeVersion returns the previous standby', () => {
+        const switcher = new BlueGreenSwitcher(HEALTHY_STABLE, HEALTHY_CANDIDATE, 'blue');
+        switcher.switchToStandby();
+
+        expect(switcher.activeVersion()).toBe(HEALTHY_CANDIDATE);
+        expect(switcher.standbyVersion()).toBe(HEALTHY_STABLE);
+    });
+});

--- a/apps/backend/src/services/rollout-strategy.test.ts
+++ b/apps/backend/src/services/rollout-strategy.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { RolloutEngine, type DeploymentVersion } from './rollout-strategy.service';
+
+const HEALTHY_STABLE: DeploymentVersion = {
+    id: 'stable-v1',
+    errorRate: 0.01,
+    p99LatencyMs: 200,
+};
+
+const HEALTHY_CANDIDATE: DeploymentVersion = {
+    id: 'candidate-v2',
+    errorRate: 0.02,
+    p99LatencyMs: 300,
+};
+
+describe('RolloutEngine — evaluateFlagWithCache', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('returns the evaluator result on cache miss', () => {
+        const engine = new RolloutEngine(HEALTHY_STABLE, HEALTHY_CANDIDATE);
+        const evaluator = vi.fn().mockReturnValue(true);
+
+        const result = engine.evaluateFlagWithCache('user-1', 'flag-a', evaluator);
+
+        expect(result).toBe(true);
+        expect(evaluator).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns cached result on cache hit within TTL', () => {
+        const engine = new RolloutEngine(HEALTHY_STABLE, HEALTHY_CANDIDATE);
+        const evaluator = vi.fn().mockReturnValue(true);
+
+        engine.evaluateFlagWithCache('user-1', 'flag-a', evaluator);
+        const result = engine.evaluateFlagWithCache('user-1', 'flag-a', evaluator);
+
+        expect(result).toBe(true);
+        expect(evaluator).toHaveBeenCalledTimes(1);
+    });
+
+    it('re-evaluates after TTL expires', () => {
+        const engine = new RolloutEngine(HEALTHY_STABLE, HEALTHY_CANDIDATE);
+        const evaluator = vi.fn().mockReturnValueOnce(true).mockReturnValueOnce(false);
+
+        vi.setSystemTime(0);
+        const first = engine.evaluateFlagWithCache('user-1', 'flag-a', evaluator);
+        expect(first).toBe(true);
+
+        vi.setSystemTime(6_000);
+        const second = engine.evaluateFlagWithCache('user-1', 'flag-a', evaluator);
+        expect(second).toBe(false);
+
+        expect(evaluator).toHaveBeenCalledTimes(2);
+    });
+
+    it('caches different flag keys independently', () => {
+        const engine = new RolloutEngine(HEALTHY_STABLE, HEALTHY_CANDIDATE);
+        const evaluatorA = vi.fn().mockReturnValue(true);
+        const evaluatorB = vi.fn().mockReturnValue(false);
+
+        expect(engine.evaluateFlagWithCache('user-1', 'flag-a', evaluatorA)).toBe(true);
+        expect(engine.evaluateFlagWithCache('user-1', 'flag-b', evaluatorB)).toBe(false);
+
+        expect(evaluatorA).toHaveBeenCalledTimes(1);
+        expect(evaluatorB).toHaveBeenCalledTimes(1);
+    });
+
+    it('caches different user IDs independently', () => {
+        const engine = new RolloutEngine(HEALTHY_STABLE, HEALTHY_CANDIDATE);
+        const evaluator1 = vi.fn().mockReturnValue(true);
+        const evaluator2 = vi.fn().mockReturnValue(false);
+
+        expect(engine.evaluateFlagWithCache('user-1', 'flag-a', evaluator1)).toBe(true);
+        expect(engine.evaluateFlagWithCache('user-2', 'flag-a', evaluator2)).toBe(false);
+    });
+
+    it('evicts oldest entry when cache exceeds MAX_FLAG_CACHE_ENTRIES', () => {
+        const engine = new RolloutEngine(HEALTHY_STABLE, HEALTHY_CANDIDATE);
+
+        for (let i = 0; i < 10_001; i++) {
+            engine.evaluateFlagWithCache(`user-${i}`, 'flag-a', () => true);
+        }
+
+        const evaluator = vi.fn().mockReturnValue(false);
+        const result = engine.evaluateFlagWithCache('user-0', 'flag-a', evaluator);
+
+        expect(result).toBe(false);
+        expect(evaluator).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('RolloutEngine — clearFlagCache', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('clears cache for a specific flagKey', () => {
+        const engine = new RolloutEngine(HEALTHY_STABLE, HEALTHY_CANDIDATE);
+        const evaluatorA = vi.fn().mockReturnValue(true);
+        const evaluatorB = vi.fn().mockReturnValue(false);
+
+        engine.evaluateFlagWithCache('user-1', 'flag-a', evaluatorA);
+        engine.evaluateFlagWithCache('user-1', 'flag-b', evaluatorB);
+
+        engine.clearFlagCache('flag-a');
+
+        const resultA = engine.evaluateFlagWithCache('user-1', 'flag-a', evaluatorA);
+        const resultB = engine.evaluateFlagWithCache('user-1', 'flag-b', evaluatorB);
+
+        expect(resultA).toBe(true);
+        expect(evaluatorA).toHaveBeenCalledTimes(2);
+
+        expect(resultB).toBe(false);
+        expect(evaluatorB).toHaveBeenCalledTimes(1);
+    });
+
+    it('clears all cache entries when no flagKey is provided', () => {
+        const engine = new RolloutEngine(HEALTHY_STABLE, HEALTHY_CANDIDATE);
+        const evaluatorA = vi.fn().mockReturnValue(true);
+        const evaluatorB = vi.fn().mockReturnValue(false);
+
+        engine.evaluateFlagWithCache('user-1', 'flag-a', evaluatorA);
+        engine.evaluateFlagWithCache('user-1', 'flag-b', evaluatorB);
+
+        engine.clearFlagCache();
+
+        const resultA = engine.evaluateFlagWithCache('user-1', 'flag-a', evaluatorA);
+        const resultB = engine.evaluateFlagWithCache('user-1', 'flag-b', evaluatorB);
+
+        expect(resultA).toBe(true);
+        expect(evaluatorA).toHaveBeenCalledTimes(2);
+        expect(resultB).toBe(false);
+        expect(evaluatorB).toHaveBeenCalledTimes(2);
+    });
+
+    it('clearFlagCache does not throw when cache is empty', () => {
+        const engine = new RolloutEngine(HEALTHY_STABLE, HEALTHY_CANDIDATE);
+        expect(() => engine.clearFlagCache()).not.toThrow();
+        expect(() => engine.clearFlagCache('nonexistent-flag')).not.toThrow();
+    });
+});


### PR DESCRIPTION
## Summary

Adds co-located unit tests for four modules that previously had no test coverage:

1. **mutation-testing.helpers.ts** — , , , , , , , and the  map. Edge cases include empty transition arrays, terminal/boundary states, and invalid self-loops.

2. **rollout-strategy.service.ts** —  (boundaries 0, 100, out-of-range ),  at exact  (>=) and  (>) boundaries, and  for both healthy-switch and unhealthy-no-switch paths.

3. **rollout-strategy.ts** (cache logic within ) —  cache-hit/miss behavior, TTL expiry,  eviction, and  with and without a specific .

4. **tracing.ts** — , ,  (including null/undefined/empty/malformed inputs),  success/error paths, exception event attributes, and correlation-ID generation when no incoming ID is present.

## Changes

- `apps/backend/src/services/mutation-testing.helpers.test.ts` (new)
- `apps/backend/src/services/rollout-strategy.service.test.ts` (new)
- `apps/backend/src/services/rollout-strategy.test.ts` (new)
- `apps/backend/src/lib/tracing.test.ts` (new)

## Issues

Closes #1079
Closes #1080
Closes #1081
Closes #1082