### PR TITLE
test(backend): add unit coverage for deployment fixtures, env template generator, supabase lock, and server client factory

### DIFF
--- a/apps/backend/src/lib/deployment-fixtures.test.ts
+++ b/apps/backend/src/lib/deployment-fixtures.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+import { MOCK_DEPLOYMENTS, MOCK_ANALYTICS } from './deployment-fixtures';
+
+const REQUIRED_ENVIRONMENTS = ['production', 'staging', 'preview', 'development'];
+const REQUIRED_TRIGGERS = ['push', 'manual', 'schedule', 'api'];
+
+describe('deployment-fixtures', () => {
+    describe('MOCK_DEPLOYMENTS', () => {
+        it('exports a non-empty array of deployments', () => {
+            expect(Array.isArray(MOCK_DEPLOYMENTS)).toBe(true);
+            expect(MOCK_DEPLOYMENTS.length).toBeGreaterThan(0);
+        });
+
+        it('each deployment has the required shape', () => {
+            for (const dep of MOCK_DEPLOYMENTS) {
+                expect(typeof dep.id).toBe('string');
+                expect(dep.id.length).toBeGreaterThan(0);
+                expect(typeof dep.name).toBe('string');
+                expect(dep.name.length).toBeGreaterThan(0);
+                expect(typeof dep.status).toBe('string');
+                expect(dep.status.length).toBeGreaterThan(0);
+                expect(typeof dep.environment).toBe('string');
+                expect(dep.environment.length).toBeGreaterThan(0);
+                expect(typeof dep.trigger).toBe('string');
+                expect(dep.trigger.length).toBeGreaterThan(0);
+                expect(dep.commit).toBeDefined();
+                expect(typeof dep.commit.sha).toBe('string');
+                expect(dep.commit.sha.length).toBeGreaterThan(0);
+                expect(typeof dep.commit.message).toBe('string');
+                expect(dep.commit.message.length).toBeGreaterThan(0);
+                expect(typeof dep.commit.author).toBe('string');
+                expect(dep.commit.author.length).toBeGreaterThan(0);
+                expect(typeof dep.commit.branch).toBe('string');
+                expect(dep.commit.branch.length).toBeGreaterThan(0);
+                expect(dep.region).toBeDefined();
+                expect(typeof dep.region.id).toBe('string');
+                expect(dep.region.id.length).toBeGreaterThan(0);
+                expect(typeof dep.region.label).toBe('string');
+                expect(dep.region.label.length).toBeGreaterThan(0);
+                expect(typeof dep.region.flag).toBe('string');
+                expect(dep.region.flag.length).toBeGreaterThan(0);
+                expect(typeof dep.createdAt).toBe('string');
+                expect(new Date(dep.createdAt).toISOString()).toBe(dep.createdAt);
+            }
+        });
+
+        it('all environments are valid deployment environments', () => {
+            for (const dep of MOCK_DEPLOYMENTS) {
+                expect(REQUIRED_ENVIRONMENTS).toContain(dep.environment);
+            }
+        });
+
+        it('all triggers are valid deployment triggers', () => {
+            for (const dep of MOCK_DEPLOYMENTS) {
+                expect(REQUIRED_TRIGGERS).toContain(dep.trigger);
+            }
+        });
+
+        it('createdAt dates are in the past', () => {
+            const now = Date.now();
+            for (const dep of MOCK_DEPLOYMENTS) {
+                const created = new Date(dep.createdAt).getTime();
+                expect(created).toBeLessThan(now);
+            }
+        });
+
+        it('deployments with completedAt have durationSeconds', () => {
+            for (const dep of MOCK_DEPLOYMENTS) {
+                if (dep.completedAt) {
+                    expect(dep.durationSeconds).toBeDefined();
+                    expect(typeof dep.durationSeconds).toBe('number');
+                    expect(dep.durationSeconds).toBeGreaterThan(0);
+                }
+            }
+        });
+
+        it('deployments with url have a valid https url', () => {
+            for (const dep of MOCK_DEPLOYMENTS) {
+                if (dep.url) {
+                    expect(dep.url).toMatch(/^https:\/\//);
+                }
+            }
+        });
+    });
+
+    describe('MOCK_ANALYTICS', () => {
+        it('has all required analytics fields', () => {
+            expect(typeof MOCK_ANALYTICS.totalDeployments).toBe('number');
+            expect(typeof MOCK_ANALYTICS.successRate).toBe('number');
+            expect(typeof MOCK_ANALYTICS.avgDurationSeconds).toBe('number');
+            expect(typeof MOCK_ANALYTICS.activeDeployments).toBe('number');
+            expect(typeof MOCK_ANALYTICS.failedLast24h).toBe('number');
+            expect(typeof MOCK_ANALYTICS.deploymentsToday).toBe('number');
+            expect(typeof MOCK_ANALYTICS.successRateTrend).toBe('number');
+            expect(typeof MOCK_ANALYTICS.avgDurationTrend).toBe('number');
+        });
+
+        it('has sensible default values', () => {
+            expect(MOCK_ANALYTICS.totalDeployments).toBeGreaterThan(0);
+            expect(MOCK_ANALYTICS.successRate).toBeGreaterThan(0);
+            expect(MOCK_ANALYTICS.successRate).toBeLessThanOrEqual(100);
+            expect(MOCK_ANALYTICS.avgDurationSeconds).toBeGreaterThan(0);
+            expect(MOCK_ANALYTICS.activeDeployments).toBeGreaterThanOrEqual(0);
+            expect(MOCK_ANALYTICS.failedLast24h).toBeGreaterThanOrEqual(0);
+            expect(MOCK_ANALYTICS.deploymentsToday).toBeGreaterThanOrEqual(0);
+        });
+    });
+});

--- a/apps/backend/src/lib/env/env-template-generator.test.ts
+++ b/apps/backend/src/lib/env/env-template-generator.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect } from 'vitest';
+import {
+    buildEnvVarEntries,
+    renderEnvLocal,
+    renderEnvExample,
+    buildVercelEnvVars,
+    SECRET_PLACEHOLDER,
+} from './env-template-generator';
+import type { CustomizationConfig } from '@craft/types';
+import type { TemplateFamilyId } from '@/services/code-generator.service';
+
+const baseConfig: CustomizationConfig = {
+    branding: {
+        appName: 'Test App',
+        primaryColor: '#007bff',
+        secondaryColor: '#6c757d',
+        fontFamily: 'Inter',
+    },
+    stellar: {
+        network: 'testnet',
+        horizonUrl: 'https://horizon-testnet.stellar.org',
+        sorobanRpcUrl: 'https://soroban-testnet.stellar.org',
+        assetPairs: [
+            { code: 'XLM', issuer: 'GABC1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ12' },
+        ],
+        contractAddresses: {
+            router: 'GABC1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ12',
+        },
+    },
+    features: {
+        enableCharts: true,
+        enableTransactionHistory: false,
+        enableAnalytics: true,
+        enableNotifications: false,
+    },
+};
+
+const testSecrets = {
+    SUPABASE_SERVICE_ROLE_KEY: 'resolved-secret-key',
+};
+
+describe('env-template-generator', () => {
+    describe('buildEnvVarEntries', () => {
+        const families: TemplateFamilyId[] = [
+            'stellar-dex',
+            'soroban-defi',
+            'payment-gateway',
+            'asset-issuance',
+        ];
+
+        for (const family of families) {
+            describe(`family: ${family}`, () => {
+                it('includes required branding and stellar vars for all families', () => {
+                    const entries = buildEnvVarEntries(family, baseConfig);
+                    const keys = entries.map((e) => e.key);
+
+                    expect(keys).toContain('NEXT_PUBLIC_APP_NAME');
+                    expect(keys).toContain('NEXT_PUBLIC_PRIMARY_COLOR');
+                    expect(keys).toContain('NEXT_PUBLIC_SECONDARY_COLOR');
+                    expect(keys).toContain('NEXT_PUBLIC_FONT_FAMILY');
+                    expect(keys).toContain('NEXT_PUBLIC_STELLAR_NETWORK');
+                    expect(keys).toContain('NEXT_PUBLIC_HORIZON_URL');
+                    expect(keys).toContain('NEXT_PUBLIC_NETWORK_PASSPHRASE');
+                });
+
+                it('public vars target all environments', () => {
+                    const entries = buildEnvVarEntries(family, baseConfig);
+                    const publicEntries = entries.filter((e) => !e.secret);
+
+                    for (const entry of publicEntries) {
+                        expect(entry.targets).toContain('production');
+                        expect(entry.targets).toContain('preview');
+                        expect(entry.targets).toContain('development');
+                    }
+                });
+
+                it('secret vars target production and preview only', () => {
+                    const entries = buildEnvVarEntries(family, baseConfig);
+                    const secretEntries = entries.filter((e) => e.secret);
+
+                    for (const entry of secretEntries) {
+                        expect(entry.targets).toContain('production');
+                        expect(entry.targets).toContain('preview');
+                        expect(entry.targets).not.toContain('development');
+                    }
+                });
+            });
+        }
+
+        describe('target scoping', () => {
+            it('SUPABASE_SERVICE_ROLE_KEY is scoped to production and preview', () => {
+                const entries = buildEnvVarEntries('stellar-dex', baseConfig);
+                const secretEntry = entries.find((e) => e.key === 'SUPABASE_SERVICE_ROLE_KEY');
+
+                expect(secretEntry).toBeDefined();
+                expect(secretEntry!.secret).toBe(true);
+                expect(secretEntry!.targets).toEqual(['production', 'preview']);
+            });
+        });
+
+        describe('secret vs plain classification', () => {
+            it('marks SUPABASE_SERVICE_ROLE_KEY as secret', () => {
+                const entries = buildEnvVarEntries('stellar-dex', baseConfig);
+                const entry = entries.find((e) => e.key === 'SUPABASE_SERVICE_ROLE_KEY');
+
+                expect(entry).toBeDefined();
+                expect(entry!.secret).toBe(true);
+            });
+
+            it('marks public variables as non-secret', () => {
+                const entries = buildEnvVarEntries('stellar-dex', baseConfig);
+                const publicKeys = entries.filter((e) => !e.secret).map((e) => e.key);
+
+                expect(publicKeys).toContain('NEXT_PUBLIC_APP_NAME');
+                expect(publicKeys).toContain('NEXT_PUBLIC_HORIZON_URL');
+                expect(publicKeys).toContain('NEXT_PUBLIC_ENABLE_CHARTS');
+            });
+        });
+
+        describe('family-specific overrides', () => {
+            it('soroban-defi always includes NEXT_PUBLIC_SOROBAN_RPC_URL', () => {
+                const entries = buildEnvVarEntries('soroban-defi', baseConfig);
+                const keys = entries.map((e) => e.key);
+                expect(keys).toContain('NEXT_PUBLIC_SOROBAN_RPC_URL');
+            });
+
+            it('stellar-dex includes asset pairs when configured', () => {
+                const entries = buildEnvVarEntries('stellar-dex', baseConfig);
+                const keys = entries.map((e) => e.key);
+                expect(keys).toContain('NEXT_PUBLIC_ASSET_PAIRS');
+            });
+
+            it('soroban-defi includes contract addresses when configured', () => {
+                const entries = buildEnvVarEntries('soroban-defi', baseConfig);
+                const keys = entries.map((e) => e.key);
+                expect(keys).toContain('NEXT_PUBLIC_CONTRACT_ADDRESSES');
+            });
+        });
+    });
+
+    describe('buildVercelEnvVars', () => {
+        it('maps entries to Vercel-compatible format with plain type', () => {
+            const vars = buildVercelEnvVars('stellar-dex', baseConfig, testSecrets);
+            const publicVar = vars.find((v) => v.key === 'NEXT_PUBLIC_APP_NAME');
+
+            expect(publicVar).toBeDefined();
+            expect(publicVar!.type).toBe('plain');
+            expect(publicVar!.target).toEqual(['production', 'preview', 'development']);
+        });
+
+        it('maps secret entries to encrypted type', () => {
+            const vars = buildVercelEnvVars('stellar-dex', baseConfig, testSecrets);
+            const secretVar = vars.find((v) => v.key === 'SUPABASE_SERVICE_ROLE_KEY');
+
+            expect(secretVar).toBeDefined();
+            expect(secretVar!.type).toBe('encrypted');
+            expect(secretVar!.value).toBe('resolved-secret-key');
+        });
+
+        it('throws when a required secret is unresolved', () => {
+            expect(() => buildVercelEnvVars('stellar-dex', baseConfig)).toThrow(
+                /Missing required secret value/
+            );
+        });
+
+        it('uses resolved secret value when provided', () => {
+            const vars = buildVercelEnvVars('stellar-dex', baseConfig, {
+                SUPABASE_SERVICE_ROLE_KEY: 'my-secret',
+            });
+
+            const secretVar = vars.find((v) => v.key === 'SUPABASE_SERVICE_ROLE_KEY');
+            expect(secretVar!.value).toBe('my-secret');
+        });
+    });
+
+    describe('renderEnvLocal', () => {
+        it('renders a non-empty env file with header comments', () => {
+            const output = renderEnvLocal('stellar-dex', baseConfig);
+
+            expect(output).toContain('# Auto-generated by CRAFT Platform');
+            expect(output).toContain('# Template: stellar-dex');
+            expect(output).toContain('NEXT_PUBLIC_APP_NAME=');
+            expect(output).toContain('NEXT_PUBLIC_HORIZON_URL=');
+        });
+
+        it('includes resolved values without placeholders', () => {
+            const output = renderEnvLocal('stellar-dex', baseConfig);
+
+            expect(output).toContain(`NEXT_PUBLIC_APP_NAME=${baseConfig.branding.appName}`);
+            expect(output).toContain(`NEXT_PUBLIC_STELLAR_NETWORK=${baseConfig.stellar.network}`);
+        });
+
+        it('marks optional variables with comments', () => {
+            const output = renderEnvLocal('stellar-dex', baseConfig);
+
+            expect(output).toContain('# Optional');
+        });
+    });
+
+    describe('renderEnvExample', () => {
+        it('renders a non-empty env example with header comments', () => {
+            const output = renderEnvExample('stellar-dex', baseConfig);
+
+            expect(output).toContain('# Auto-generated by CRAFT Platform');
+            expect(output).toContain('# Template: stellar-dex');
+        });
+
+        it('redacts secret values with placeholder', () => {
+            const output = renderEnvExample('stellar-dex', baseConfig);
+
+            expect(output).toContain(`SUPABASE_SERVICE_ROLE_KEY=${SECRET_PLACEHOLDER}`);
+            expect(output).not.toContain('resolved-secret-key');
+        });
+
+        it('shows resolved values for public variables', () => {
+            const output = renderEnvExample('stellar-dex', baseConfig);
+
+            expect(output).toContain(`NEXT_PUBLIC_APP_NAME=${baseConfig.branding.appName}`);
+        });
+
+        it('marks secrets with [SECRET] tag', () => {
+            const output = renderEnvExample('stellar-dex', baseConfig);
+
+            expect(output).toContain('[SECRET]');
+        });
+    });
+});

--- a/apps/backend/src/lib/supabase/server.test.ts
+++ b/apps/backend/src/lib/supabase/server.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createClient } from './server';
+
+vi.mock('@supabase/ssr', () => ({
+    createServerClient: vi.fn(() => ({})),
+}));
+
+vi.mock('next/headers', () => ({
+    cookies: vi.fn(() => ({
+        get: vi.fn(),
+        set: vi.fn(),
+    })),
+}));
+
+import { createServerClient } from '@supabase/ssr';
+
+describe('server', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://test.supabase.co';
+        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'test-anon-key';
+    });
+
+    afterEach(() => {
+        delete process.env.NEXT_PUBLIC_SUPABASE_URL;
+        delete process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+    });
+
+    it('creates a Supabase client using environment variables', () => {
+        createClient();
+
+        expect(createServerClient).toHaveBeenCalledWith(
+            'https://test.supabase.co',
+            'test-anon-key',
+            expect.objectContaining({
+                cookies: expect.objectContaining({
+                    get: expect.any(Function),
+                    set: expect.any(Function),
+                }),
+            })
+        );
+    });
+
+    it('throws when NEXT_PUBLIC_SUPABASE_URL is missing', () => {
+        delete process.env.NEXT_PUBLIC_SUPABASE_URL;
+
+        expect(() => createClient()).toThrow();
+    });
+
+    it('throws when NEXT_PUBLIC_SUPABASE_ANON_KEY is missing', () => {
+        delete process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+        expect(() => createClient()).toThrow();
+    });
+});

--- a/apps/backend/src/lib/supabase/supabase-lock.test.ts
+++ b/apps/backend/src/lib/supabase/supabase-lock.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { acquireAdvisoryLock, releaseAdvisoryLock } from './supabase-lock';
+
+vi.mock('./server', () => ({
+    createClient: vi.fn(),
+}));
+
+import { createClient } from './server';
+
+describe('supabase-lock', () => {
+    let mockRpc: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        mockRpc = vi.fn().mockResolvedValue({ data: true, error: null });
+        (createClient as any).mockReturnValue({ rpc: mockRpc });
+    });
+
+    describe('hashKey determinism', () => {
+        it('produces the same lock id for the same key', async () => {
+            await acquireAdvisoryLock('my-unique-key', 1000);
+            await acquireAdvisoryLock('my-unique-key', 1000);
+
+            const lockIds = mockRpc.mock.calls.map((call: any) => call[1].lock_id);
+            expect(lockIds[0]).toBe(lockIds[1]);
+        });
+
+        it('produces distinct lock ids for distinct realistic keys', async () => {
+            await acquireAdvisoryLock('deployment-pipeline-user-123', 1000);
+            await acquireAdvisoryLock('vercel-sync-service-customer-456', 1000);
+
+            const lockIds = mockRpc.mock.calls.map((call: any) => call[1].lock_id);
+            expect(lockIds[0]).not.toBe(lockIds[1]);
+        });
+    });
+
+    describe('acquireAdvisoryLock', () => {
+        it('returns true immediately when the lock is acquired on first try', async () => {
+            const result = await acquireAdvisoryLock('lock-key', 5000);
+
+            expect(result).toBe(true);
+            expect(mockRpc).toHaveBeenCalledWith('pg_try_advisory_lock', { lock_id: expect.any(Number) });
+            expect(mockRpc).toHaveBeenCalledTimes(1);
+        });
+
+        it('polls and returns true when lock is acquired after retry', async () => {
+            mockRpc
+                .mockResolvedValueOnce({ data: false, error: null })
+                .mockResolvedValueOnce({ data: true, error: null });
+
+            const result = await acquireAdvisoryLock('lock-key', 5000);
+
+            expect(result).toBe(true);
+            expect(mockRpc).toHaveBeenCalledTimes(2);
+        });
+
+        it('returns false when timeout expires before lock is acquired', async () => {
+            mockRpc.mockResolvedValue({ data: false, error: null });
+
+            const result = await acquireAdvisoryLock('lock-key', 100);
+
+            expect(result).toBe(false);
+        });
+
+        it('throws a descriptive error when the rpc returns an error', async () => {
+            mockRpc.mockResolvedValue({ data: null, error: { message: 'connection lost' } });
+
+            await expect(acquireAdvisoryLock('lock-key', 5000)).rejects.toThrow(
+                'Advisory lock error: connection lost'
+            );
+        });
+    });
+
+    describe('releaseAdvisoryLock', () => {
+        it('calls pg_advisory_unlock with the same lock id', async () => {
+            mockRpc.mockResolvedValue({ data: null, error: null });
+
+            await releaseAdvisoryLock('lock-key');
+
+            expect(mockRpc).toHaveBeenCalledWith('pg_advisory_unlock', { lock_id: expect.any(Number) });
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Adds co-located unit test suites for four backend utilities that previously had no dedicated test coverage:

- `apps/backend/src/lib/deployment-fixtures.test.ts`
- `apps/backend/src/lib/env/env-template-generator.test.ts`
- `apps/backend/src/lib/supabase/supabase-lock.test.ts`
- `apps/backend/src/lib/supabase/server.test.ts`

## Changes

### deployment-fixtures.test.ts
- Verifies `MOCK_DEPLOYMENTS` array shape and required fields.
- Confirms valid environments, triggers, and date formatting.
- Asserts `MOCK_ANALYTICS` has sensible defaults.

### env-template-generator.test.ts
- Covers target scoping for all supported Vercel targets (production/preview/development).
- Validates secret vs plain variable classification.
- Tests family-specific overrides and config-driven entry generation.

### supabase-lock.test.ts
- Mocks the Supabase client RPC layer.
- Verifies `hashKey` determinism and distinct-key non-collision.
- Covers immediate lock acquisition, polling success, timeout returning false, and RPC error throwing.

### server.test.ts
- Mocks `next/headers` and `@supabase/ssr`.
- Asserts client creation reads from expected environment variables.
- Confirms missing required env vars throws clear errors.

## Test Plan

Run the targeted backend test suites:

```bash
npm run test --workspace=@craft/backend -- deployment-fixtures
npm run test --workspace=@craft/backend -- env-template-generator
npm run test --workspace=@craft/backend -- supabase-lock
npm run test --workspace=@craft/backend -- lib/supabase/server
```

## Issues Closed

Closes #1083
Closes #1084
Closes #1085
Closes #1086